### PR TITLE
Add introspection package initialization

### DIFF
--- a/introspection/__init__.py
+++ b/introspection/__init__.py
@@ -1,0 +1,5 @@
+"""Package for introspection components."""
+
+from . import introspection_pipeline
+
+__all__ = ["introspection_pipeline"]

--- a/tests/test_introspection_import.py
+++ b/tests/test_introspection_import.py
@@ -1,0 +1,3 @@
+def test_package_import():
+    from introspection import introspection_pipeline
+    assert hasattr(introspection_pipeline, "run_full_audit")


### PR DESCRIPTION
## Summary
- add `introspection/__init__.py` to expose `introspection_pipeline`
- test that `from introspection import introspection_pipeline` works

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688542cc2ff08320b9e2dab8d1c69a05