### PR TITLE
Add init_db for explicit table setup

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -409,4 +409,8 @@ class MarketplaceListing(Base):
     price = Column(String, nullable=False)
     timestamp = Column(String, nullable=False)
 
-Base.metadata.create_all(bind=engine)
+
+def init_db() -> None:
+    """Create all tables defined in this module."""
+    Base.metadata.create_all(bind=engine)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,9 +301,9 @@ import pytest
 @pytest.fixture
 def test_db(tmp_path):
     """Provide an in-memory SQLite session for tests."""
-    from db_models import Base, SessionLocal, engine
+    from db_models import Base, SessionLocal, engine, init_db
 
-    Base.metadata.create_all(bind=engine)
+    init_db()
     db = SessionLocal()
     try:
         yield db


### PR DESCRIPTION
## Summary
- introduce `init_db()` in `db_models` to create tables when needed
- call `init_db()` in the test `test_db` fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688531db1b948320b89f4d744cbee23a