### PR TITLE
Add direction validation for export_causal_path

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -44,6 +44,8 @@ def export_causal_path(
     """
     Export a simplified causal trace path in either upstream or downstream direction.
     """
+    if direction not in {"ancestors", "descendants"}:
+        raise ValueError("direction must be 'ancestors' or 'descendants'")
     trace = (
         graph.trace_to_ancestors(node_id, max_depth=depth)
         if direction == "ancestors"


### PR DESCRIPTION
## Summary
- validate direction in `export_causal_path`
- test new validation logic

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: no matching distribution found for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6884e7e54fdc83209ba73761640df574