### PR TITLE
Improve linting and optional imports

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -1,6 +1,4 @@
-"""
-audit_bridge.py - Symbolic Trace Logger & Hypothesis Reference Engine (superNova_2177 v3.6)
-"""
+"""Symbolic Trace Logger & Hypothesis Reference Engine (superNova_2177 v3.6)"""
 
 import json
 import uuid
@@ -30,8 +28,8 @@ def log_hypothesis_with_trace(
     metadata: Optional[Dict[str, Any]] = None
 ) -> str:
     """
-    Store a hypothesis log with its supporting causal node IDs and optional metadata.
-    Returns the key used in SystemState.
+    Store a hypothesis log with its supporting causal node IDs and optional
+    metadata. Returns the key used in SystemState.
     """
     payload = {
         "timestamp": datetime.utcnow().isoformat(),
@@ -53,7 +51,8 @@ def export_causal_path(
     depth: int = 3
 ) -> Dict[str, Any]:
     """
-    Export a simplified causal trace path in either upstream or downstream direction.
+    Export a simplified causal trace path in either upstream or downstream
+    direction.
     """
     if direction not in {"ancestors", "descendants"}:
         raise ValueError("direction must be 'ancestors' or 'descendants'")
@@ -64,7 +63,11 @@ def export_causal_path(
     )
     path_nodes = [entry["node_id"] for entry in trace]
     edge_list = [
-        (entry["edge"]["source"], entry["edge"]["target"], entry["edge"].get("edge_type", ""))
+        (
+            entry["edge"]["source"],
+            entry["edge"]["target"],
+            entry["edge"].get("edge_type", ""),
+        )
         for entry in trace
     ]
     highlights = []
@@ -89,7 +92,8 @@ def attach_trace_to_logentry(
     summary: Optional[str] = None
 ) -> None:
     """
-    Attach causal node references and optional commentary to an existing LogEntry.
+    Attach causal node references and optional commentary to an existing
+    LogEntry.
     """
     entry = db.query(LogEntry).filter(LogEntry.id == log_id).first()
     if not entry:
@@ -118,6 +122,8 @@ def generate_commentary_from_trace(trace: Dict[str, Any]) -> str:
 
     chain = " → ".join(trace["path_nodes"])
     highlights = trace.get("highlights", [])
-    highlight_text = f" Notable nodes: {', '.join(highlights)}." if highlights else ""
+    highlight_text = (
+        f" Notable nodes: {', '.join(highlights)}." if highlights else ""
+    )
 
     return f"This trace follows the causal chain: {chain}.{highlight_text}"

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -4028,8 +4028,12 @@ class TranscendentalCLI(cmd.Cmd):
 
 # --- MODULE: tests.py ---
 
-import pytest
-import httpx
+try:
+    import pytest  # type: ignore
+    import httpx  # type: ignore
+except ImportError:  # pragma: no cover - optional testing dependencies
+    pytest = None
+    httpx = None
 
 
 @pytest.fixture
@@ -4806,13 +4810,21 @@ if __name__ == "__main__":
     cosmic_nexus = CosmicNexus(SessionLocal, SystemStateService(SessionLocal()))
     agent = RemixAgent(cosmic_nexus=cosmic_nexus)
     if len(sys.argv) > 1 and sys.argv[1] == "test":
-        import pytest
+        try:
+            import pytest  # type: ignore
+        except ImportError:
+            print("pytest not installed.")
+            sys.exit(1)
 
         pytest.main(["-vv"])
     elif len(sys.argv) > 1 and sys.argv[1] == "cli":
         TranscendentalCLI(agent).cmdloop()
     else:
-        import uvicorn
+        try:
+            import uvicorn
+        except ImportError:
+            print("uvicorn not installed.")
+            sys.exit(1)
 
         run_validation_cycle()
         uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/validators/strategies/voting_consensus_engine.py
+++ b/validators/strategies/voting_consensus_engine.py
@@ -9,9 +9,9 @@ Used in superNova_2177 to formalize multi-validator decision making.
 """
 
 import logging
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional
 from collections import Counter, defaultdict
-from statistics import mean, median
+from statistics import mean
 from enum import Enum
 
 logger = logging.getLogger("superNova_2177.voting")
@@ -26,21 +26,21 @@ class VotingMethod(Enum):
 
 class Config:
    """Configuration for voting consensus engine."""
-   
+
    # Quorum requirements
    MIN_VALIDATORS_FOR_CONSENSUS = 3
    MIN_DIVERSITY_SCORE = 0.3
    MIN_TEMPORAL_TRUST = 0.5
-   
+
    # Consensus thresholds
    MAJORITY_THRESHOLD = 0.51
    SUPERMAJORITY_THRESHOLD = 0.67
    CONSENSUS_THRESHOLD = 0.80
-   
+
    # Reputation weighting
    MIN_REPUTATION_FOR_VOTE = 0.2
    MAX_REPUTATION_WEIGHT = 3.0
-   
+
    # Tie-breaking preferences
    DEFAULT_TIE_BREAK_METHOD = "median"
    ABSTENTION_PENALTY = 0.1
@@ -54,14 +54,14 @@ def aggregate_validator_votes(
 ) -> Dict[str, Any]:
    """
    Aggregate multiple validator votes into a consensus decision.
-   
+
    Args:
        votes: List of vote dicts with validator_id, score, confidence, decision
        method: Voting aggregation method to use
        reputations: Optional reputation scores per validator
        diversity_score: Optional overall diversity score for the validator pool
        temporal_trust: Optional temporal trust scores per validator
-       
+
    Returns:
        Dict containing:
        - consensus_decision: str or float
@@ -73,38 +73,40 @@ def aggregate_validator_votes(
    """
    if not votes:
        return _empty_consensus_result("no_votes")
-   
+
    # Validate inputs
    reputations = reputations or {}
    temporal_trust = temporal_trust or {}
    diversity_score = diversity_score or 0.0
-   
+
    # Filter valid votes
    valid_votes = []
    for vote in votes:
        validator_id = vote.get("validator_id")
        if not validator_id:
            continue
-           
+
        # Check minimum reputation threshold
        reputation = reputations.get(validator_id, 0.5)
        if reputation < Config.MIN_REPUTATION_FOR_VOTE:
            continue
-           
+
        valid_votes.append(vote)
-   
+
    if len(valid_votes) < Config.MIN_VALIDATORS_FOR_CONSENSUS:
        return _empty_consensus_result("insufficient_quorum")
-   
+
    # Check diversity and temporal requirements
    flags = []
    if diversity_score < Config.MIN_DIVERSITY_SCORE:
        flags.append("low_diversity_warning")
-   
-   avg_temporal_trust = mean(temporal_trust.get(v.get("validator_id"), 0.5) for v in valid_votes)
+
+    avg_temporal_trust = mean(
+        temporal_trust.get(v.get("validator_id"), 0.5) for v in valid_votes
+    )
    if avg_temporal_trust < Config.MIN_TEMPORAL_TRUST:
        flags.append("low_temporal_trust")
-   
+
    # Route to appropriate aggregation method
    if method == VotingMethod.WEIGHTED_AVERAGE:
        result = _weighted_average_consensus(valid_votes, reputations)
@@ -115,10 +117,14 @@ def aggregate_validator_votes(
    elif method == VotingMethod.CONSENSUS_THRESHOLD:
        result = _consensus_threshold_vote(valid_votes, reputations)
    elif method == VotingMethod.REPUTATION_WEIGHTED:
-       result = _reputation_weighted_consensus(valid_votes, reputations, temporal_trust)
+        result = _reputation_weighted_consensus(
+            valid_votes, reputations, temporal_trust
+        )
    else:
-       result = _reputation_weighted_consensus(valid_votes, reputations, temporal_trust)
-   
+        result = _reputation_weighted_consensus(
+            valid_votes, reputations, temporal_trust
+        )
+
    # Add metadata
    result.update({
        "voting_method": method.value,
@@ -128,75 +134,88 @@ def aggregate_validator_votes(
        "diversity_score": diversity_score,
        "flags": flags
    })
-   
-   logger.info(f"Consensus reached via {method.value}: {result['consensus_decision']} "
-              f"(confidence: {result['consensus_confidence']:.3f})")
-   
+
+    logger.info(
+        "Consensus via %s: %s (confidence: %.3f)",
+        method.value,
+        result["consensus_decision"],
+        result["consensus_confidence"],
+    )
+
    return result
 
 def _weighted_average_consensus(
-   votes: List[Dict[str, Any]], 
+   votes: List[Dict[str, Any]],
    reputations: Dict[str, float]
 ) -> Dict[str, Any]:
    """Simple weighted average of numerical scores."""
    weighted_sum = 0.0
    total_weight = 0.0
    confidences = []
-   
+
    for vote in votes:
        validator_id = vote.get("validator_id")
        score = float(vote.get("score", 0.5))
        confidence = float(vote.get("confidence", 0.5))
-       
+
        weight = reputations.get(validator_id, 0.5)
-       weight = min(weight * Config.MAX_REPUTATION_WEIGHT, Config.MAX_REPUTATION_WEIGHT)
-       
+        weight = min(
+            weight * Config.MAX_REPUTATION_WEIGHT,
+            Config.MAX_REPUTATION_WEIGHT,
+        )
+
        weighted_sum += score * weight
        total_weight += weight
        confidences.append(confidence * weight)
-   
+
    consensus_score = weighted_sum / total_weight if total_weight > 0 else 0.0
-   consensus_confidence = sum(confidences) / total_weight if total_weight > 0 else 0.0
-   
+    consensus_confidence = (
+        sum(confidences) / total_weight if total_weight > 0 else 0.0
+    )
+
    return {
        "consensus_decision": round(consensus_score, 3),
        "consensus_confidence": round(consensus_confidence, 3),
-       "vote_breakdown": {
-           "method": "weighted_average",
-           "total_weight": round(total_weight, 3),
-           "raw_average": round(mean([float(v.get("score", 0.5)) for v in votes]), 3)
-       }
+        "vote_breakdown": {
+            "method": "weighted_average",
+            "total_weight": round(total_weight, 3),
+            "raw_average": round(
+                mean([float(v.get("score", 0.5)) for v in votes]), 3
+            ),
+        }
    }
 
 def _majority_rule_consensus(
-   votes: List[Dict[str, Any]], 
+   votes: List[Dict[str, Any]],
    reputations: Dict[str, float]
 ) -> Dict[str, Any]:
    """Majority rule with reputation-weighted vote counting."""
    decisions = []
    total_weight = 0.0
-   
+
    for vote in votes:
        validator_id = vote.get("validator_id")
        decision = vote.get("decision", "abstain")
        weight = reputations.get(validator_id, 0.5)
-       
+
        decisions.extend([decision] * int(weight * 10))  # Weight by reputation
        total_weight += weight
-   
+
    if not decisions:
        return _empty_consensus_result("no_valid_decisions")
-   
+
    decision_counts = Counter(decisions)
    winning_decision = decision_counts.most_common(1)[0][0]
    winning_count = decision_counts[winning_decision]
-   
+
    confidence = winning_count / len(decisions)
    meets_majority = confidence >= Config.MAJORITY_THRESHOLD
-   
-   return {
-       "consensus_decision": winning_decision if meets_majority else "no_consensus",
-       "consensus_confidence": round(confidence, 3),
+
+    return {
+        "consensus_decision": (
+            winning_decision if meets_majority else "no_consensus"
+        ),
+        "consensus_confidence": round(confidence, 3),
        "vote_breakdown": {
            "method": "majority_rule",
            "decision_counts": dict(decision_counts),
@@ -206,51 +225,62 @@ def _majority_rule_consensus(
    }
 
 def _supermajority_consensus(
-   votes: List[Dict[str, Any]], 
+   votes: List[Dict[str, Any]],
    reputations: Dict[str, float]
 ) -> Dict[str, Any]:
    """Supermajority rule (2/3+) with reputation weighting."""
    result = _majority_rule_consensus(votes, reputations)
-   
+
    confidence = result["consensus_confidence"]
    meets_supermajority = confidence >= Config.SUPERMAJORITY_THRESHOLD
-   
-   result.update({
-       "consensus_decision": result["consensus_decision"] if meets_supermajority else "no_consensus",
-       "vote_breakdown": {
+
+    result.update(
+        {
+            "consensus_decision": (
+                result["consensus_decision"]
+                if meets_supermajority
+                else "no_consensus"
+            ),
+            "vote_breakdown": {
            **result["vote_breakdown"],
            "method": "supermajority",
            "supermajority_threshold": Config.SUPERMAJORITY_THRESHOLD,
            "meets_threshold": meets_supermajority
        }
    })
-   
+
    return result
 
 def _consensus_threshold_vote(
-   votes: List[Dict[str, Any]], 
+   votes: List[Dict[str, Any]],
    reputations: Dict[str, float]
 ) -> Dict[str, Any]:
    """High consensus threshold (80%+) for critical decisions."""
    result = _majority_rule_consensus(votes, reputations)
-   
+
    confidence = result["consensus_confidence"]
    meets_consensus = confidence >= Config.CONSENSUS_THRESHOLD
-   
-   result.update({
-       "consensus_decision": result["consensus_decision"] if meets_consensus else "no_consensus",
-       "vote_breakdown": {
-           **result["vote_breakdown"],
-           "method": "consensus_threshold",
-           "consensus_threshold": Config.CONSENSUS_THRESHOLD,
-           "meets_threshold": meets_consensus
-       }
-   })
-   
+
+    result.update(
+        {
+            "consensus_decision": (
+                result["consensus_decision"]
+                if meets_consensus
+                else "no_consensus"
+            ),
+            "vote_breakdown": {
+                **result["vote_breakdown"],
+                "method": "consensus_threshold",
+                "consensus_threshold": Config.CONSENSUS_THRESHOLD,
+                "meets_threshold": meets_consensus
+            },
+        }
+    )
+
    return result
 
 def _reputation_weighted_consensus(
-   votes: List[Dict[str, Any]], 
+   votes: List[Dict[str, Any]],
    reputations: Dict[str, float],
    temporal_trust: Dict[str, float]
 ) -> Dict[str, Any]:
@@ -258,42 +288,48 @@ def _reputation_weighted_consensus(
    weighted_scores = []
    total_weight = 0.0
    decision_weights = defaultdict(float)
-   
+
    for vote in votes:
        validator_id = vote.get("validator_id")
        score = float(vote.get("score", 0.5))
        decision = vote.get("decision", "abstain")
        confidence = float(vote.get("confidence", 0.5))
-       
+
        # Combine reputation and temporal trust
        reputation = reputations.get(validator_id, 0.5)
        temporal = temporal_trust.get(validator_id, 0.5)
        combined_weight = (reputation * 0.7 + temporal * 0.3) * confidence
-       
+
        weighted_scores.append(score * combined_weight)
        decision_weights[decision] += combined_weight
        total_weight += combined_weight
-   
+
    # Calculate consensus score
-   consensus_score = sum(weighted_scores) / total_weight if total_weight > 0 else 0.0
-   
+    consensus_score = (
+        sum(weighted_scores) / total_weight if total_weight > 0 else 0.0
+    )
+
    # Find consensus decision
    if decision_weights:
        consensus_decision = max(decision_weights, key=decision_weights.get)
-       decision_confidence = decision_weights[consensus_decision] / total_weight
+        decision_confidence = (
+            decision_weights[consensus_decision] / total_weight
+        )
    else:
        consensus_decision = "no_decision"
        decision_confidence = 0.0
-   
+
    return {
        "consensus_decision": round(consensus_score, 3),
        "consensus_confidence": round(decision_confidence, 3),
-       "vote_breakdown": {
-           "method": "reputation_weighted",
-           "total_weight": round(total_weight, 3),
-           "decision_weights": {k: round(v, 3) for k, v in decision_weights.items()},
-           "top_decision": consensus_decision
-       }
+        "vote_breakdown": {
+            "method": "reputation_weighted",
+            "total_weight": round(total_weight, 3),
+            "decision_weights": {
+                k: round(v, 3) for k, v in decision_weights.items()
+            },
+            "top_decision": consensus_decision,
+        }
    }
 
 def _empty_consensus_result(reason: str) -> Dict[str, Any]:
@@ -313,40 +349,48 @@ def validate_voting_integrity(
 ) -> Dict[str, Any]:
    """
    Check for voting manipulation, coordination, or suspicious patterns.
-   
+
    Returns:
        Dict with integrity flags and recommendations
    """
    flags = []
-   
+
    # Check for duplicate validators
-   validator_ids = [v.get("validator_id") for v in votes if v.get("validator_id")]
+    validator_ids = [
+        v.get("validator_id") for v in votes if v.get("validator_id")
+    ]
    if len(validator_ids) != len(set(validator_ids)):
        flags.append("duplicate_validators")
-   
+
    # Check for suspicious score clustering
    scores = [float(v.get("score", 0.5)) for v in votes]
    if len(scores) > 2:
        score_range = max(scores) - min(scores)
        if score_range < 0.1:  # Very tight clustering
            flags.append("suspicious_score_clustering")
-   
+
    # Check reputation distribution
-   validator_reputations = [reputations.get(v.get("validator_id"), 0.5) for v in votes]
+    validator_reputations = [
+        reputations.get(v.get("validator_id"), 0.5) for v in votes
+    ]
    high_rep_count = sum(1 for r in validator_reputations if r > 0.8)
    if high_rep_count / len(validator_reputations) > 0.8:
        flags.append("high_reputation_concentration")
-   
+
    return {
        "integrity_flags": flags,
        "vote_count": len(votes),
        "unique_validators": len(set(validator_ids)),
-       "avg_reputation": round(mean(validator_reputations), 3) if validator_reputations else 0.0
+        "avg_reputation": (
+            round(mean(validator_reputations), 3)
+            if validator_reputations
+            else 0.0
+        )
    }
 
 # TODO v4.6:
 # - Add ranked choice voting support
-# - Implement quadratic voting mechanisms  
+# - Implement quadratic voting mechanisms
 # - Add delegation/proxy voting
 # - Include time-decay for stale votes
 # - Add cross-validation consensus tracking


### PR DESCRIPTION
## Summary
- shorten long lines and improve readability in `audit_bridge.py`
- tidy imports, remove unused values, and wrap logger output in `voting_consensus_engine.py`
- guard optional test/runtime imports in `superNova_2177.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_688550841f448320b4bf6ab622c56d52