### PR TITLE
Add metadata_json field to hypothesis tracking

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -377,6 +377,9 @@ class HypothesisRecord(Base):
     validation_log_ids = Column(JSON, default=lambda: [])  # LogEntry.id references
     audit_sources = Column(JSON, default=lambda: [])       # causal_trigger.py, audit_bridge.py etc. refs (SystemState keys)
 
+    # renamed from ``metadata`` to avoid clashing with SQLAlchemy's ``metadata`` attribute
+    metadata_json = Column(JSON, default=lambda: {})
+
     created_at = Column(DateTime, default=datetime.datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 

--- a/hypothesis_tracker.py
+++ b/hypothesis_tracker.py
@@ -98,7 +98,7 @@ def register_hypothesis(text: str, db: Session, metadata: Optional[Dict[str, Any
         created_at=now_dt,  # Store datetime object
         status="open",
         score=0.0,
-        metadata=metadata or {},
+        metadata_json=metadata or {},
     )
 
     # Ensure mutable JSON columns are initialized before use
@@ -166,9 +166,9 @@ def update_hypothesis_score(
     # Update metadata field (JSON column)
     if metadata_update:
         # Load existing JSON, update, then reassign to trigger ORM change detection
-        current_metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        current_metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
         current_metadata.update(metadata_update)
-        record.metadata = current_metadata 
+        record.metadata_json = current_metadata
 
     history_entry = {
         "t": datetime.utcnow().isoformat(), # Use ISO string for history entry
@@ -228,13 +228,13 @@ def attach_evidence_to_hypothesis(
             record.validation_log_ids.append(log_id)
 
     # Attach supporting_nodes information to metadata (JSON column, dict)
-    current_metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    current_metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
     if 'supporting_nodes_history' not in current_metadata:
         current_metadata['supporting_nodes_history'] = []
     # Append new nodes, ensuring uniqueness within the history
     current_nodes_in_history = set(current_metadata['supporting_nodes_history'])
     current_metadata['supporting_nodes_history'].extend([n for n in node_ids if n not in current_nodes_in_history])
-    record.metadata = current_metadata # Reassign to ensure ORM detects change
+    record.metadata_json = current_metadata # Reassign to ensure ORM detects change
 
     note_text = f"Evidence attached: Nodes {node_ids}, Logs {log_ids}."
     if summary_note:

--- a/tests/test_hypothesis_tracker.py
+++ b/tests/test_hypothesis_tracker.py
@@ -16,3 +16,17 @@ def test_register_hypothesis_generates_unique_id(test_db):
     hid2 = register_hypothesis("another hypothesis", test_db)
     assert hid != hid2
 
+
+def test_metadata_round_trip(test_db):
+    hid = register_hypothesis("meta hypothesis", test_db, {"foo": "bar"})
+
+    # load in a fresh session to ensure data persisted
+    from db_models import SessionLocal
+    new_db = SessionLocal()
+    try:
+        record = new_db.query(HypothesisRecord).filter_by(id=hid).first()
+        assert record is not None
+        assert record.metadata_json == {"foo": "bar"}
+    finally:
+        new_db.close()
+


### PR DESCRIPTION
## Summary
- add `metadata_json` column to `HypothesisRecord`
- use new column in `register_hypothesis`, `update_hypothesis_score`, and `attach_evidence_to_hypothesis`
- test metadata persistence across sessions

## Testing
- `pytest tests/test_hypothesis_tracker.py::test_metadata_round_trip -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688542a99eec83208732faa6789daf0b