### PR TITLE
Switch api_call to synchronous

### DIFF
--- a/transcendental-resonance-frontend/src/pages/ai_assist_page.py
+++ b/transcendental-resonance-frontend/src/pages/ai_assist_page.py
@@ -24,7 +24,7 @@ async def ai_assist_page(vibenode_id: int):
 
         async def get_ai_response():
             data = {'prompt': prompt.value}
-            resp = await api_call('POST', f'/ai-assist/{vibenode_id}', data)
+            resp = api_call('POST', f'/ai-assist/{vibenode_id}', data)
             if resp:
                 ui.label('AI Response:').classes('mb-2')
                 ui.label(resp['response']).classes('text-sm break-words')

--- a/transcendental-resonance-frontend/src/pages/events_page.py
+++ b/transcendental-resonance-frontend/src/pages/events_page.py
@@ -32,7 +32,7 @@ async def events_page():
                 'start_time': e_start.value,
                 'group_id': int(group_id.value),
             }
-            resp = await api_call('POST', '/events/', data)
+            resp = api_call('POST', '/events/', data)
             if resp:
                 ui.notify('Event created!', color='positive')
                 await refresh_events()
@@ -44,7 +44,7 @@ async def events_page():
         events_list = ui.column().classes('w-full')
 
         async def refresh_events():
-            events = await api_call('GET', '/events/') or []
+            events = api_call('GET', '/events/') or []
             events_list.clear()
             for e in events:
                 with events_list:
@@ -53,7 +53,7 @@ async def events_page():
                         ui.label(e['description']).classes('text-sm')
                         ui.label(f"Start: {e['start_time']}").classes('text-sm')
                         async def attend_fn(e_id=e['id']):
-                            await api_call('POST', f'/events/{e_id}/attend')
+                            api_call('POST', f'/events/{e_id}/attend')
                             await refresh_events()
                         ui.button('Attend/Leave', on_click=attend_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/pages/groups_page.py
+++ b/transcendental-resonance-frontend/src/pages/groups_page.py
@@ -25,7 +25,7 @@ async def groups_page():
 
         async def create_group():
             data = {'name': g_name.value, 'description': g_desc.value}
-            resp = await api_call('POST', '/groups/', data)
+            resp = api_call('POST', '/groups/', data)
             if resp:
                 ui.notify('Group created!', color='positive')
                 await refresh_groups()
@@ -37,7 +37,7 @@ async def groups_page():
         groups_list = ui.column().classes('w-full')
 
         async def refresh_groups():
-            groups = await api_call('GET', '/groups/') or []
+            groups = api_call('GET', '/groups/') or []
             groups_list.clear()
             for g in groups:
                 with groups_list:
@@ -45,7 +45,7 @@ async def groups_page():
                         ui.label(g['name']).classes('text-lg')
                         ui.label(g['description']).classes('text-sm')
                         async def join_fn(g_id=g['id']):
-                            await api_call('POST', f'/groups/{g_id}/join')
+                            api_call('POST', f'/groups/{g_id}/join')
                             await refresh_groups()
                         ui.button('Join/Leave', on_click=join_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/pages/login_page.py
+++ b/transcendental-resonance-frontend/src/pages/login_page.py
@@ -22,7 +22,7 @@ async def login_page():
 
         async def handle_login():
             data = {'username': username.value, 'password': password.value}
-            resp = await api_call('POST', '/token', data=data)
+            resp = api_call('POST', '/token', data=data)
             if resp and 'access_token' in resp:
                 set_token(resp['access_token'])
                 ui.notify('Login successful!', color='positive')
@@ -60,7 +60,7 @@ async def register_page():
                 'email': email.value,
                 'password': password.value,
             }
-            resp = await api_call('POST', '/users/register', data)
+            resp = api_call('POST', '/users/register', data)
             if resp:
                 ui.notify('Registration successful! Please login.', color='positive')
                 ui.open(login_page)

--- a/transcendental-resonance-frontend/src/pages/messages_page.py
+++ b/transcendental-resonance-frontend/src/pages/messages_page.py
@@ -25,7 +25,7 @@ async def messages_page():
 
         async def send_message():
             data = {'content': content.value}
-            resp = await api_call('POST', f'/messages/{recipient.value}', data)
+            resp = api_call('POST', f'/messages/{recipient.value}', data)
             if resp:
                 ui.notify('Message sent!', color='positive')
                 await refresh_messages()
@@ -37,7 +37,7 @@ async def messages_page():
         messages_list = ui.column().classes('w-full')
 
         async def refresh_messages():
-            messages = await api_call('GET', '/messages/') or []
+            messages = api_call('GET', '/messages/') or []
             messages_list.clear()
             for m in messages:
                 with messages_list:

--- a/transcendental-resonance-frontend/src/pages/network_analysis_page.py
+++ b/transcendental-resonance-frontend/src/pages/network_analysis_page.py
@@ -21,7 +21,7 @@ async def network_page():
             f'color: {THEME["accent"]};'
         )
 
-        analysis = await api_call('GET', '/network-analysis/')
+        analysis = api_call('GET', '/network-analysis/')
         if analysis:
             ui.label(f"Nodes: {analysis['metrics']['node_count']}").classes('mb-2')
             ui.label(f"Edges: {analysis['metrics']['edge_count']}").classes('mb-2')

--- a/transcendental-resonance-frontend/src/pages/notifications_page.py
+++ b/transcendental-resonance-frontend/src/pages/notifications_page.py
@@ -23,7 +23,7 @@ async def notifications_page():
         notifs_list = ui.column().classes('w-full')
 
         async def refresh_notifs():
-            notifs = await api_call('GET', '/notifications/') or []
+            notifs = api_call('GET', '/notifications/') or []
             notifs_list.clear()
             for n in notifs:
                 with notifs_list:
@@ -31,7 +31,7 @@ async def notifications_page():
                         ui.label(n['message']).classes('text-sm')
                         if not n['is_read']:
                             async def mark_read(n_id=n['id']):
-                                await api_call('PUT', f'/notifications/{n_id}/read')
+                                api_call('PUT', f'/notifications/{n_id}/read')
                                 await refresh_notifs()
                             ui.button('Mark Read', on_click=mark_read).style(
                                 f'background: {THEME["primary"]}; color: {THEME["text"]};'

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -19,7 +19,7 @@ async def profile_page():
         ui.open(login_page)
         return
 
-    user_data = await api_call('GET', '/users/me')
+    user_data = api_call('GET', '/users/me')
     if not user_data:
         clear_token()
         ui.open(login_page)
@@ -39,7 +39,7 @@ async def profile_page():
         bio = ui.input('Bio', value=user_data.get('bio', '')).classes('w-full mb-2')
 
         async def update_bio():
-            resp = await api_call('PUT', '/users/me', {'bio': bio.value})
+            resp = api_call('PUT', '/users/me', {'bio': bio.value})
             if resp:
                 ui.notify('Bio updated', color='positive')
 

--- a/transcendental-resonance-frontend/src/pages/proposals_page.py
+++ b/transcendental-resonance-frontend/src/pages/proposals_page.py
@@ -32,7 +32,7 @@ async def proposals_page():
                 'proposal_type': p_type.value,
                 'group_id': int(p_group_id.value) if p_group_id.value else None,
             }
-            resp = await api_call('POST', '/proposals/', data)
+            resp = api_call('POST', '/proposals/', data)
             if resp:
                 ui.notify('Proposal created!', color='positive')
                 await refresh_proposals()
@@ -44,7 +44,7 @@ async def proposals_page():
         proposals_list = ui.column().classes('w-full')
 
         async def refresh_proposals():
-            proposals = await api_call('GET', '/proposals/') or []
+            proposals = api_call('GET', '/proposals/') or []
             proposals_list.clear()
             for p in proposals:
                 with proposals_list:
@@ -54,10 +54,10 @@ async def proposals_page():
                         ui.label(f"Status: {p['status']}").classes('text-sm')
                         if p['status'] == 'open':
                             async def vote_yes(p_id=p['id']):
-                                await api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'yes'})
+                                api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'yes'})
                                 await refresh_proposals()
                             async def vote_no(p_id=p['id']):
-                                await api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'no'})
+                                api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'no'})
                                 await refresh_proposals()
                             ui.row().classes('justify-between')
                             ui.button('Yes', on_click=vote_yes).style('background: green; color: white;')

--- a/transcendental-resonance-frontend/src/pages/status_page.py
+++ b/transcendental-resonance-frontend/src/pages/status_page.py
@@ -16,7 +16,7 @@ async def status_page():
         )
 
         async def refresh_status():
-            status = await api_call('GET', '/status')
+            status = api_call('GET', '/status')
             if status:
                 ui.label(f"Status: {status['status']}").classes('mb-2')
                 ui.label(

--- a/transcendental-resonance-frontend/src/pages/upload_page.py
+++ b/transcendental-resonance-frontend/src/pages/upload_page.py
@@ -24,7 +24,7 @@ async def upload_page():
 
         async def handle_upload(content, name):
             files = {'file': (name, content.read(), 'multipart/form-data')}
-            resp = await api_call('POST', '/upload/', files=files, method='multipart')
+            resp = api_call('POST', '/upload/', files=files, method='multipart')
             if resp:
                 ui.notify(f"Uploaded: {resp['media_url']}", color='positive')
 

--- a/transcendental-resonance-frontend/src/pages/vibenodes_page.py
+++ b/transcendental-resonance-frontend/src/pages/vibenodes_page.py
@@ -37,7 +37,7 @@ async def vibenodes_page():
                 'tags': [t.strip() for t in tags.value.split(',')] if tags.value else None,
                 'parent_vibenode_id': int(parent_id.value) if parent_id.value else None,
             }
-            resp = await api_call('POST', '/vibenodes/', data)
+            resp = api_call('POST', '/vibenodes/', data)
             if resp:
                 ui.notify('VibeNode created!', color='positive')
                 await refresh_vibenodes()
@@ -49,7 +49,7 @@ async def vibenodes_page():
         vibenodes_list = ui.column().classes('w-full')
 
         async def refresh_vibenodes():
-            vibenodes = await api_call('GET', '/vibenodes/') or []
+            vibenodes = api_call('GET', '/vibenodes/') or []
             vibenodes_list.clear()
             for vn in vibenodes:
                 with vibenodes_list:
@@ -58,7 +58,7 @@ async def vibenodes_page():
                         ui.label(vn['description']).classes('text-sm')
                         ui.label(f"Likes: {vn.get('likes_count', 0)}").classes('text-sm')
                         async def like_fn(vn_id=vn['id']):
-                            await api_call('POST', f'/vibenodes/{vn_id}/like')
+                            api_call('POST', f'/vibenodes/{vn_id}/like')
                             await refresh_vibenodes()
                         ui.button('Like/Unlike', on_click=like_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/utils/api.py
+++ b/transcendental-resonance-frontend/src/utils/api.py
@@ -19,8 +19,13 @@ THEME = {
 
 TOKEN: Optional[str] = None
 
-async def api_call(method: str, endpoint: str, data: Optional[Dict] = None,
-                   headers: Optional[Dict] = None, files: Optional[Dict] = None):
+def api_call(
+    method: str,
+    endpoint: str,
+    data: Optional[Dict] = None,
+    headers: Optional[Dict] = None,
+    files: Optional[Dict] = None,
+) -> Optional[Dict]:
     """Wrapper around ``requests`` to interact with the backend API."""
     url = f"{BACKEND_URL}{endpoint}"
     default_headers = {'Content-Type': 'application/json'} if method != 'multipart' else {}


### PR DESCRIPTION
## Summary
- make `api_call` synchronous using `requests`
- drop `await` from all frontend usages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'c')*

------
https://chatgpt.com/codex/tasks/task_e_6884cba627388320803b58ea1bfcbbe6