### PR TITLE
Add daily participation validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ Flags: ['limited_consensus', 'low_diversity']
 - Check timestamp clustering for coordination risks
 ```
 
+## 🗓️ Daily Participation Validator
+
+Use `evaluate_daily_participation` to detect users who have not interacted for
+a configurable number of days. Provide a list of activity records with
+`user_id` and `timestamp` strings:
+
+```python
+from validators.daily_participation_validator import evaluate_daily_participation
+
+result = evaluate_daily_participation(activity_log, inactivity_days=3)
+```
+
+`result["inactive_users"]` will contain any user IDs that have been inactive
+beyond the threshold.
+
 ## 🏗️ Architecture (v4.6)
 
 * `validation_integrity_pipeline.py` — Orchestrator for full validation logic
@@ -126,6 +141,7 @@ Flags: ['limited_consensus', 'low_diversity']
 * `diversity_analyzer.py` — Detects echo chambers and affiliation bias
 * `temporal_consistency_checker.py` — Tracks time-based volatility
 * `network_coordination_detector.py` — Spots suspicious group behavior
+* `daily_participation_validator.py` — Alerts on prolonged user inactivity
 
 ## 🧪 Status
 

--- a/tests/test_daily_participation_validator.py
+++ b/tests/test_daily_participation_validator.py
@@ -1,0 +1,25 @@
+import datetime
+from validators.daily_participation_validator import evaluate_daily_participation
+
+
+def test_inactive_users_flagged():
+    now = datetime.datetime(2025, 1, 5, 12, 0, 0)
+    logs = [
+        {"user_id": "u1", "timestamp": (now - datetime.timedelta(days=1)).isoformat()},
+        {"user_id": "u2", "timestamp": (now - datetime.timedelta(days=4)).isoformat()},
+    ]
+
+    result = evaluate_daily_participation(logs, inactivity_days=2, current_time=now)
+    assert "u2" in result["inactive_users"]
+    assert "u1" not in result["inactive_users"]
+
+
+def test_no_inactive_users():
+    now = datetime.datetime(2025, 1, 5, 12, 0, 0)
+    logs = [
+        {"user_id": "u1", "timestamp": (now - datetime.timedelta(days=0)).isoformat()},
+        {"user_id": "u2", "timestamp": (now - datetime.timedelta(days=1)).isoformat()},
+    ]
+
+    result = evaluate_daily_participation(logs, inactivity_days=2, current_time=now)
+    assert result["inactive_users"] == []

--- a/validators/daily_participation_validator.py
+++ b/validators/daily_participation_validator.py
@@ -1,0 +1,74 @@
+"""Daily Participation Validator (RFC 002).
+
+Checks that each user performs at least one action per calendar day and
+flags users who have been inactive for longer than a configurable
+threshold.
+"""
+
+import logging
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger("superNova_2177.daily")
+
+
+class Config:
+    """Default configuration values."""
+
+    # Number of days a user can be inactive before triggering an alert
+    INACTIVITY_THRESHOLD_DAYS = 3
+
+
+def evaluate_daily_participation(
+    activity_log: List[Dict[str, Any]],
+    inactivity_days: Optional[int] = None,
+    *,
+    current_time: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Analyze user activity and return users inactive past the threshold.
+
+    Args:
+        activity_log: Sequence of records with ``user_id`` and ``timestamp``.
+        inactivity_days: Days of allowed inactivity before a user is flagged.
+        current_time: Evaluation timestamp (defaults to ``datetime.utcnow()``).
+
+    Returns:
+        Dictionary with ``inactive_users`` and ``total_users`` counts.
+    """
+
+    if not activity_log:
+        return {"inactive_users": [], "total_users": 0, "flags": ["no_activity_records"]}
+
+    threshold = inactivity_days or Config.INACTIVITY_THRESHOLD_DAYS
+    now = current_time or datetime.utcnow()
+
+    last_seen: Dict[str, datetime] = {}
+    for record in activity_log:
+        user_id = record.get("user_id")
+        ts_raw = record.get("timestamp")
+        if not user_id or not ts_raw:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except Exception as e:  # pragma: no cover - log malformed timestamps
+            logger.warning(f"Invalid timestamp for user {user_id}: {ts_raw} - {e}")
+            continue
+        prev = last_seen.get(user_id)
+        if not prev or ts > prev:
+            last_seen[user_id] = ts
+
+    inactive_users = [
+        uid
+        for uid, ts in last_seen.items()
+        if (now.date() - ts.date()).days > threshold
+    ]
+
+    logger.info(
+        "Daily participation check: %d/%d inactive users", len(inactive_users), len(last_seen)
+    )
+
+    return {
+        "inactive_users": inactive_users,
+        "total_users": len(last_seen),
+        "flags": ["inactive_users"] if inactive_users else [],
+    }


### PR DESCRIPTION
## Summary
- implement new `daily_participation_validator` to flag inactive users
- test inactivity detection logic
- document validator usage in README

## Testing
- `pytest tests/test_daily_participation_validator.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855e71867083209f739985f9db4979