### PR TITLE
Allow accent customization

### DIFF
--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -3,7 +3,13 @@
 from nicegui import ui
 
 from utils.api import api_call, TOKEN, clear_token
-from utils.styles import get_theme
+from utils.styles import (
+    get_theme,
+    set_theme,
+    set_accent,
+    get_theme_name,
+    THEMES,
+)
 from .login_page import login_page
 from .vibenodes_page import vibenodes_page
 from .groups_page import groups_page
@@ -71,3 +77,15 @@ async def profile_page():
             'Logout',
             on_click=lambda: (clear_token(), ui.open(login_page)),
         ).classes('w-full').style(f'background: red; color: {THEME["text"]};')
+
+        with ui.row().classes('w-full mt-4'):
+            theme_select = ui.select(
+                list(THEMES.keys()),
+                value=get_theme_name(),
+                on_change=lambda e: set_theme(e.value),
+            ).classes('mr-2')
+            ui.color_input(
+                'Accent',
+                value=THEME['accent'],
+                on_change=lambda e: set_accent(e.value),
+            )

--- a/transcendental-resonance-frontend/src/utils/styles.py
+++ b/transcendental-resonance-frontend/src/utils/styles.py
@@ -1,6 +1,6 @@
 """Styling utilities for the Transcendental Resonance frontend."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from nicegui import ui
 
@@ -22,18 +22,42 @@ THEMES: Dict[str, Dict[str, str]] = {
     },
 }
 
-# Currently active theme. Can be switched at runtime via ``set_theme``.
-ACTIVE_THEME: Dict[str, str] = THEMES["dark"]
+# Currently active theme name and accent color. They can be changed at runtime
+# and are persisted in the browser ``localStorage``.
+ACTIVE_THEME_NAME: str = "dark"
+ACTIVE_ACCENT: str = THEMES[ACTIVE_THEME_NAME]["accent"]
 
 
 def apply_global_styles() -> None:
-    """Inject global CSS styles into the application."""
+    """Inject global CSS styles based on stored theme and accent settings."""
+    global ACTIVE_THEME_NAME, ACTIVE_ACCENT
+
+    try:
+        stored_theme: Optional[str] = ui.run_javascript(
+            "localStorage.getItem('theme')",
+            respond=True,
+        )
+        if isinstance(stored_theme, str) and stored_theme in THEMES:
+            ACTIVE_THEME_NAME = stored_theme
+        stored_accent: Optional[str] = ui.run_javascript(
+            "localStorage.getItem('accent')",
+            respond=True,
+        )
+        if isinstance(stored_accent, str) and stored_accent:
+            ACTIVE_ACCENT = stored_accent
+    except Exception:
+        # Accessing localStorage may fail during testing
+        pass
+
+    theme = THEMES[ACTIVE_THEME_NAME].copy()
+    theme["accent"] = ACTIVE_ACCENT
+
     ui.add_head_html(
         f"""
         <style id="global-theme">
-            body {{ background: {ACTIVE_THEME['background']}; color: {ACTIVE_THEME['text']}; }}
-            .q-btn:hover {{ border: 1px solid {ACTIVE_THEME['accent']}; }}
-            .futuristic-gradient {{ background: {ACTIVE_THEME['gradient']}; }}
+            body {{ background: {theme['background']}; color: {theme['text']}; }}
+            .q-btn:hover {{ border: 1px solid {theme['accent']}; }}
+            .futuristic-gradient {{ background: {theme['gradient']}; }}
         </style>
         """
     )
@@ -41,11 +65,31 @@ def apply_global_styles() -> None:
 
 def set_theme(name: str) -> None:
     """Switch the active theme by name and reapply global styles."""
-    global ACTIVE_THEME
-    ACTIVE_THEME = THEMES.get(name, THEMES["dark"])
+    global ACTIVE_THEME_NAME, ACTIVE_ACCENT
+    ACTIVE_THEME_NAME = name if name in THEMES else "dark"
+    # reset accent to theme default when switching themes
+    ACTIVE_ACCENT = THEMES[ACTIVE_THEME_NAME]["accent"]
+    ui.run_javascript(f"localStorage.setItem('theme', '{ACTIVE_THEME_NAME}')")
+    ui.run_javascript(f"localStorage.setItem('accent', '{ACTIVE_ACCENT}')")
     apply_global_styles()
 
 
 def get_theme() -> Dict[str, str]:
     """Return the currently active theme dictionary."""
-    return ACTIVE_THEME
+    theme = THEMES[ACTIVE_THEME_NAME].copy()
+    theme["accent"] = ACTIVE_ACCENT
+    return theme
+
+
+def get_theme_name() -> str:
+    """Return the name of the currently active theme."""
+    return ACTIVE_THEME_NAME
+
+
+def set_accent(color: str) -> None:
+    """Update only the accent color and store the preference."""
+    global ACTIVE_ACCENT
+    ACTIVE_ACCENT = color
+    ui.run_javascript(f"localStorage.setItem('accent', '{color}')")
+    apply_global_styles()
+

--- a/transcendental-resonance-frontend/tests/test_styles.py
+++ b/transcendental-resonance-frontend/tests/test_styles.py
@@ -1,20 +1,34 @@
 import types
 from utils import styles
 
+def dummy_ui(captured):
+    return types.SimpleNamespace(
+        add_head_html=lambda html: captured.setdefault("html", html),
+        run_javascript=lambda *_args, **_kwargs: None,
+    )
+
+
 def test_set_theme_switches(monkeypatch):
-    dummy = types.SimpleNamespace(add_head_html=lambda *_: None)
+    dummy = dummy_ui({})
     monkeypatch.setattr(styles, "ui", dummy)
     styles.set_theme("light")
-    assert styles.get_theme() is styles.THEMES["light"]
+    assert styles.get_theme_name() == "light"
     styles.set_theme("dark")
-    assert styles.get_theme() is styles.THEMES["dark"]
+    assert styles.get_theme_name() == "dark"
 
 
 def test_apply_global_styles_injects_css(monkeypatch):
     captured = {}
-    def add_head_html(html):
-        captured["html"] = html
-    dummy = types.SimpleNamespace(add_head_html=add_head_html)
+    dummy = dummy_ui(captured)
     monkeypatch.setattr(styles, "ui", dummy)
     styles.apply_global_styles()
     assert "global-theme" in captured["html"]
+
+
+def test_set_accent_overrides_default(monkeypatch):
+    captured = {}
+    dummy = dummy_ui(captured)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.set_theme("dark")
+    styles.set_accent("#123456")
+    assert styles.get_theme()["accent"] == "#123456"


### PR DESCRIPTION
## Summary
- add runtime accent color configuration to styles
- persist theme and accent in localStorage
- expose theme and accent controls in profile page
- update tests for new style handling

## Testing
- `pytest -q transcendental-resonance-frontend/tests/test_styles.py`
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6885680e13388320bb1cb098e0b90e89