### PR TITLE
Add local diversity scoring

### DIFF
--- a/tests/test_diversity_analyzer.py
+++ b/tests/test_diversity_analyzer.py
@@ -1,0 +1,12 @@
+import pytest
+from diversity_analyzer import compute_diversity_score
+
+
+def test_compute_diversity_score_basic():
+    vals = [
+        {"validator_id": "a", "specialty": "x", "affiliation": "u"},
+        {"validator_id": "b", "specialty": "y", "affiliation": "u"},
+    ]
+    result = compute_diversity_score(vals)
+    assert 0.0 <= result["diversity_score"] <= 1.0
+    assert result["counts"]["unique_validators"] == 2


### PR DESCRIPTION
## Summary
- implement a `compute_diversity_score` function inside `diversity_analyzer`
- remove erroneous self-import
- add basic unit test for `compute_diversity_score`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reputation_influence_tracker')*

------
https://chatgpt.com/codex/tasks/task_e_6884c37459d48320ab7efbb59ef615d3