### PR TITLE
Add mypy config exclusion

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = (?x)(\Atranscendental-resonance-frontend/tests/)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker


### PR DESCRIPTION
## Summary
- add a simple `mypy.ini` with an exclude rule for the frontend tests
- make the `tests` folder a package so MyPy doesn't report duplicate modules

## Testing
- `mypy . >/tmp/mypy.log && grep -i duplicate /tmp/mypy.log || echo "no duplicate" && tail -n 2 /tmp/mypy.log`

------
https://chatgpt.com/codex/tasks/task_e_6884c379110883208961b6e34935af04