### PR TITLE
Integrate sentence embeddings for coordination checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Flags: ['limited_consensus', 'low_diversity']
 * `reputation_influence_tracker.py` — Tracks and scores validators over time
 * `diversity_analyzer.py` — Detects echo chambers and affiliation bias
 * `temporal_consistency_checker.py` — Tracks time-based volatility
-* `network_coordination_detector.py` — Spots suspicious group behavior
+* `network_coordination_detector.py` — Spots suspicious group behavior using
+  sentence‑embedding similarity
 
 ## 🧪 Status
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ types-python-dateutil
 types-requests
 types-networkx
 numpy
+sentence-transformers

--- a/tests/test_network_coordination_detector.py
+++ b/tests/test_network_coordination_detector.py
@@ -2,6 +2,7 @@ import pytest
 from network.network_coordination_detector import (
     calculate_sophisticated_risk_score,
     analyze_coordination_patterns,
+    detect_semantic_coordination,
 )
 
 
@@ -71,4 +72,27 @@ def test_analyze_coordination_patterns_detects_clusters():
 
     # Overall risk score is rounded to three decimals
     assert result["overall_risk_score"] == pytest.approx(0.32, abs=0.01)
+
+
+def test_detect_semantic_coordination_embeddings():
+    validations = [
+        {
+            "validator_id": "v1",
+            "hypothesis_id": "h1",
+            "score": 0.8,
+            "timestamp": "2025-01-01T00:00:00Z",
+            "note": "the quick brown fox jumps over the lazy dog",
+        },
+        {
+            "validator_id": "v2",
+            "hypothesis_id": "h2",
+            "score": 0.8,
+            "timestamp": "2025-01-01T00:01:00Z",
+            "note": "the quick brown fox leaps over the lazy dog",
+        },
+    ]
+
+    result = detect_semantic_coordination(validations)
+    assert result["semantic_clusters"]
+    assert result["semantic_clusters"][0]["similarity_score"] >= 0.8
 


### PR DESCRIPTION
## Summary
- add lightweight `sentence-transformers` dependency
- replace phrase-based semantic coordination with sentence embeddings
- document new approach in README
- expand tests for embedding similarity

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855e50716c8320aa83a7db4b92ba53