### PR TITLE
Add guard for entanglement factor

### DIFF
--- a/quantum_sim.py
+++ b/quantum_sim.py
@@ -244,6 +244,11 @@ class QuantumContext:
         assumptions: probabilistic weight models linkage
         validation_notes: unit tests verify weight update
         """
+        if influence_factor < 0:
+            raise ValueError("influence_factor must be >= 0")
+
+        influence_factor = max(0.0, influence_factor)
+
         pair = tuple(sorted((entity1_id, entity2_id)))
         self.entangled_pairs[pair] = (
             self.entangled_pairs.get(pair, 0.0) + influence_factor

--- a/tests/test_scientific.py
+++ b/tests/test_scientific.py
@@ -288,3 +288,12 @@ def test_assess_meta_cognitive_awareness_basic():
     assert result["total_validations"] == 4
     assert result["bias_correction_events"] == 2
     assert 0.5 <= result["average_accuracy"] <= 0.95
+
+
+def test_entangle_entities_negative_factor_raises():
+    """Negative influence factors should raise ``ValueError``."""
+    qc = QuantumContext()
+    pair = tuple(sorted(("a", "b")))
+    with pytest.raises(ValueError):
+        qc.entangle_entities("a", "b", influence_factor=-1.0)
+    assert pair not in qc.entangled_pairs


### PR DESCRIPTION
## Summary
- prevent negative `influence_factor` values in `quantum_sim.QuantumContext.entangle_entities`
- test that negative factors raise `ValueError`

## Testing
- `pytest -k entangle_entities_negative_factor_raises -q` *(fails: AttributeError: 'NoneType' object has no attribute 'c')*

------
https://chatgpt.com/codex/tasks/task_e_6884e9d3823c8320b0c10eb54e07f011