### PR TITLE
Update installation notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ python validate_hypothesis.py --validations sample_validations.json
 pip install -r requirements.txt
 ```
 
+This project is tested with **SQLAlchemy 2.x**, so ensure you have
+`sqlalchemy>=2.0` installed.
+
 ## 🔧 Configuration
 
 `SECRET_KEY` **must** be supplied via environment variables for JWT signing.  A
@@ -49,6 +52,9 @@ After installing the dependencies, run:
 ```bash
 pytest
 ```
+
+Some tests rely on optional packages such as `networkx`. Install them
+with `pip install networkx` to run the full test suite.
 
 ## ✨ Features
 


### PR DESCRIPTION
## Summary
- clarify minimum SQLAlchemy version in installation instructions
- note that optional packages such as `networkx` are needed to run all tests

## Testing
- `pytest -q` *(fails: RelationshipProperty.__init__() got an unexpected keyword argument 'primary_join')*

------
https://chatgpt.com/codex/tasks/task_e_68852d3464bc8320ad07a1498f6125d4