### PR TITLE
Add system insights page

### DIFF
--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -6,6 +6,7 @@ import asyncio
 from .utils.api import clear_token, api_call
 from .utils.styles import apply_global_styles, set_theme, get_theme, THEMES
 from .pages import *  # register all pages
+from .pages.system_insights_page import system_insights_page  # noqa: F401
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()

--- a/transcendental-resonance-frontend/src/pages/__init__.py
+++ b/transcendental-resonance-frontend/src/pages/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "upload_page",
     "status_page",
     "network_page",
+    "system_insights_page",
 ]
 
 

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -67,6 +67,10 @@ async def profile_page():
         ui.button('Messages', on_click=lambda: ui.open(messages_page)).classes('w-full mb-2').style(
             f'background: {THEME["accent"]}; color: {THEME["background"]};'
         )
+        from .system_insights_page import system_insights_page  # lazy import
+        ui.button('System Insights', on_click=lambda: ui.open(system_insights_page)).classes('w-full mb-2').style(
+            f'background: {THEME["accent"]}; color: {THEME["background"]};'
+        )
         ui.button(
             'Logout',
             on_click=lambda: (clear_token(), ui.open(login_page)),

--- a/transcendental-resonance-frontend/src/pages/system_insights_page.py
+++ b/transcendental-resonance-frontend/src/pages/system_insights_page.py
@@ -1,0 +1,44 @@
+"""Detailed system insights metrics page."""
+
+from nicegui import ui
+
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
+from .login_page import login_page
+
+
+@ui.page('/system-insights')
+async def system_insights_page():
+    """Render global epistemic metrics and entropy details."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with ui.column().classes('w-full p-4').style(
+        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
+    ):
+        ui.label('System Insights').classes('text-2xl font-bold mb-4').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        entropy_label = ui.label().classes('mb-2')
+        uncertainty_label = ui.label().classes('mb-2')
+        hypotheses_label = ui.label().classes('mb-2')
+
+        async def refresh_metrics() -> None:
+            state = api_call('GET', '/api/global-epistemic-state') or {}
+            details = api_call('GET', '/system/entropy-details') or {}
+
+            entropy_label.text = (
+                f"Entropy: {details.get('current_entropy', 'N/A')}"
+            )
+            uncertainty_label.text = (
+                f"Uncertainty: {state.get('uncertainty', 'N/A')}"
+            )
+            hypotheses_label.text = (
+                f"Active Hypotheses: {state.get('active_hypotheses', 'N/A')}"
+            )
+
+        await refresh_metrics()
+        ui.timer(10, refresh_metrics)

--- a/transcendental-resonance-frontend/tests/test_system_insights_page.py
+++ b/transcendental-resonance-frontend/tests/test_system_insights_page.py
@@ -1,0 +1,5 @@
+import inspect
+from pages.system_insights_page import system_insights_page
+
+def test_system_insights_page_is_async():
+    assert inspect.iscoroutinefunction(system_insights_page)


### PR DESCRIPTION
## Summary
- implement `system_insights_page` with entropy and epistemic metrics
- register new page and expose navigation from profile page
- add test verifying coroutine definition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688568047c288320af7ef502417e3564