### PR TITLE
Fix None handling in PredictionManager

### DIFF
--- a/prediction_manager.py
+++ b/prediction_manager.py
@@ -72,7 +72,7 @@ class PredictionManager:
 
     def _get_value(self, key: str) -> Optional[str]:
         if self.state_service is not None:
-            return self.state_service.get_state(key, "")
+            return self.state_service.get_state(key, None)
         session = self.session_factory()
         try:
             state = session.query(SystemState).filter(SystemState.key == key).first()


### PR DESCRIPTION
## Summary
- make `_get_value` return `None` when a state key is absent

## Testing
- `pytest -q` *(fails: AttributeError - missing SQLAlchemy setup)*

------
https://chatgpt.com/codex/tasks/task_e_6884cbd033dc8320abd692638f15387a