### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=change-me
+DATABASE_URL=postgresql+asyncpg://user:password@localhost/transcendental_resonance
+BACKEND_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ strong random value is recommended:
 export SECRET_KEY="your-random-secret"
 ```
 
+Copy `.env.example` to `.env` and set values for `SECRET_KEY`, `DATABASE_URL`,
+and `BACKEND_URL` before running the app.
+
 ## 🧪 Running Tests
 
 After installing the dependencies, run:


### PR DESCRIPTION
## Summary
- add a `.env.example` with common environment variables
- document the `.env.example` in the README configuration section

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885585e96908320a191d654353bb20b