### PR TITLE
Improve introspection pipeline logging

### DIFF
--- a/introspection/introspection_pipeline.py
+++ b/introspection/introspection_pipeline.py
@@ -88,7 +88,11 @@ def run_full_audit(hypothesis_id: str, db: Session) -> Dict[str, Any]:
                     "causal_audit_ref": log_value_payload.get("causal_audit_ref")
                 })
             except json.JSONDecodeError:
-                pass # Skip malformed log entries
+                logger.warning(
+                    "Skipping malformed log entry %s: %s",
+                    getattr(log_entry, "id", "<unknown>"),
+                    getattr(log_entry, "payload", "<no payload>"),
+                )
 
         if parsed_logs:
             # Sort by timestamp (or ID if timestamps are identical) to find the 'latest'


### PR DESCRIPTION
## Summary
- log malformed entries when parsing validation logs

## Testing
- `pytest -q` *(fails: AttributeError in db_models during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884cb35d5588320a1ff4fd1510dc5a8