### PR TITLE
Add RFC for cross-universe bridge validator

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -17,6 +17,7 @@ new RFC:
 | Number | Title |
 |-------|-------|
 | [002](validators/002-example-validator/README.md) | Daily Participation Validator ✅ |
+| [003](validators/003-cross-universe-bridge/README.md) | Cross-Universe Bridge Validator |
 
 ### Governance
 

--- a/rfcs/validators/003-cross-universe-bridge/README.md
+++ b/rfcs/validators/003-cross-universe-bridge/README.md
@@ -1,0 +1,28 @@
+# Cross-Universe Bridge Validator
+
+<!-- Example path: rfcs/validators/003-cross-universe-bridge/README.md -->
+
+## Summary
+This proposal introduces a validator that verifies remix provenance when content travels between distinct universes. The rule ensures each remix retains a traceable history of its origins even after crossing universe boundaries.
+
+## Motivation
+Creators frequently adapt works that originated in parallel universes. Without clear provenance, it becomes difficult to credit original authors or audit the lineage of ideas. By tracking cross-universe remixes, the community can maintain transparency and properly attribute contributions.
+
+## Specification
+- Each remix must include metadata referencing the universe and unique identifier of the source material.
+- The validator checks hashes or signed proofs embedded in the remix to confirm authenticity.
+- Any missing or mismatched provenance data results in a flagged violation, optionally preventing the remix from being certified until corrected.
+
+## Rationale
+Maintaining an unbroken provenance chain encourages collaboration across universes while respecting the rights of original creators. It also allows auditors to reconstruct the flow of ideas and measure influence between universes.
+
+## Drawbacks
+- Storing additional provenance metadata increases record size and may expose cross-universe relationships that some users wish to keep private.
+- Synchronizing identifiers between different universes can be complex if naming schemes diverge.
+
+## Adoption Strategy
+Begin with a voluntary mode that simply records and reports missing provenance. Once stabilized, enforcement can prevent uncertified remixes from propagating across bridges without proper metadata.
+
+## Unresolved Questions
+- What format should be used for cross-universe identifiers and signatures?
+- How can the validator interoperate with universes that do not expose full provenance information?


### PR DESCRIPTION
## Summary
- draft RFC for a validator that ensures remix provenance across universes
- index new validator in the RFC overview

## Testing
- `pytest -q` *(fails: TypeError 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_688563103f08832084c89a4c1a5813bb