### PR TITLE
Make backend URL configurable via env var

### DIFF
--- a/transcendental-resonance-frontend/README.md
+++ b/transcendental-resonance-frontend/README.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 streamlit run src/main.py
 ```
 
-Replace the backend URL in `src/utils/api.py` if your API is not running on `http://localhost:8000`.
+If your backend is not running on `http://localhost:8000`, set the `BACKEND_URL` environment variable before starting the app.
 
 ## Structure
 

--- a/transcendental-resonance-frontend/src/utils/api.py
+++ b/transcendental-resonance-frontend/src/utils/api.py
@@ -2,11 +2,12 @@
 
 from typing import Optional, Dict
 
+import os
 import requests
 from nicegui import ui
 
 # Backend API base URL
-BACKEND_URL = "http://localhost:8000"
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 # Theme configuration used across all pages
 THEME = {


### PR DESCRIPTION
## Summary
- allow overriding BACKEND_URL with env var in frontend `api.py`
- document `BACKEND_URL` environment variable in frontend README

## Testing
- `pip install -r requirements.txt`
- `pip install -r transcendental-resonance-frontend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853f0e335883208a8beb3aa8a1ac7e