### PR TITLE
Fix entropy sampling with decay

### DIFF
--- a/scientific_metrics.py
+++ b/scientific_metrics.py
@@ -213,7 +213,8 @@ def calculate_interaction_entropy(
         # Bootstrap confidence using multinomial resampling
         samples = []
         for _ in range(10):
-            sample = random.choices(range(len(probs)), probs, k=total)
+            k = int(round(total))
+            sample = random.choices(range(len(probs)), probs, k=k)
             sample_counts = [sample.count(i) for i in range(len(probs))]
             s_probs = [c / total for c in sample_counts]
             if method == "gini":

--- a/tests/test_scientific.py
+++ b/tests/test_scientific.py
@@ -162,6 +162,19 @@ def test_interaction_entropy_zero():
     result = calculate_interaction_entropy(dummy, None)
     assert result["value"] == 0.0
 
+
+def test_interaction_entropy_with_decay():
+    """Non-zero decay should not raise and returns bounded entropy."""
+    now = datetime.datetime.utcnow()
+    dummy = types.SimpleNamespace(
+        vibenodes=[types.SimpleNamespace(created_at=now)],
+        comments=[types.SimpleNamespace(created_at=now - datetime.timedelta(seconds=30))],
+        liked_vibenodes=[],
+        following=[],
+    )
+    result = calculate_interaction_entropy(dummy, None, decay_rate=0.01)
+    assert 0.0 <= result["value"] <= 1.0
+
 def test_quantum_context_superposition():
     qc = QuantumContext(fuzzy_enabled=True, simulate=True)
     val = qc.measure_superposition(0.6)


### PR DESCRIPTION
## Summary
- fix bootstrap sampling when decay produces float counts
- test calculate_interaction_entropy with decay rate > 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688531db30008320aebff07884692fb6