### PR TITLE
Add tests for audit bundle and prediction manager

### DIFF
--- a/tests/test_auditor_report_formatter.py
+++ b/tests/test_auditor_report_formatter.py
@@ -1,0 +1,41 @@
+import re
+from auditor_report_formatter import generate_structured_audit_bundle
+
+
+def test_generate_structured_audit_bundle_basic():
+    explainer = {
+        "summary": "All good",
+        "reasoning": ["step1"],
+        "supporting_nodes": ["n1"],
+        "risk_flags": ["f1"]
+    }
+    bias = {"summary": "no major bias"}
+    causal = [{"id": 1}]
+
+    bundle = generate_structured_audit_bundle(
+        explainer_output=explainer,
+        bias_data=bias,
+        causal_chain_data=causal,
+        hypothesis_id="H1",
+        hypothesis_text_preview="Example text",
+        validation_id=7,
+    )
+
+    assert bundle["hypothesis_id"] == "H1"
+    assert bundle["validation_id"] == 7
+    assert bundle["summary"] == "All good"
+    assert bundle["risk_flags"] == ["f1"]
+    assert bundle["bias_summary"] == "no major bias"
+    assert bundle["causal_trace"] == causal
+
+    md = bundle["markdown_report"]
+    assert "# Hypothesis Audit Report: `H1`" in md
+    assert "## Bias Impact Summary" in md
+    assert "no major bias" in md
+
+    plain = bundle["plain_text_report"]
+    assert "Summary: All good" in plain
+    assert "Risk Flags:" in plain
+
+    # timestamp should be ISO formatted
+    assert re.match(r"\d{4}-\d{2}-\d{2}T", bundle["timestamp"])

--- a/tests/test_prediction_manager.py
+++ b/tests/test_prediction_manager.py
@@ -1,0 +1,29 @@
+from prediction_manager import PredictionManager
+from db_models import SessionLocal, init_db, Base, engine
+
+
+def test_prediction_lifecycle(tmp_path):
+    # ensure tables exist
+    init_db()
+    manager = PredictionManager(session_factory=SessionLocal)
+
+    data = {"foo": 1, "status": "created"}
+    pid = manager.store_prediction(data)
+    record = manager.get_prediction(pid)
+
+    assert record["prediction_id"] == pid
+    assert record["data"]["foo"] == 1
+    assert record["status"] == "created"
+
+    manager.update_prediction_status(pid, "done", {"res": 2})
+    updated = manager.get_prediction(pid)
+    assert updated["status"] == "done"
+    assert updated["actual_outcome"]["res"] == 2
+
+    exp_id = manager.store_experiment_design({"name": "exp"})
+    exp = manager.get_experiment_design(exp_id)
+    assert exp["experiment_id"] == exp_id
+    assert exp["data"]["name"] == "exp"
+
+    # cleanup
+    Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Summary
- add unit tests for `generate_structured_audit_bundle`
- cover basic lifecycle of `PredictionManager`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853dd790dc8320aa52cb05c951d0d0