### PR TITLE
Add frontend API tests

### DIFF
--- a/transcendental-resonance-frontend/tests/conftest.py
+++ b/transcendental-resonance-frontend/tests/conftest.py
@@ -4,3 +4,93 @@ from pathlib import Path
 SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+import types
+import pytest
+
+
+class DummyUI:
+    """Lightweight NiceGUI stub used for tests."""
+
+    def __init__(self) -> None:
+        self.buttons = []
+        self.inputs = []
+        self.notifications = []
+        self.opened = []
+        self.head_html = ""
+
+    # decorator -------------------------------------------------------------
+    def page(self, path: str):
+        def decorator(func):
+            setattr(func, "__nicegui_path__", path)
+            return func
+        return decorator
+
+    # element stubs --------------------------------------------------------
+    context = types.SimpleNamespace(client=types.SimpleNamespace(request=types.SimpleNamespace(headers={"user-agent": "test"})))
+
+    def column(self):
+        return self
+
+    def label(self, *args, **kwargs):
+        return self
+
+    def input(self, *args, **kwargs):
+        obj = types.SimpleNamespace(value="", classes=lambda *_: obj)
+        self.inputs.append(obj)
+        return obj
+
+    textarea = input
+    select = input
+
+    def button(self, *args, on_click=None, **kwargs):
+        if on_click:
+            self.buttons.append(on_click)
+        obj = types.SimpleNamespace(classes=lambda *_: obj, style=lambda *_: obj)
+        return obj
+
+    def on_click(self, *_, **__):
+        return self
+
+    def classes(self, *_):
+        return self
+
+    def style(self, *_):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def open(self, target):
+        self.opened.append(target)
+
+    def notify(self, message, color=None):
+        self.notifications.append((message, color))
+
+    def timer(self, *_, **__):
+        pass
+
+    def html(self, *_, **__):
+        pass
+
+    def add_head_html(self, html: str) -> None:
+        self.head_html += html
+
+
+@pytest.fixture(autouse=True)
+def stub_nicegui(monkeypatch):
+    """Provide a minimal ``nicegui.ui`` stub for page tests."""
+
+    ui_stub = DummyUI()
+    nicegui_stub = types.SimpleNamespace(ui=ui_stub)
+    monkeypatch.setitem(sys.modules, "nicegui", nicegui_stub)
+    # ensure utilities use the stubbed ui
+    if "utils.styles" in sys.modules:
+        monkeypatch.setattr(sys.modules["utils.styles"], "ui", ui_stub)
+    if "utils.api" in sys.modules:
+        monkeypatch.setattr(sys.modules["utils.api"], "ui", ui_stub)
+    yield ui_stub
+

--- a/transcendental-resonance-frontend/tests/test_page_api_responses.py
+++ b/transcendental-resonance-frontend/tests/test_page_api_responses.py
@@ -1,0 +1,71 @@
+import importlib
+import pytest
+
+from utils import api
+from pages import login_page as login_mod
+
+
+def reload_login():
+    """Reload the login module so patched ``ui`` is applied."""
+    importlib.reload(login_mod)
+
+def get_button(ui_stub):
+    assert ui_stub.buttons, "no button captured"
+    return ui_stub.buttons.pop()
+
+
+@pytest.mark.asyncio
+async def test_login_success(monkeypatch, stub_nicegui):
+    monkeypatch.setattr(api, "api_call", lambda *a, **k: {"access_token": "tok"})
+    token = {}
+    monkeypatch.setattr(api, "set_token", lambda t: token.setdefault("value", t))
+
+    reload_login()
+    await login_mod.login_page()
+    stub_nicegui.inputs[0].value = "u"
+    stub_nicegui.inputs[1].value = "p"
+    await get_button(stub_nicegui)()
+
+    assert token.get("value") == "tok"
+    assert ("Login successful!", "positive") in stub_nicegui.notifications
+    assert stub_nicegui.opened
+
+
+@pytest.mark.asyncio
+async def test_login_error(monkeypatch, stub_nicegui):
+    monkeypatch.setattr(api, "api_call", lambda *a, **k: None)
+    reload_login()
+    await login_mod.login_page()
+    stub_nicegui.inputs[0].value = "u"
+    stub_nicegui.inputs[1].value = "p"
+    await get_button(stub_nicegui)()
+
+    assert ("Login failed", "negative") in stub_nicegui.notifications
+
+
+@pytest.mark.asyncio
+async def test_register_success(monkeypatch, stub_nicegui):
+    monkeypatch.setattr(api, "api_call", lambda *a, **k: True)
+    reload_login()
+    await login_mod.register_page()
+    stub_nicegui.inputs[0].value = "u"
+    stub_nicegui.inputs[1].value = "e@x"
+    stub_nicegui.inputs[2].value = "pass"
+    await get_button(stub_nicegui)()
+
+    assert ("Registration successful! Please login.", "positive") in stub_nicegui.notifications
+
+
+@pytest.mark.asyncio
+async def test_register_error(monkeypatch, stub_nicegui):
+    monkeypatch.setattr(api, "api_call", lambda *a, **k: None)
+    reload_login()
+    await login_mod.register_page()
+    stub_nicegui.inputs[0].value = "u"
+    stub_nicegui.inputs[1].value = "e@x"
+    stub_nicegui.inputs[2].value = "pass"
+    await get_button(stub_nicegui)()
+
+    assert ("Registration failed", "negative") in stub_nicegui.notifications
+
+

--- a/transcendental-resonance-frontend/tests/test_page_decorators.py
+++ b/transcendental-resonance-frontend/tests/test_page_decorators.py
@@ -1,0 +1,29 @@
+import importlib
+import pages
+
+PAGE_MODULES = {
+    "login_page": "pages.login_page",
+    "register_page": "pages.login_page",
+    "profile_page": "pages.profile_page",
+    "vibenodes_page": "pages.vibenodes_page",
+    "groups_page": "pages.groups_page",
+    "events_page": "pages.events_page",
+    "proposals_page": "pages.proposals_page",
+    "notifications_page": "pages.notifications_page",
+    "messages_page": "pages.messages_page",
+    "ai_assist_page": "pages.ai_assist_page",
+    "upload_page": "pages.upload_page",
+    "status_page": "pages.status_page",
+    "network_page": "pages.network_analysis_page",
+}
+
+
+def test_pages_have_nicegui_path():
+    for name in pages.__all__:
+        module_path = PAGE_MODULES[name]
+        module = importlib.reload(importlib.import_module(module_path))
+        func = getattr(module, name)
+        assert hasattr(func, "__nicegui_path__"), f"{name} missing __nicegui_path__"
+
+
+

--- a/transcendental-resonance-frontend/tests/test_styles.py
+++ b/transcendental-resonance-frontend/tests/test_styles.py
@@ -1,0 +1,8 @@
+import importlib
+from utils.styles import apply_global_styles
+
+
+def test_apply_global_styles_injects_css(stub_nicegui):
+    apply_global_styles()
+    assert "futuristic-gradient" in stub_nicegui.head_html
+


### PR DESCRIPTION
## Summary
- create a DummyUI stub to exercise page logic in tests
- test login and registration success/failure flows with mocked API calls
- verify each page exposes a `__nicegui_path__` attribute
- test that global CSS styles get injected

## Testing
- `pytest transcendental-resonance-frontend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68853f06c11c8320bf14ed52a168b9ac