### PR TITLE
Fix Lorenz integration deprecation

### DIFF
--- a/immutable_tri_species_adjust.py
+++ b/immutable_tri_species_adjust.py
@@ -44,7 +44,7 @@ class ImmutableTriSpeciesAgent(RemixAgent):
         curve = np.insert(cum_values, 0, 0)
         pop = np.insert(cum_population, 0, 0)
         # Gini = 1 - 2 * area under curve
-        gini = Decimal(1 - 2 * np.trapz(curve, pop))
+        gini = Decimal(1 - 2 * np.trapezoid(curve, pop))
         return gini
 
     def _get_dynamic_threshold(self, total_voters: int, is_constitutional: bool, avg_yes: Decimal) -> Decimal:


### PR DESCRIPTION
## Summary
- use `np.trapezoid` instead of `np.trapz` when integrating Lorenz curve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855722305083209ede6335426c7906