### PR TITLE
Import RemixAgent and define InvalidEventError

### DIFF
--- a/immutable_tri_species_adjust.py
+++ b/immutable_tri_species_adjust.py
@@ -3,6 +3,11 @@ from collections import defaultdict
 from decimal import Decimal
 import logging
 import numpy as np  # For Lorenz curve computation
+from superNova_2177 import RemixAgent
+
+class InvalidEventError(Exception):
+    """Raised when an event cannot be processed due to invalid data."""
+    pass
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- update immutable_tri_species_adjust to import RemixAgent
- define InvalidEventError exception for vote processing

## Testing
- `python -m py_compile immutable_tri_species_adjust.py`
- `pytest -q` *(fails: AttributeError, ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884c31c278083209b75d6adaf13f438