### PR TITLE
Fix SQLAlchemy relationships and tests

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -56,12 +56,12 @@ def export_causal_path(
         (entry["edge"]["source"], entry["edge"]["target"], entry["edge"].get("edge_type", ""))
         for entry in trace
     ]
-    highlights = [
-        entry["node_id"]
-        for entry in trace
-        if entry["node_data"].get("node_specific_entropy", 1.0) < 0.25
-        or entry["node_data"].get("debug_payload")
-    ]
+    highlights = []
+    for entry in trace:
+        data = entry.get("node_data") or {}
+        entropy = data.get("node_specific_entropy")
+        if ((entropy is not None and entropy < 0.25) or data.get("debug_payload")):
+            highlights.append(entry["node_id"])
     return {
         "path_nodes": path_nodes,
         "edge_list": edge_list,

--- a/db_models.py
+++ b/db_models.py
@@ -113,8 +113,12 @@ class Harmonizer(Base):
         back_populates="receiver",
         cascade="all, delete-orphan",
     )
-    groups = relationship("Group", secondary=group_members, back_populates="groups")
-    events = relationship("Event", secondary=event_attendees, back_populates="events")
+    groups = relationship(
+        "Group", secondary=group_members, back_populates="members"
+    )
+    events = relationship(
+        "Event", secondary=event_attendees, back_populates="attendees"
+    )
     following = relationship(
         "Harmonizer",
         secondary=harmonizer_follows,
@@ -150,6 +154,7 @@ class VibeNode(Base):
         backref="parent_vibenode",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
     comments = relationship(
         "Comment", back_populates="vibenode", cascade="all, delete-orphan"
@@ -160,8 +165,8 @@ class VibeNode(Base):
     entangled_with = relationship(
         "VibeNode",
         secondary=vibenode_entanglements,
-        primary_join=(vibenode_entanglements.c.source_id == id),
-        secondary_join=(vibenode_entanglements.c.target_id == id),
+        primaryjoin=(vibenode_entanglements.c.source_id == id),
+        secondaryjoin=(vibenode_entanglements.c.target_id == id),
         backref="entangled_from",
     )
     creative_guild = relationship(
@@ -238,6 +243,7 @@ class Comment(Base):
         backref="parent_comment",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
 
 

--- a/scientific_metrics.py
+++ b/scientific_metrics.py
@@ -980,10 +980,13 @@ def log_metric_change(
 ) -> None:
     """Persist a single metric change event to ``SystemState`` audit log."""
 
+    def _json_safe(val: Any) -> Any:
+        return float(val) if isinstance(val, Decimal) else val
+
     entry = {
         "metric_name": metric_name,
-        "old_value": old_value,
-        "new_value": new_value,
+        "old_value": _json_safe(old_value),
+        "new_value": _json_safe(new_value),
         "source_module": source_module,
         "note": optional_note,
         "timestamp": datetime.datetime.utcnow().isoformat(),

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -572,8 +572,12 @@ class Harmonizer(Base):
         back_populates="receiver",
         cascade="all, delete-orphan",
     )
-    groups = relationship("Group", secondary=group_members, back_populates="groups")
-    events = relationship("Event", secondary=event_attendees, back_populates="events")
+    groups = relationship(
+        "Group", secondary=group_members, back_populates="members"
+    )
+    events = relationship(
+        "Event", secondary=event_attendees, back_populates="attendees"
+    )
     following = relationship(
         "Harmonizer",
         secondary=harmonizer_follows,
@@ -609,6 +613,7 @@ class VibeNode(Base):
         backref="parent_vibenode",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
     comments = relationship(
         "Comment", back_populates="vibenode", cascade="all, delete-orphan"
@@ -697,6 +702,7 @@ class Comment(Base):
         backref="parent_comment",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
 
 


### PR DESCRIPTION
## Summary
- fix Harmonizer/Group and Harmonizer/Event relationship directions
- correct join argument names in `VibeNode.entangled_with`
- satisfy delete-orphan requirements with `single_parent=True`
- make audit bridge robust to missing node data
- allow Decimal values in metric log serialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852d6022c083208e13008e35993065