### PR TITLE
Fix relationship links in ORM models

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -56,12 +56,11 @@ def export_causal_path(
         (entry["edge"]["source"], entry["edge"]["target"], entry["edge"].get("edge_type", ""))
         for entry in trace
     ]
-    highlights = [
-        entry["node_id"]
-        for entry in trace
-        if entry["node_data"].get("node_specific_entropy", 1.0) < 0.25
-        or entry["node_data"].get("debug_payload")
-    ]
+    highlights = []
+    for entry in trace:
+        entropy = entry["node_data"].get("node_specific_entropy")
+        if (entropy is not None and entropy < 0.25) or entry["node_data"].get("debug_payload"):
+            highlights.append(entry["node_id"])
     return {
         "path_nodes": path_nodes,
         "edge_list": edge_list,

--- a/db_models.py
+++ b/db_models.py
@@ -113,8 +113,8 @@ class Harmonizer(Base):
         back_populates="receiver",
         cascade="all, delete-orphan",
     )
-    groups = relationship("Group", secondary=group_members, back_populates="groups")
-    events = relationship("Event", secondary=event_attendees, back_populates="events")
+    groups = relationship("Group", secondary=group_members, back_populates="members")
+    events = relationship("Event", secondary=event_attendees, back_populates="attendees")
     following = relationship(
         "Harmonizer",
         secondary=harmonizer_follows,
@@ -150,6 +150,7 @@ class VibeNode(Base):
         backref="parent_vibenode",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
     comments = relationship(
         "Comment", back_populates="vibenode", cascade="all, delete-orphan"
@@ -160,8 +161,8 @@ class VibeNode(Base):
     entangled_with = relationship(
         "VibeNode",
         secondary=vibenode_entanglements,
-        primary_join=(vibenode_entanglements.c.source_id == id),
-        secondary_join=(vibenode_entanglements.c.target_id == id),
+        primaryjoin=(vibenode_entanglements.c.source_id == id),
+        secondaryjoin=(vibenode_entanglements.c.target_id == id),
         backref="entangled_from",
     )
     creative_guild = relationship(
@@ -238,6 +239,7 @@ class Comment(Base):
         backref="parent_comment",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
 
 

--- a/scientific_metrics.py
+++ b/scientific_metrics.py
@@ -1007,9 +1007,9 @@ def log_metric_change(
         log = log[-1000:]
 
     if state:
-        state.value = json.dumps(log)
+        state.value = json.dumps(log, default=str)
     else:
-        state = SystemState(key="metric_audit_log", value=json.dumps(log))
+        state = SystemState(key="metric_audit_log", value=json.dumps(log, default=str))
         db.add(state)
     db.commit()
 


### PR DESCRIPTION
## Summary
- fix Harmonizer groups/events relationship names
- add SQLAlchemy `single_parent` settings for self-referential relationships
- make audit log JSON serialization robust to Decimal
- avoid comparing `None` values in causal path export
- verify all tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852df7a79c8320aab661182009c514