### PR TITLE
Fix SQLAlchemy stub for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,8 @@ for mod_name in [
             def _base():
                 class B:
                     metadata = types.SimpleNamespace()
+                    metadata.create_all = lambda *a, **kw: None
+                    metadata.drop_all = lambda *a, **kw: None
 
                 return B
 


### PR DESCRIPTION
## Summary
- enhance `_base` stub for SQLAlchemy ORM so `metadata` has `create_all` and `drop_all`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688536bfe6688320aa3bce238e66a111