### PR TITLE
Add gitignore for Python cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- add a `.gitignore` ignoring `__pycache__/` and `*.pyc`

There were no existing `__pycache__` directories in the repo history, so no history cleanup was needed.

## Testing
- `find . -type d -name __pycache__ -print`


------
https://chatgpt.com/codex/tasks/task_e_6884cba2f21883209fa3f684900dc526