### PR TITLE
Add python-dateutil dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 
 This project is tested with **SQLAlchemy 2.x**, so ensure you have
 `sqlalchemy>=2.0` installed.
+The code also requires `python-dateutil` for timestamp parsing.
 
 ## 🔧 Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 sqlalchemy
 networkx
+python-dateutil


### PR DESCRIPTION
## Summary
- include `python-dateutil` in `requirements.txt`
- note the extra dependency in README installation section

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853b1b579c832092e9fac9261c8b4e