### PR TITLE
Add annual audit background task

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ if "superNova_2177" not in sys.modules:
         PROACTIVE_INTERVENTION_INTERVAL_SECONDS = 3600
         AI_PERSONA_EVOLUTION_INTERVAL_SECONDS = 86400
         GUINNESS_PURSUIT_INTERVAL_SECONDS = 86400 * 3
+        ANNUAL_AUDIT_INTERVAL_SECONDS = 86400 * 365
         METRICS_PORT = 8001
         INFLUENCE_THRESHOLD_FOR_AURA_GAIN = 0.1
         PASSIVE_AURA_GAIN_MULTIPLIER = Decimal("10.0")
@@ -153,6 +154,12 @@ for mod_name in [
             stub.Session = Session
             stub.sessionmaker = lambda *a, **kw: None
             stub.relationship = lambda *a, **kw: None
+            class DeclarativeBase:
+                metadata = types.SimpleNamespace(
+                    create_all=lambda *a, **kw: None,
+                    drop_all=lambda *a, **kw: None,
+                )
+            stub.DeclarativeBase = DeclarativeBase
             def _base():
                 class B:
                     metadata = types.SimpleNamespace()
@@ -196,6 +203,7 @@ for mod_name in [
             stub.BaseModel = BaseModel
             stub.Field = lambda *a, **kw: None
             stub.EmailStr = str
+            stub.ValidationError = type("ValidationError", (), {})
         if mod_name == "pydantic_settings":
             class BaseSettings:
                 pass

--- a/tests/test_annual_audit_task.py
+++ b/tests/test_annual_audit_task.py
@@ -1,0 +1,44 @@
+import asyncio
+import ast
+from pathlib import Path
+import types
+import pytest
+
+# Dynamically load the annual_audit_task definition without importing heavy deps
+src = Path(__file__).resolve().parents[1] / "superNova_2177.py"
+text = src.read_text()
+tree = ast.parse(text)
+func_code = None
+for node in tree.body:
+    if isinstance(node, ast.AsyncFunctionDef) and node.name == "annual_audit_task":
+        func_code = ast.get_source_segment(text, node)
+        break
+namespace = {}
+globals()['CosmicNexus'] = object
+globals()['logger'] = types.SimpleNamespace(info=lambda *a, **k: None)
+exec(func_code, globals(), namespace)
+annual_audit_task = namespace["annual_audit_task"]
+
+class DummyConfig:
+    ANNUAL_AUDIT_INTERVAL_SECONDS = 0.01
+
+class DummyNexus:
+    def __init__(self):
+        self.calls = 0
+    def quantum_audit(self):
+        self.calls += 1
+
+def test_annual_audit_task_triggers_quantum_audit():
+    globals()["Config"] = DummyConfig
+    nexus = DummyNexus()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    task = loop.create_task(annual_audit_task(nexus))
+    loop.run_until_complete(asyncio.sleep(0.02))
+    task.cancel()
+    try:
+        loop.run_until_complete(task)
+    except asyncio.CancelledError:
+        pass
+    assert nexus.calls >= 1
+    loop.close()


### PR DESCRIPTION
## Summary
- add `ANNUAL_AUDIT_INTERVAL_SECONDS` config
- implement `CosmicNexus.quantum_audit` and async `annual_audit_task`
- schedule the new task on startup
- extend Config stub and add unit test for the audit task

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688556fb87088320bba5488cd1dfea42