### PR TITLE
Add search and sort inputs

### DIFF
--- a/transcendental-resonance-frontend/src/pages/events_page.py
+++ b/transcendental-resonance-frontend/src/pages/events_page.py
@@ -22,6 +22,9 @@ async def events_page():
             f'color: {THEME["accent"]};'
         )
 
+        search_query = ui.input('Search').classes('w-full mb-2')
+        sort_select = ui.select(['name', 'date'], value='name').classes('w-full mb-4')
+
         e_name = ui.input('Event Name').classes('w-full mb-2')
         e_desc = ui.textarea('Description').classes('w-full mb-2')
         e_start = ui.input('Start Time (YYYY-MM-DDTHH:MM)').classes('w-full mb-2')
@@ -46,7 +49,19 @@ async def events_page():
         events_list = ui.column().classes('w-full')
 
         async def refresh_events():
-            events = api_call('GET', '/events/') or []
+            params = {}
+            if search_query.value:
+                params['search'] = search_query.value
+            if sort_select.value:
+                params['sort'] = sort_select.value
+            events = api_call('GET', '/events/', params) or []
+            if search_query.value:
+                events = [e for e in events if search_query.value.lower() in e['name'].lower()]
+            if sort_select.value:
+                if sort_select.value == 'name':
+                    events.sort(key=lambda x: x.get('name', ''))
+                elif sort_select.value == 'date':
+                    events.sort(key=lambda x: x.get('start_time', ''))
             events_list.clear()
             for e in events:
                 with events_list:

--- a/transcendental-resonance-frontend/src/pages/groups_page.py
+++ b/transcendental-resonance-frontend/src/pages/groups_page.py
@@ -22,6 +22,9 @@ async def groups_page():
             f'color: {THEME["accent"]};'
         )
 
+        search_query = ui.input('Search').classes('w-full mb-2')
+        sort_select = ui.select(['name', 'date'], value='name').classes('w-full mb-4')
+
         g_name = ui.input('Group Name').classes('w-full mb-2')
         g_desc = ui.textarea('Description').classes('w-full mb-2')
 
@@ -39,7 +42,19 @@ async def groups_page():
         groups_list = ui.column().classes('w-full')
 
         async def refresh_groups():
-            groups = api_call('GET', '/groups/') or []
+            params = {}
+            if search_query.value:
+                params['search'] = search_query.value
+            if sort_select.value:
+                params['sort'] = sort_select.value
+            groups = api_call('GET', '/groups/', params) or []
+            if search_query.value:
+                groups = [g for g in groups if search_query.value.lower() in g['name'].lower()]
+            if sort_select.value:
+                if sort_select.value == 'name':
+                    groups.sort(key=lambda x: x.get('name', ''))
+                elif sort_select.value == 'date':
+                    groups.sort(key=lambda x: x.get('created_at', ''))
             groups_list.clear()
             for g in groups:
                 with groups_list:

--- a/transcendental-resonance-frontend/src/pages/vibenodes_page.py
+++ b/transcendental-resonance-frontend/src/pages/vibenodes_page.py
@@ -22,6 +22,9 @@ async def vibenodes_page():
             f'color: {THEME["accent"]};'
         )
 
+        search_query = ui.input('Search').classes('w-full mb-2')
+        sort_select = ui.select(['name', 'date'], value='name').classes('w-full mb-4')
+
         name = ui.input('Name').classes('w-full mb-2')
         description = ui.textarea('Description').classes('w-full mb-2')
         media_type = ui.select(
@@ -51,7 +54,19 @@ async def vibenodes_page():
         vibenodes_list = ui.column().classes('w-full')
 
         async def refresh_vibenodes():
-            vibenodes = api_call('GET', '/vibenodes/') or []
+            params = {}
+            if search_query.value:
+                params['search'] = search_query.value
+            if sort_select.value:
+                params['sort'] = sort_select.value
+            vibenodes = api_call('GET', '/vibenodes/', params) or []
+            if search_query.value:
+                vibenodes = [vn for vn in vibenodes if search_query.value.lower() in vn['name'].lower()]
+            if sort_select.value:
+                if sort_select.value == 'name':
+                    vibenodes.sort(key=lambda x: x.get('name', ''))
+                elif sort_select.value == 'date':
+                    vibenodes.sort(key=lambda x: x.get('created_at', ''))
             vibenodes_list.clear()
             for vn in vibenodes:
                 with vibenodes_list:

--- a/transcendental-resonance-frontend/tests/test_events_page.py
+++ b/transcendental-resonance-frontend/tests/test_events_page.py
@@ -3,3 +3,8 @@ from pages.events_page import events_page
 
 def test_events_page_is_async():
     assert inspect.iscoroutinefunction(events_page)
+
+def test_events_page_has_search_widgets():
+    src = inspect.getsource(events_page)
+    assert "ui.input('Search'" in src
+    assert "ui.select(['name', 'date']" in src

--- a/transcendental-resonance-frontend/tests/test_groups_page.py
+++ b/transcendental-resonance-frontend/tests/test_groups_page.py
@@ -3,3 +3,8 @@ from pages.groups_page import groups_page
 
 def test_groups_page_is_async():
     assert inspect.iscoroutinefunction(groups_page)
+
+def test_groups_page_has_search_widgets():
+    src = inspect.getsource(groups_page)
+    assert "ui.input('Search'" in src
+    assert "ui.select(['name', 'date']" in src

--- a/transcendental-resonance-frontend/tests/test_vibenodes_page.py
+++ b/transcendental-resonance-frontend/tests/test_vibenodes_page.py
@@ -3,3 +3,8 @@ from pages.vibenodes_page import vibenodes_page
 
 def test_vibenodes_page_is_async():
     assert inspect.iscoroutinefunction(vibenodes_page)
+
+def test_vibenodes_page_has_search_widgets():
+    src = inspect.getsource(vibenodes_page)
+    assert "ui.input('Search'" in src
+    assert "ui.select(['name', 'date']" in src


### PR DESCRIPTION
## Summary
- add search query inputs and sort selectors to Events, Groups and VibeNodes pages
- filter and sort fetched lists with query parameters
- verify presence of these widgets in tests

## Testing
- `pytest -q transcendental-resonance-frontend/tests/test_events_page.py transcendental-resonance-frontend/tests/test_groups_page.py transcendental-resonance-frontend/tests/test_vibenodes_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6885681062308320ad9709f1c586663d