### PR TITLE
Add metadata_json persistence test

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -373,6 +373,7 @@ class HypothesisRecord(Base):
     score = Column(Float, default=0.0)
     entropy_change = Column(Float, default=0.0) # From associated audit metadata
     confidence_interval = Column(String, default="") # From hypothesis_reasoner
+    metadata_json = Column(JSON, default=lambda: {})
 
     validation_log_ids = Column(JSON, default=lambda: [])  # LogEntry.id references
     audit_sources = Column(JSON, default=lambda: [])       # causal_trigger.py, audit_bridge.py etc. refs (SystemState keys)

--- a/governance/governance_reviewer.py
+++ b/governance/governance_reviewer.py
@@ -44,7 +44,7 @@ def evaluate_governance_risks(
     requires_human_review = False
     score_penalty = 0.0
 
-    metadata = hypothesis.metadata or {}
+    metadata = hypothesis.metadata_json or {}
     text = (hypothesis.text or "").lower()
 
     # --- Metadata checks ---
@@ -120,10 +120,10 @@ def apply_governance_actions(hypothesis: HypothesisRecord, actions: List[str], d
             hypothesis.status = "quarantined"  # Ensure 'quarantined' is a valid status in your model
             logger.warning(f"Hypothesis {hypothesis.id} quarantined due to governance violations.")
         elif action == "flag_for_retraining":
-            hypothesis.metadata["retraining_required"] = True
+            hypothesis.metadata_json["retraining_required"] = True
             logger.info(f"Hypothesis {hypothesis.id} flagged for retraining.")
         elif action == "rollback_requested":
-            hypothesis.metadata["rollback_flag"] = True
+            hypothesis.metadata_json["rollback_flag"] = True
             logger.warning(f"Rollback flag set for hypothesis {hypothesis.id}.")
         else:
             logger.info(f"Action '{action}' logged for hypothesis {hypothesis.id} (no-op).")

--- a/hypothesis_tracker.py
+++ b/hypothesis_tracker.py
@@ -98,7 +98,7 @@ def register_hypothesis(text: str, db: Session, metadata: Optional[Dict[str, Any
         created_at=now_dt,  # Store datetime object
         status="open",
         score=0.0,
-        metadata=metadata or {},
+        metadata_json=metadata or {},
     )
 
     # Ensure mutable JSON columns are initialized before use
@@ -166,9 +166,9 @@ def update_hypothesis_score(
     # Update metadata field (JSON column)
     if metadata_update:
         # Load existing JSON, update, then reassign to trigger ORM change detection
-        current_metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        current_metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
         current_metadata.update(metadata_update)
-        record.metadata = current_metadata 
+        record.metadata_json = current_metadata
 
     history_entry = {
         "t": datetime.utcnow().isoformat(), # Use ISO string for history entry
@@ -228,13 +228,13 @@ def attach_evidence_to_hypothesis(
             record.validation_log_ids.append(log_id)
 
     # Attach supporting_nodes information to metadata (JSON column, dict)
-    current_metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    current_metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
     if 'supporting_nodes_history' not in current_metadata:
         current_metadata['supporting_nodes_history'] = []
     # Append new nodes, ensuring uniqueness within the history
     current_nodes_in_history = set(current_metadata['supporting_nodes_history'])
     current_metadata['supporting_nodes_history'].extend([n for n in node_ids if n not in current_nodes_in_history])
-    record.metadata = current_metadata # Reassign to ensure ORM detects change
+    record.metadata_json = current_metadata # Reassign to ensure ORM detects change
 
     note_text = f"Evidence attached: Nodes {node_ids}, Logs {log_ids}."
     if summary_note:

--- a/tests/test_hypothesis_tracker.py
+++ b/tests/test_hypothesis_tracker.py
@@ -16,3 +16,19 @@ def test_register_hypothesis_generates_unique_id(test_db):
     hid2 = register_hypothesis("another hypothesis", test_db)
     assert hid != hid2
 
+
+def test_metadata_json_persistence_new_session(test_db):
+    metadata = {"creator": "tester", "timestamp": "2025-01-01T00:00:00"}
+    hid = register_hypothesis("metadata test", test_db, metadata)
+
+    test_db.close()
+    from db_models import SessionLocal
+
+    new_session = SessionLocal()
+    try:
+        record = new_session.query(HypothesisRecord).filter_by(id=hid).first()
+        assert record is not None
+        assert record.metadata_json == metadata
+    finally:
+        new_session.close()
+


### PR DESCRIPTION
## Summary
- add `metadata_json` column to `HypothesisRecord`
- adapt helper logic to use the new column
- update governance reviewer for new field
- test that metadata_json persists across DB sessions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688542c4074483209f84d3709d7f53d7