### PR TITLE
Fix test data path

### DIFF
--- a/tests/test_validation_pipeline.py
+++ b/tests/test_validation_pipeline.py
@@ -1,8 +1,12 @@
 import json
+from pathlib import Path
 from validation_certifier import analyze_validation_integrity
 
+DATA_FILE = Path(__file__).resolve().parents[1] / "sample_validations.json"
+
+
 def test_sample_data_analysis():
-    with open("sample_validations.json") as f:
+    with open(DATA_FILE) as f:
         data = json.load(f)
         validations = data.get("validations", [])
     


### PR DESCRIPTION
## Summary
- make sample_validations.json path absolute in tests

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'c')*

------
https://chatgpt.com/codex/tasks/task_e_6884cbf4517083208b999fe21f15e433