### PR TITLE
Fix: use logger in _get_all_hypotheses

### DIFF
--- a/hypothesis_reasoner.py
+++ b/hypothesis_reasoner.py
@@ -48,7 +48,10 @@ def _get_all_hypotheses(db: Session) -> List[Dict[str, Any]]:
             parsed_hypotheses.append(json.loads(entry.value))
         except json.JSONDecodeError:
             # Log error for malformed entry, but continue
-            print(f"Warning: Malformed hypothesis record found for key: {entry.key}")
+            logger.warning(
+                "Warning: Malformed hypothesis record found for key: %s",
+                entry.key,
+            )
             continue
     return parsed_hypotheses
 


### PR DESCRIPTION
## Summary
- use `logger.warning` for malformed hypothesis JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853dce5514832089563857e03b2065