### PR TITLE
Use stored causal audit ref

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,7 @@ for mod_name in [
     "redis",
     "passlib",
     "jose",
+    "governance_reviewer",
 ]:
     if mod_name not in sys.modules:
         stub = types.ModuleType(mod_name)
@@ -219,6 +220,12 @@ for mod_name in [
         if mod_name == "jose":
             stub.jwt = types.SimpleNamespace(encode=lambda *a, **kw: "", decode=lambda *a, **kw: {})
             stub.JWTError = type("JWTError", (), {})
+        if mod_name == "governance_reviewer":
+            def _noop(*_a, **_kw):
+                return {}
+
+            stub.evaluate_governance_risks = _noop
+            stub.apply_governance_actions = _noop
         sys.modules[mod_name] = stub
 
 # Provide a minimal networkx stub if the real package is unavailable

--- a/tests/test_causal_trigger.py
+++ b/tests/test_causal_trigger.py
@@ -1,0 +1,39 @@
+import json
+import datetime
+from causal_trigger import trigger_causal_audit
+from db_models import LogEntry, SystemState
+from causal_graph import InfluenceGraph
+
+
+def test_trigger_causal_audit_uses_audit_ref(test_db):
+    ref = "test_audit_ref"
+    snapshot = {
+        "trace": {
+            "trace_detail": {
+                "path_nodes_data": [
+                    {"id": "n1"}
+                ],
+                "edge_list_data": []
+            }
+        }
+    }
+    test_db.add(SystemState(key=ref, value=json.dumps(snapshot)))
+    test_db.commit()
+
+    payload = json.dumps({"causal_audit_ref": ref})
+    log = LogEntry(
+        timestamp=datetime.datetime.utcnow(),
+        event_type="test",
+        payload=payload,
+        previous_hash="p",
+        current_hash="c",
+    )
+    test_db.add(log)
+    test_db.commit()
+
+    graph = InfluenceGraph()
+    result = trigger_causal_audit(test_db, log.id, graph)
+    chain = result.get("causal_chain")
+    assert isinstance(chain, list)
+    assert chain and chain[0].get("type") == "node_event"
+


### PR DESCRIPTION
## Summary
- parse `LogEntry.payload` for `causal_audit_ref`
- trace causal chain via the stored audit ref
- document new audit reference requirement
- stub `governance_reviewer` for tests
- add regression test for tracing with stored audit reference

## Testing
- `pytest tests/test_causal_trigger.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688536ce3b008320870f406048dc36a9