### PR TITLE
Use logger for non-finite score warning

### DIFF
--- a/hypothesis_tracker.py
+++ b/hypothesis_tracker.py
@@ -151,7 +151,11 @@ def update_hypothesis_score(
         return False
 
     if not math.isfinite(new_score):
-        print(f"Warning: Attempted to set non-finite score for hypothesis {hypothesis_id}: {new_score}")
+        logger.warning(
+            "Attempted to set non-finite score for hypothesis %s: %s",
+            hypothesis_id,
+            new_score,
+        )
         return False
 
     record.score = new_score


### PR DESCRIPTION
## Summary
- switch `print` to `logger.warning` in `update_hypothesis_score`

## Testing
- `pytest -q` *(fails: AttributeError in db_models)*

------
https://chatgpt.com/codex/tasks/task_e_6884c32336048320840b4457d9502f62