### PR TITLE
Implement daily participation validator

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -16,7 +16,7 @@ new RFC:
 
 | Number | Title |
 |-------|-------|
-| [002](validators/002-example-validator/README.md) | Daily Participation Validator |
+| [002](validators/002-example-validator/README.md) | Daily Participation Validator ✅ |
 
 ### Governance
 

--- a/tests/test_daily_participation_validator.py
+++ b/tests/test_daily_participation_validator.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+from validators.daily_participation_validator import detect_inactive_users
+
+
+def test_detect_inactive_users_flags_inactivity():
+    now = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    logs = [
+        {"user_id": "active", "timestamp": "2024-01-09T23:59:00Z"},
+        {"user_id": "inactive", "timestamp": "2023-12-15T00:00:00Z"},
+    ]
+    result = detect_inactive_users(logs, threshold_days=20, current_time=now)
+    assert result == ["inactive"]
+
+
+def test_detect_inactive_users_respects_threshold():
+    now = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    logs = [{"user_id": "u1", "timestamp": "2024-01-08T12:00:00Z"}]
+
+    flagged = detect_inactive_users(logs, threshold_days=0, current_time=now)
+    assert flagged == ["u1"]
+
+    flagged = detect_inactive_users(logs, threshold_days=2, current_time=now)
+    assert flagged == []
+
+
+def test_detect_inactive_users_ignores_bad_logs():
+    now = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    logs = [
+        {"user_id": "a", "timestamp": "not-a-date"},
+        {"user_id": "a", "timestamp": "2024-01-01T00:00:00Z"},
+    ]
+    result = detect_inactive_users(logs, threshold_days=5, current_time=now)
+    assert result == ["a"]

--- a/validators/daily_participation_validator.py
+++ b/validators/daily_participation_validator.py
@@ -1,0 +1,68 @@
+"""Daily Participation Validator — detect prolonged user inactivity.
+
+Implements the rule described in RFC 002. The validator checks user
+activity logs and returns identifiers for participants who have not
+been active for more than a configurable number of days.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("superNova_2177.participation")
+
+
+class Config:
+    """Configuration constants."""
+
+    DEFAULT_THRESHOLD_DAYS = 7
+
+
+def detect_inactive_users(
+    activity_logs: List[Dict[str, Any]],
+    *,
+    threshold_days: int | None = None,
+    current_time: Optional[datetime] = None,
+) -> List[str]:
+    """Return user IDs with no activity for more than ``threshold_days``.
+
+    Parameters
+    ----------
+    activity_logs:
+        Sequence of log dictionaries containing ``user_id`` and
+        ``timestamp`` fields in ISO format.
+    threshold_days:
+        Days of inactivity required to flag a user. If omitted, the
+        value from :class:`Config` is used.
+    current_time:
+        Reference ``datetime`` for computing inactivity. Defaults to
+        ``datetime.utcnow``.
+    """
+
+    threshold_days = (
+        threshold_days if threshold_days is not None else Config.DEFAULT_THRESHOLD_DAYS
+    )
+    now = current_time or datetime.utcnow()
+
+    last_seen: Dict[str, datetime] = {}
+    for entry in activity_logs:
+        user = entry.get("user_id")
+        ts_raw = entry.get("timestamp")
+        if not user or not ts_raw:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except Exception:  # pragma: no cover - ignore malformed timestamps
+            logger.debug("Invalid timestamp %s for user %s", ts_raw, user)
+            continue
+        if user not in last_seen or ts > last_seen[user]:
+            last_seen[user] = ts
+
+    inactive = []
+    for user, ts in last_seen.items():
+        if (now - ts).days > threshold_days:
+            inactive.append(user)
+
+    return sorted(inactive)


### PR DESCRIPTION
## Summary
- add RFC 002 daily participation validator module
- test inactivity detection logic
- mark RFC as implemented

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855e3ec31083208423487868754995