### PR TITLE
Read SECRET_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ python validate_hypothesis.py --demo
 python validate_hypothesis.py --validations sample_validations.json
 ````
 
+## 🔧 Configuration
+
+`SECRET_KEY` **must** be supplied via environment variables for JWT signing.  A
+strong random value is recommended:
+
+```bash
+export SECRET_KEY="your-random-secret"
+```
+
 ## ✨ Features
 
 * **🧠 Smart Scoring** — Combines confidence, signal strength, and NLP sentiment

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -319,7 +319,9 @@ class Settings(BaseSettings):
     # PRODUCTION WARNING: Avoid using SQLite here; it cannot handle concurrent writes in a multi-user environment.
     # Configure a PostgreSQL database URL before deploying.
 
-    SECRET_KEY: str = "generate_a_secure_secret_key"
+    # SECRET_KEY must be provided via environment variables for security
+    # Using Field(..., env="SECRET_KEY") ensures there is no insecure default
+    SECRET_KEY: str = Field(..., env="SECRET_KEY")
 
     ALGORITHM: str = "HS256"
     ALLOWED_ORIGINS: List[str] = [


### PR DESCRIPTION
## Summary
- ensure `SECRET_KEY` in `Settings` is required from the environment
- document the required env var in the README

## Testing
- `pytest -q` *(fails: AttributeError in tests due to missing dependencies)*
- `pip install sqlalchemy pydantic fastapi pydantic-settings redis passlib[bcrypt] python-jose pytest` *(fails: ProxyError because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6884c35ce31c83208b8ced0659de5ebf