### PR TITLE
Fix relationships and decimal serialization

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -113,8 +113,8 @@ class Harmonizer(Base):
         back_populates="receiver",
         cascade="all, delete-orphan",
     )
-    groups = relationship("Group", secondary=group_members, back_populates="groups")
-    events = relationship("Event", secondary=event_attendees, back_populates="events")
+    groups = relationship("Group", secondary=group_members, back_populates="members")
+    events = relationship("Event", secondary=event_attendees, back_populates="attendees")
     following = relationship(
         "Harmonizer",
         secondary=harmonizer_follows,
@@ -150,6 +150,7 @@ class VibeNode(Base):
         backref="parent_vibenode",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
     comments = relationship(
         "Comment", back_populates="vibenode", cascade="all, delete-orphan"
@@ -238,6 +239,7 @@ class Comment(Base):
         backref="parent_comment",
         remote_side=[id],
         cascade="all, delete-orphan",
+        single_parent=True,
     )
 
 

--- a/scientific_metrics.py
+++ b/scientific_metrics.py
@@ -982,8 +982,8 @@ def log_metric_change(
 
     entry = {
         "metric_name": metric_name,
-        "old_value": old_value,
-        "new_value": new_value,
+        "old_value": float(old_value) if isinstance(old_value, Decimal) else old_value,
+        "new_value": float(new_value) if isinstance(new_value, Decimal) else new_value,
         "source_module": source_module,
         "note": optional_note,
         "timestamp": datetime.datetime.utcnow().isoformat(),


### PR DESCRIPTION
## Summary
- fix many-to-many relationship mappings in `db_models`
- allow self-referential relationships to delete children safely
- ensure decimal values are serialized for metric change logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852f341a208320ba2801a1771780cd