### PR TITLE
Implement reputation persistence

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -346,6 +346,17 @@ class SystemState(Base):
     value = Column(String, nullable=False)
 
 
+class ValidatorReputation(Base):
+    """Stores reputation scores for validators."""
+
+    __tablename__ = "validator_reputations"
+
+    validator_id = Column(String, primary_key=True)
+    reputation = Column(Float, nullable=False, default=0.0)
+    updated_at = Column(DateTime, default=datetime.datetime.utcnow,
+                        onupdate=datetime.datetime.utcnow)
+
+
 # Add this below the SystemState class but before Coin to maintain ordering:
 class HypothesisRecord(Base):
     """

--- a/tests/test_validator_reputation_storage.py
+++ b/tests/test_validator_reputation_storage.py
@@ -1,0 +1,22 @@
+import pytest
+from validator_reputation_tracker import save_reputations, load_reputations
+from db_models import ValidatorReputation
+
+
+def test_save_and_load_reputations(test_db):
+    reps = {"v1": 0.7, "v2": 0.3}
+    save_reputations(reps, test_db)
+
+    db_rows = {r.validator_id: r.reputation for r in test_db.query(ValidatorReputation).all()}
+    assert db_rows == reps
+
+    loaded = load_reputations(test_db)
+    assert loaded == reps
+
+
+def test_save_updates_existing(test_db):
+    save_reputations({"v1": 0.4}, test_db)
+    save_reputations({"v1": 0.9}, test_db)
+
+    row = test_db.query(ValidatorReputation).filter_by(validator_id="v1").first()
+    assert row.reputation == 0.9

--- a/validator_reputation_tracker.py
+++ b/validator_reputation_tracker.py
@@ -98,18 +98,38 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
 
 # --- Placeholder Persistence Functions ---
 def save_reputations(reputations: Dict[str, float], db) -> None:
-    """
-    Placeholder for persistence to DB.
-    """
-    logger.debug("Saving reputations — not yet implemented.")
+    """Persist reputation scores using the provided session."""
+
+    try:
+        from db_models import ValidatorReputation
+    except Exception as e:  # pragma: no cover - fallback handling
+        logger.error(f"DB models unavailable: {e}")
+        return
+
+    for vid, rep in reputations.items():
+        row = db.query(ValidatorReputation).filter(
+            ValidatorReputation.validator_id == vid
+        ).first()
+        if row:
+            row.reputation = float(rep)
+        else:
+            row = ValidatorReputation(validator_id=vid, reputation=float(rep))
+            db.add(row)
+
+    db.commit()
 
 
 def load_reputations(db) -> Dict[str, float]:
-    """
-    Placeholder for loading from DB.
-    """
-    logger.debug("Loading reputations — not yet implemented.")
-    return {}
+    """Return all saved reputation scores."""
+
+    try:
+        from db_models import ValidatorReputation
+    except Exception as e:  # pragma: no cover - fallback handling
+        logger.error(f"DB models unavailable: {e}")
+        return {}
+
+    rows = db.query(ValidatorReputation).all()
+    return {row.validator_id: float(row.reputation) for row in rows}
 
 # TODO (v4.2):
 # - Implement semantic_contradiction_resolver integration


### PR DESCRIPTION
## Summary
- add `ValidatorReputation` table for saving validator reputations
- implement `save_reputations` and `load_reputations`
- test persistence of validator reputations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885326f7acc8320b458906404e59f71