### PR TITLE
Fix highlight normalization and SQLAlchemy join args

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -56,12 +56,14 @@ def export_causal_path(
         (entry["edge"]["source"], entry["edge"]["target"], entry["edge"].get("edge_type", ""))
         for entry in trace
     ]
-    highlights = [
-        entry["node_id"]
-        for entry in trace
-        if entry["node_data"].get("node_specific_entropy", 1.0) < 0.25
-        or entry["node_data"].get("debug_payload")
-    ]
+    highlights = []
+    for entry in trace:
+        node_data = entry.get("node_data", {})
+        entropy = node_data.get("node_specific_entropy", 1.0)
+        if entropy is None:
+            entropy = 1.0
+        if entropy < 0.25 or node_data.get("debug_payload"):
+            highlights.append(entry["node_id"])
     return {
         "path_nodes": path_nodes,
         "edge_list": edge_list,

--- a/db_models.py
+++ b/db_models.py
@@ -160,8 +160,8 @@ class VibeNode(Base):
     entangled_with = relationship(
         "VibeNode",
         secondary=vibenode_entanglements,
-        primary_join=(vibenode_entanglements.c.source_id == id),
-        secondary_join=(vibenode_entanglements.c.target_id == id),
+        primaryjoin=(vibenode_entanglements.c.source_id == id),
+        secondaryjoin=(vibenode_entanglements.c.target_id == id),
         backref="entangled_from",
     )
     creative_guild = relationship(


### PR DESCRIPTION
## Summary
- fix export_causal_path highlight handling when entropy missing
- update relationship arguments for SQLAlchemy compatibility

## Testing
- `pytest tests/test_audit_bridge.py::test_export_causal_path_valid_directions -q`

------
https://chatgpt.com/codex/tasks/task_e_68852d60a39483209ba7d0780fb1fbb4