### PR TITLE
Fix invalid escape sequence warnings in docstrings

### DIFF
--- a/causal_graph.py
+++ b/causal_graph.py
@@ -189,7 +189,7 @@ class CausalGraph:
         return node in self.graph
 
     def get_edge_data(self, u: Any, v: Any, default=None):
-        """Return attribute dictionary for the edge ``u``\->``v``.
+        """Return attribute dictionary for the edge ``u``->``v``.
 
         Parameters
         ----------

--- a/quantum_sim.py
+++ b/quantum_sim.py
@@ -102,7 +102,7 @@ class QuantumContext:
     def measure_superposition(
         self, input_value: float, *, error_rate: float = 0.0
     ) -> Dict[str, Optional[float]]:
-        """Simulate measurement of a superposition for a decision.
+        r"""Simulate measurement of a superposition for a decision.
 
         Scientific Basis
         ----------------
@@ -412,7 +412,7 @@ quantum_prediction_engine = QuantumContext.quantum_prediction_engine
 def approximate_trace_distance(
     state1: list[float], state2: list[float]
 ) -> Dict[str, Optional[float]]:
-    """Approximate trace distance between two quantum states.
+    r"""Approximate trace distance between two quantum states.
 
     Scientific Basis
     ----------------
@@ -456,7 +456,7 @@ def approximate_trace_distance(
 def pseudo_fidelity_score(
     initial: list[float], final: list[float]
 ) -> Dict[str, Optional[float]]:
-    """Pseudo fidelity between initial and final states using cosine similarity.
+    r"""Pseudo fidelity between initial and final states using cosine similarity.
 
     Scientific Basis
     ----------------


### PR DESCRIPTION
## Summary
- avoid warnings from invalid escape sequences in `quantum_sim.py`
- correct docstring arrow in `causal_graph.py`

## Testing
- `python -m py_compile quantum_sim.py causal_graph.py`
- `pytest -q` *(fails: TypeError in tests during setup)*

------
https://chatgpt.com/codex/tasks/task_e_6885653682d48320b10ed32e44d17c64