### PR TITLE
Add python-dateutil to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export SECRET_KEY="your-random-secret"
 
 ## 🧪 Running Tests
 
-Install the minimal requirements and run `pytest`:
+Install the minimal requirements (including `python-dateutil` for datetime parsing) and run `pytest`:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 sqlalchemy
 networkx
+python-dateutil


### PR DESCRIPTION
## Summary
- include `python-dateutil` in requirements
- note the new dependency in the README

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'c')*

------
https://chatgpt.com/codex/tasks/task_e_6884cbf83bb883209927d3951a4413a5