### PR TITLE
Add reputation decay to validators

### DIFF
--- a/tests/test_validator_reputation_decay.py
+++ b/tests/test_validator_reputation_decay.py
@@ -1,0 +1,27 @@
+import datetime
+from validators.reputation_influence_tracker import compute_validator_reputations
+
+def _build_validations(ts):
+    return [
+        {"validator_id": "a", "hypothesis_id": "h1", "score": 0.8, "timestamp": ts.isoformat()},
+        {"validator_id": "a", "hypothesis_id": "h1", "score": 0.75, "timestamp": ts.isoformat()},
+        {"validator_id": "a", "hypothesis_id": "h1", "score": 0.78, "timestamp": ts.isoformat()},
+    ]
+
+
+def test_reputation_decays_with_age():
+    now = datetime.datetime.utcnow().replace(microsecond=0)
+    old_ts = now - datetime.timedelta(days=60)
+
+    recent_vals = _build_validations(now)
+    old_vals = _build_validations(old_ts)
+
+    consensus = {"h1": 0.8}
+
+    recent = compute_validator_reputations(recent_vals, consensus, current_time=now, half_life_days=30)
+    old = compute_validator_reputations(old_vals, consensus, current_time=now, half_life_days=30)
+
+    rep_recent = recent["validator_reputations"].get("a")
+    rep_old = old["validator_reputations"].get("a")
+
+    assert rep_recent > rep_old


### PR DESCRIPTION
## Summary
- implement time-based reputation decay in `compute_validator_reputations`
- add configurable half-life and current time parameters
- create regression test to verify old validations lower reputation

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'c')*

------
https://chatgpt.com/codex/tasks/task_e_6884cbd4ff808320b9d1d18ffeca5d0e