### PR TITLE
Add RFC 003 coordination feedback validator

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -17,6 +17,7 @@ new RFC:
 | Number | Title |
 |-------|-------|
 | [002](validators/002-example-validator/README.md) | Daily Participation Validator |
+| [003](validators/003-coordination-feedback/README.md) | Coordination Feedback Validator |
 
 ### Governance
 

--- a/rfcs/validators/003-coordination-feedback/README.md
+++ b/rfcs/validators/003-coordination-feedback/README.md
@@ -1,0 +1,30 @@
+# Coordination Feedback Validator
+
+<!-- Example path: rfcs/validators/003-coordination-feedback/README.md -->
+
+## Summary
+This RFC proposes a validator that feeds network coordination outcomes back into the reputation scoring system. By analyzing how participants align on shared tasks, the validator rewards collaborative success and flags disruptive behavior.
+
+## Motivation
+Network reputation currently focuses on individual actions. Integrating coordination results highlights teamwork and encourages constructive group dynamics.
+
+## Specification
+- Monitor metrics such as task completion rates, conflict resolution times, and consensus-building events.
+- Compare expected versus actual coordination outcomes for groups of participants.
+- Increase reputation for members who measurably improve coordination efficiency.
+- Apply small penalties when behavior repeatedly disrupts group alignment.
+- Store coordination feedback in a ledger tied to each participant.
+
+## Rationale
+Collaboration is essential to the project. Without feedback from coordination results, reputation may overvalue solo contributions and undervalue cooperation.
+
+## Drawbacks
+- Requires accurate tracking of coordination events and participant involvement.
+- Adds complexity to the reputation calculation.
+
+## Adoption Strategy
+Begin with low weighting for coordination metrics while validating data collection. Gradually increase influence as the model proves reliable.
+
+## Unresolved Questions
+- Which coordination metrics should carry the most weight?
+- How do we prevent unfair penalties for healthy disagreement?


### PR DESCRIPTION
## Summary
- document a new validator that rewards collaboration by feeding network coordination metrics back into reputation
- index RFC 003 in the validators table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68855e7f20dc8320bf073168c531ca4b