### PR TITLE
Add theme toggle to frontend

### DIFF
--- a/transcendental-resonance-frontend/README.md
+++ b/transcendental-resonance-frontend/README.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 streamlit run src/main.py
 ```
 
-Replace the backend URL in `src/utils/api.py` if your API is not running on `http://localhost:8000`.
+Replace the backend URL with the `BACKEND_URL` environment variable if your API is not running on `http://localhost:8000`.
 
 ## Structure
 
@@ -20,4 +20,4 @@ Replace the backend URL in `src/utils/api.py` if your API is not running on `htt
 
 ## Notes
 
-This UI is mobile-first with a futuristic aesthetic (dark mode and neon accents). Future improvements include real-time notifications, theming, and internationalization.
+This UI is mobile-first with a futuristic aesthetic (dark mode and neon accents). A theme toggle is built in so you can switch between light and dark palettes. Future improvements include real-time notifications and internationalization.

--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -3,11 +3,24 @@
 from nicegui import ui
 
 from .utils.api import clear_token
-from .utils.styles import apply_global_styles
+from .utils.styles import apply_global_styles, set_theme, get_theme, THEMES
 from .pages import *  # register all pages
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
+
+
+def toggle_theme() -> None:
+    """Switch between light and dark themes."""
+    current = get_theme()
+    new_name = "light" if current is THEMES["dark"] else "dark"
+    set_theme(new_name)
+
+
+ui.button(
+    "Toggle Theme",
+    on_click=toggle_theme,
+).classes("fixed top-0 right-0 m-2")
 
 # Potential future enhancements:
 # - Real-time updates via WebSockets

--- a/transcendental-resonance-frontend/src/pages/ai_assist_page.py
+++ b/transcendental-resonance-frontend/src/pages/ai_assist_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def ai_assist_page(vibenode_id: int):
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/events_page.py
+++ b/transcendental-resonance-frontend/src/pages/events_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def events_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/groups_page.py
+++ b/transcendental-resonance-frontend/src/pages/groups_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def groups_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/login_page.py
+++ b/transcendental-resonance-frontend/src/pages/login_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, set_token
+from utils.api import api_call, set_token
+from utils.styles import get_theme
 from utils.api import clear_token  # imported for completeness
 
 
@@ -10,6 +11,7 @@ from utils.api import clear_token  # imported for completeness
 async def login_page():
     """Render the login form and handle authentication."""
     ui.context.client.request.headers['user-agent']
+    THEME = get_theme()
     with ui.column().classes('w-full max-w-md mx-auto p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):
@@ -43,6 +45,7 @@ async def login_page():
 @ui.page('/register')
 async def register_page():
     """Render the registration form."""
+    THEME = get_theme()
     with ui.column().classes('w-full max-w-md mx-auto p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/messages_page.py
+++ b/transcendental-resonance-frontend/src/pages/messages_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def messages_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/network_analysis_page.py
+++ b/transcendental-resonance-frontend/src/pages/network_analysis_page.py
@@ -3,7 +3,8 @@
 import json
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -14,6 +15,7 @@ async def network_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/notifications_page.py
+++ b/transcendental-resonance-frontend/src/pages/notifications_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def notifications_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN, clear_token
+from utils.api import api_call, TOKEN, clear_token
+from utils.styles import get_theme
 from .login_page import login_page
 from .vibenodes_page import vibenodes_page
 from .groups_page import groups_page
@@ -25,6 +26,7 @@ async def profile_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/proposals_page.py
+++ b/transcendental-resonance-frontend/src/pages/proposals_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def proposals_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/status_page.py
+++ b/transcendental-resonance-frontend/src/pages/status_page.py
@@ -2,12 +2,14 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME
+from utils.api import api_call
+from utils.styles import get_theme
 
 
 @ui.page('/status')
 async def status_page():
     """Display real-time system metrics."""
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/upload_page.py
+++ b/transcendental-resonance-frontend/src/pages/upload_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def upload_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/pages/vibenodes_page.py
+++ b/transcendental-resonance-frontend/src/pages/vibenodes_page.py
@@ -2,7 +2,8 @@
 
 from nicegui import ui
 
-from utils.api import api_call, THEME, TOKEN
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
 from .login_page import login_page
 
 
@@ -13,6 +14,7 @@ async def vibenodes_page():
         ui.open(login_page)
         return
 
+    THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):

--- a/transcendental-resonance-frontend/src/utils/api.py
+++ b/transcendental-resonance-frontend/src/utils/api.py
@@ -2,20 +2,12 @@
 
 from typing import Optional, Dict
 
+import os
 import requests
 from nicegui import ui
 
 # Backend API base URL
-BACKEND_URL = "http://localhost:8000"
-
-# Theme configuration used across all pages
-THEME = {
-    'primary': '#0d47a1',  # Deep blue for futuristic feel
-    'accent': '#00e676',   # Neon green
-    'background': '#121212',  # Dark mode
-    'text': '#ffffff',
-    'gradient': 'linear-gradient(135deg, #0d47a1 0%, #121212 100%)'
-}
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 TOKEN: Optional[str] = None
 

--- a/transcendental-resonance-frontend/src/utils/styles.py
+++ b/transcendental-resonance-frontend/src/utils/styles.py
@@ -1,17 +1,51 @@
 """Styling utilities for the Transcendental Resonance frontend."""
 
+from typing import Dict
+
 from nicegui import ui
-from .api import THEME
+
+# Theme palettes. The default "dark" theme matches the original neon aesthetic.
+THEMES: Dict[str, Dict[str, str]] = {
+    "dark": {
+        "primary": "#0d47a1",
+        "accent": "#00e676",
+        "background": "#121212",
+        "text": "#ffffff",
+        "gradient": "linear-gradient(135deg, #0d47a1 0%, #121212 100%)",
+    },
+    "light": {
+        "primary": "#1976d2",
+        "accent": "#ff4081",
+        "background": "#ffffff",
+        "text": "#000000",
+        "gradient": "linear-gradient(135deg, #ffffff 0%, #f3f3f3 100%)",
+    },
+}
+
+# Currently active theme. Can be switched at runtime via ``set_theme``.
+ACTIVE_THEME: Dict[str, str] = THEMES["dark"]
 
 
 def apply_global_styles() -> None:
     """Inject global CSS styles into the application."""
     ui.add_head_html(
         f"""
-        <style>
-            body {{ background: {THEME['background']}; color: {THEME['text']}; }}
-            .q-btn:hover {{ border: 1px solid {THEME['accent']}; }}
-            .futuristic-gradient {{ background: {THEME['gradient']}; }}
+        <style id="global-theme">
+            body {{ background: {ACTIVE_THEME['background']}; color: {ACTIVE_THEME['text']}; }}
+            .q-btn:hover {{ border: 1px solid {ACTIVE_THEME['accent']}; }}
+            .futuristic-gradient {{ background: {ACTIVE_THEME['gradient']}; }}
         </style>
         """
     )
+
+
+def set_theme(name: str) -> None:
+    """Switch the active theme by name and reapply global styles."""
+    global ACTIVE_THEME
+    ACTIVE_THEME = THEMES.get(name, THEMES["dark"])
+    apply_global_styles()
+
+
+def get_theme() -> Dict[str, str]:
+    """Return the currently active theme dictionary."""
+    return ACTIVE_THEME

--- a/transcendental-resonance-frontend/tests/test_styles.py
+++ b/transcendental-resonance-frontend/tests/test_styles.py
@@ -1,0 +1,20 @@
+import types
+from utils import styles
+
+def test_set_theme_switches(monkeypatch):
+    dummy = types.SimpleNamespace(add_head_html=lambda *_: None)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.set_theme("light")
+    assert styles.get_theme() is styles.THEMES["light"]
+    styles.set_theme("dark")
+    assert styles.get_theme() is styles.THEMES["dark"]
+
+
+def test_apply_global_styles_injects_css(monkeypatch):
+    captured = {}
+    def add_head_html(html):
+        captured["html"] = html
+    dummy = types.SimpleNamespace(add_head_html=add_head_html)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.apply_global_styles()
+    assert "global-theme" in captured["html"]


### PR DESCRIPTION
## Summary
- allow overriding backend URL via environment variable
- provide dark & light themes with a toggle button
- adjust pages to use the new theme system
- document theme toggle in README
- add tests covering theme utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68853e20e0b08320ab330485c73ee999