### PR TITLE
Fix VibeNode entanglement join arg names

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -160,8 +160,8 @@ class VibeNode(Base):
     entangled_with = relationship(
         "VibeNode",
         secondary=vibenode_entanglements,
-        primary_join=(vibenode_entanglements.c.source_id == id),
-        secondary_join=(vibenode_entanglements.c.target_id == id),
+        primaryjoin=(vibenode_entanglements.c.source_id == id),
+        secondaryjoin=(vibenode_entanglements.c.target_id == id),
         backref="entangled_from",
     )
     creative_guild = relationship(


### PR DESCRIPTION
## Summary
- correct keyword arguments for VibeNode `entangled_with` relationship
- ensure tests run without import error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852d36c2588320bfd76930fa1bb015