### PR TITLE
Fix JSON serialization for Decimal and adjust ORM relationships

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -113,8 +113,8 @@ class Harmonizer(Base):
         back_populates="receiver",
         cascade="all, delete-orphan",
     )
-    groups = relationship("Group", secondary=group_members, back_populates="groups")
-    events = relationship("Event", secondary=event_attendees, back_populates="events")
+    groups = relationship("Group", secondary=group_members, back_populates="members")
+    events = relationship("Event", secondary=event_attendees, back_populates="attendees")
     following = relationship(
         "Harmonizer",
         secondary=harmonizer_follows,
@@ -150,6 +150,7 @@ class VibeNode(Base):
         backref="parent_vibenode",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
     comments = relationship(
         "Comment", back_populates="vibenode", cascade="all, delete-orphan"
@@ -160,8 +161,8 @@ class VibeNode(Base):
     entangled_with = relationship(
         "VibeNode",
         secondary=vibenode_entanglements,
-        primary_join=(vibenode_entanglements.c.source_id == id),
-        secondary_join=(vibenode_entanglements.c.target_id == id),
+        primaryjoin=(vibenode_entanglements.c.source_id == id),
+        secondaryjoin=(vibenode_entanglements.c.target_id == id),
         backref="entangled_from",
     )
     creative_guild = relationship(
@@ -238,6 +239,7 @@ class Comment(Base):
         backref="parent_comment",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
 
 

--- a/scientific_metrics.py
+++ b/scientific_metrics.py
@@ -1007,9 +1007,9 @@ def log_metric_change(
         log = log[-1000:]
 
     if state:
-        state.value = json.dumps(log)
+        state.value = json.dumps(log, default=str)
     else:
-        state = SystemState(key="metric_audit_log", value=json.dumps(log))
+        state = SystemState(key="metric_audit_log", value=json.dumps(log, default=str))
         db.add(state)
     db.commit()
 


### PR DESCRIPTION
## Summary
- fix JSON serialization of metric audit logs by using `default=str`
- correct relationship attributes in ORM models for SQLAlchemy compatibility

## Testing
- `pytest -k test_delta_computation_and_type_robustness -q`

------
https://chatgpt.com/codex/tasks/task_e_68852dfc66d88320a5e832448913011c