### PR TITLE
Refactor API calls to async httpx

### DIFF
--- a/transcendental-resonance-frontend/requirements.txt
+++ b/transcendental-resonance-frontend/requirements.txt
@@ -1,5 +1,5 @@
 nicegui
-requests
+httpx
 pytest
 pytest-asyncio
 sentence-transformers

--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -21,7 +21,7 @@ def toggle_theme() -> None:
 async def keep_backend_awake() -> None:
     """Periodically ping the backend to keep data fresh."""
     while True:
-        api_call('GET', '/status')
+        await api_call('GET', '/status')
         await asyncio.sleep(300)
 
 

--- a/transcendental-resonance-frontend/src/pages/ai_assist_page.py
+++ b/transcendental-resonance-frontend/src/pages/ai_assist_page.py
@@ -26,7 +26,7 @@ async def ai_assist_page(vibenode_id: int):
 
         async def get_ai_response():
             data = {'prompt': prompt.value}
-            resp = api_call('POST', f'/ai-assist/{vibenode_id}', data)
+            resp = await api_call('POST', f'/ai-assist/{vibenode_id}', data)
             if resp:
                 ui.label('AI Response:').classes('mb-2')
                 ui.label(resp['response']).classes('text-sm break-words')

--- a/transcendental-resonance-frontend/src/pages/events_page.py
+++ b/transcendental-resonance-frontend/src/pages/events_page.py
@@ -34,7 +34,7 @@ async def events_page():
                 'start_time': e_start.value,
                 'group_id': int(group_id.value),
             }
-            resp = api_call('POST', '/events/', data)
+            resp = await api_call('POST', '/events/', data)
             if resp:
                 ui.notify('Event created!', color='positive')
                 await refresh_events()
@@ -46,7 +46,7 @@ async def events_page():
         events_list = ui.column().classes('w-full')
 
         async def refresh_events():
-            events = api_call('GET', '/events/') or []
+            events = await api_call('GET', '/events/') or []
             events_list.clear()
             for e in events:
                 with events_list:
@@ -55,7 +55,7 @@ async def events_page():
                         ui.label(e['description']).classes('text-sm')
                         ui.label(f"Start: {e['start_time']}").classes('text-sm')
                         async def attend_fn(e_id=e['id']):
-                            api_call('POST', f'/events/{e_id}/attend')
+                            await api_call('POST', f'/events/{e_id}/attend')
                             await refresh_events()
                         ui.button('Attend/Leave', on_click=attend_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/pages/groups_page.py
+++ b/transcendental-resonance-frontend/src/pages/groups_page.py
@@ -27,7 +27,7 @@ async def groups_page():
 
         async def create_group():
             data = {'name': g_name.value, 'description': g_desc.value}
-            resp = api_call('POST', '/groups/', data)
+            resp = await api_call('POST', '/groups/', data)
             if resp:
                 ui.notify('Group created!', color='positive')
                 await refresh_groups()
@@ -39,7 +39,7 @@ async def groups_page():
         groups_list = ui.column().classes('w-full')
 
         async def refresh_groups():
-            groups = api_call('GET', '/groups/') or []
+            groups = await api_call('GET', '/groups/') or []
             groups_list.clear()
             for g in groups:
                 with groups_list:
@@ -47,7 +47,7 @@ async def groups_page():
                         ui.label(g['name']).classes('text-lg')
                         ui.label(g['description']).classes('text-sm')
                         async def join_fn(g_id=g['id']):
-                            api_call('POST', f'/groups/{g_id}/join')
+                            await api_call('POST', f'/groups/{g_id}/join')
                             await refresh_groups()
                         ui.button('Join/Leave', on_click=join_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/pages/login_page.py
+++ b/transcendental-resonance-frontend/src/pages/login_page.py
@@ -24,7 +24,7 @@ async def login_page():
 
         async def handle_login():
             data = {'username': username.value, 'password': password.value}
-            resp = api_call('POST', '/token', data=data)
+            resp = await api_call('POST', '/token', data=data)
             if resp and 'access_token' in resp:
                 set_token(resp['access_token'])
                 ui.notify('Login successful!', color='positive')
@@ -63,7 +63,7 @@ async def register_page():
                 'email': email.value,
                 'password': password.value,
             }
-            resp = api_call('POST', '/users/register', data)
+            resp = await api_call('POST', '/users/register', data)
             if resp:
                 ui.notify('Registration successful! Please login.', color='positive')
                 ui.open(login_page)

--- a/transcendental-resonance-frontend/src/pages/messages_page.py
+++ b/transcendental-resonance-frontend/src/pages/messages_page.py
@@ -27,7 +27,7 @@ async def messages_page():
 
         async def send_message():
             data = {'content': content.value}
-            resp = api_call('POST', f'/messages/{recipient.value}', data)
+            resp = await api_call('POST', f'/messages/{recipient.value}', data)
             if resp:
                 ui.notify('Message sent!', color='positive')
                 await refresh_messages()
@@ -39,7 +39,7 @@ async def messages_page():
         messages_list = ui.column().classes('w-full')
 
         async def refresh_messages():
-            messages = api_call('GET', '/messages/') or []
+            messages = await api_call('GET', '/messages/') or []
             messages_list.clear()
             for m in messages:
                 with messages_list:

--- a/transcendental-resonance-frontend/src/pages/network_analysis_page.py
+++ b/transcendental-resonance-frontend/src/pages/network_analysis_page.py
@@ -28,7 +28,7 @@ async def network_page():
         graph = ui.html('').classes('w-full h-96')
 
         async def refresh_network() -> None:
-            analysis = api_call('GET', '/network-analysis/')
+            analysis = await api_call('GET', '/network-analysis/')
             if analysis:
                 nodes_label.text = f"Nodes: {analysis['metrics']['node_count']}"
                 edges_label.text = f"Edges: {analysis['metrics']['edge_count']}"

--- a/transcendental-resonance-frontend/src/pages/notifications_page.py
+++ b/transcendental-resonance-frontend/src/pages/notifications_page.py
@@ -25,7 +25,7 @@ async def notifications_page():
         notifs_list = ui.column().classes('w-full')
 
         async def refresh_notifs():
-            notifs = api_call('GET', '/notifications/') or []
+            notifs = await api_call('GET', '/notifications/') or []
             notifs_list.clear()
             for n in notifs:
                 with notifs_list:
@@ -33,7 +33,7 @@ async def notifications_page():
                         ui.label(n['message']).classes('text-sm')
                         if not n['is_read']:
                             async def mark_read(n_id=n['id']):
-                                api_call('PUT', f'/notifications/{n_id}/read')
+                                await api_call('PUT', f'/notifications/{n_id}/read')
                                 await refresh_notifs()
                             ui.button('Mark Read', on_click=mark_read).style(
                                 f'background: {THEME["primary"]}; color: {THEME["text"]};'

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -20,7 +20,7 @@ async def profile_page():
         ui.open(login_page)
         return
 
-    user_data = api_call('GET', '/users/me')
+    user_data = await api_call('GET', '/users/me')
     if not user_data:
         clear_token()
         ui.open(login_page)
@@ -41,7 +41,7 @@ async def profile_page():
         bio = ui.input('Bio', value=user_data.get('bio', '')).classes('w-full mb-2')
 
         async def update_bio():
-            resp = api_call('PUT', '/users/me', {'bio': bio.value})
+            resp = await api_call('PUT', '/users/me', {'bio': bio.value})
             if resp:
                 ui.notify('Bio updated', color='positive')
 

--- a/transcendental-resonance-frontend/src/pages/proposals_page.py
+++ b/transcendental-resonance-frontend/src/pages/proposals_page.py
@@ -34,7 +34,7 @@ async def proposals_page():
                 'proposal_type': p_type.value,
                 'group_id': int(p_group_id.value) if p_group_id.value else None,
             }
-            resp = api_call('POST', '/proposals/', data)
+            resp = await api_call('POST', '/proposals/', data)
             if resp:
                 ui.notify('Proposal created!', color='positive')
                 await refresh_proposals()
@@ -46,7 +46,7 @@ async def proposals_page():
         proposals_list = ui.column().classes('w-full')
 
         async def refresh_proposals():
-            proposals = api_call('GET', '/proposals/') or []
+            proposals = await api_call('GET', '/proposals/') or []
             proposals_list.clear()
             for p in proposals:
                 with proposals_list:
@@ -56,10 +56,10 @@ async def proposals_page():
                         ui.label(f"Status: {p['status']}").classes('text-sm')
                         if p['status'] == 'open':
                             async def vote_yes(p_id=p['id']):
-                                api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'yes'})
+                                await api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'yes'})
                                 await refresh_proposals()
                             async def vote_no(p_id=p['id']):
-                                api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'no'})
+                                await api_call('POST', f'/proposals/{p_id}/vote', {'vote': 'no'})
                                 await refresh_proposals()
                             ui.row().classes('justify-between')
                             ui.button('Yes', on_click=vote_yes).style('background: green; color: white;')

--- a/transcendental-resonance-frontend/src/pages/status_page.py
+++ b/transcendental-resonance-frontend/src/pages/status_page.py
@@ -23,7 +23,7 @@ async def status_page():
         entropy_label = ui.label().classes('mb-2')
 
         async def refresh_status() -> None:
-            status = api_call('GET', '/status')
+            status = await api_call('GET', '/status')
             if status:
                 status_label.text = f"Status: {status['status']}"
                 harmonizers_label.text = (

--- a/transcendental-resonance-frontend/src/pages/upload_page.py
+++ b/transcendental-resonance-frontend/src/pages/upload_page.py
@@ -26,7 +26,7 @@ async def upload_page():
 
         async def handle_upload(content, name):
             files = {'file': (name, content.read(), 'multipart/form-data')}
-            resp = api_call('POST', '/upload/', files=files, method='multipart')
+            resp = await api_call('POST', '/upload/', files=files, method='multipart')
             if resp:
                 ui.notify(f"Uploaded: {resp['media_url']}", color='positive')
 

--- a/transcendental-resonance-frontend/src/pages/vibenodes_page.py
+++ b/transcendental-resonance-frontend/src/pages/vibenodes_page.py
@@ -39,7 +39,7 @@ async def vibenodes_page():
                 'tags': [t.strip() for t in tags.value.split(',')] if tags.value else None,
                 'parent_vibenode_id': int(parent_id.value) if parent_id.value else None,
             }
-            resp = api_call('POST', '/vibenodes/', data)
+            resp = await api_call('POST', '/vibenodes/', data)
             if resp:
                 ui.notify('VibeNode created!', color='positive')
                 await refresh_vibenodes()
@@ -51,7 +51,7 @@ async def vibenodes_page():
         vibenodes_list = ui.column().classes('w-full')
 
         async def refresh_vibenodes():
-            vibenodes = api_call('GET', '/vibenodes/') or []
+            vibenodes = await api_call('GET', '/vibenodes/') or []
             vibenodes_list.clear()
             for vn in vibenodes:
                 with vibenodes_list:
@@ -60,7 +60,7 @@ async def vibenodes_page():
                         ui.label(vn['description']).classes('text-sm')
                         ui.label(f"Likes: {vn.get('likes_count', 0)}").classes('text-sm')
                         async def like_fn(vn_id=vn['id']):
-                            api_call('POST', f'/vibenodes/{vn_id}/like')
+                            await api_call('POST', f'/vibenodes/{vn_id}/like')
                             await refresh_vibenodes()
                         ui.button('Like/Unlike', on_click=like_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'

--- a/transcendental-resonance-frontend/src/utils/api.py
+++ b/transcendental-resonance-frontend/src/utils/api.py
@@ -3,7 +3,7 @@
 from typing import Optional, Dict
 
 import os
-import requests
+import httpx
 from nicegui import ui
 
 # Backend API base URL
@@ -11,14 +11,14 @@ BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 TOKEN: Optional[str] = None
 
-def api_call(
+async def api_call(
     method: str,
     endpoint: str,
     data: Optional[Dict] = None,
     headers: Optional[Dict] = None,
     files: Optional[Dict] = None,
 ) -> Optional[Dict]:
-    """Wrapper around ``requests`` to interact with the backend API."""
+    """Async wrapper around ``httpx`` to interact with the backend API."""
     url = f"{BACKEND_URL}{endpoint}"
     default_headers = {'Content-Type': 'application/json'} if method != 'multipart' else {}
     if headers:
@@ -26,25 +26,26 @@ def api_call(
     if TOKEN:
         default_headers['Authorization'] = f'Bearer {TOKEN}'
 
-    try:
-        if method == 'GET':
-            response = requests.get(url, headers=default_headers, params=data)
-        elif method == 'POST':
-            if files:
-                response = requests.post(url, headers=default_headers, data=data, files=files)
+    async with httpx.AsyncClient() as client:
+        try:
+            if method == 'GET':
+                response = await client.get(url, headers=default_headers, params=data)
+            elif method == 'POST':
+                if files:
+                    response = await client.post(url, headers=default_headers, data=data, files=files)
+                else:
+                    response = await client.post(url, headers=default_headers, json=data)
+            elif method == 'PUT':
+                response = await client.put(url, headers=default_headers, json=data)
+            elif method == 'DELETE':
+                response = await client.delete(url, headers=default_headers, json=data)
             else:
-                response = requests.post(url, headers=default_headers, json=data)
-        elif method == 'PUT':
-            response = requests.put(url, headers=default_headers, json=data)
-        elif method == 'DELETE':
-            response = requests.delete(url, headers=default_headers, json=data)
-        else:
-            raise ValueError(f"Unsupported method: {method}")
-        response.raise_for_status()
-        return response.json() if response.text else None
-    except requests.exceptions.RequestException as exc:
-        ui.notify(f"API Error: {exc}", color='negative')
-        return None
+                raise ValueError(f"Unsupported method: {method}")
+            response.raise_for_status()
+            return response.json() if response.text else None
+        except httpx.HTTPError as exc:
+            ui.notify(f"API Error: {exc}", color='negative')
+            return None
 
 
 def set_token(token: str) -> None:

--- a/transcendental-resonance-frontend/tests/test_ai_assist_page.py
+++ b/transcendental-resonance-frontend/tests/test_ai_assist_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.ai_assist_page import ai_assist_page
 
-def test_ai_assist_page_is_async():
+@pytest.mark.asyncio
+async def test_ai_assist_page_is_async():
     assert inspect.iscoroutinefunction(ai_assist_page)

--- a/transcendental-resonance-frontend/tests/test_events_page.py
+++ b/transcendental-resonance-frontend/tests/test_events_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.events_page import events_page
 
-def test_events_page_is_async():
+@pytest.mark.asyncio
+async def test_events_page_is_async():
     assert inspect.iscoroutinefunction(events_page)

--- a/transcendental-resonance-frontend/tests/test_groups_page.py
+++ b/transcendental-resonance-frontend/tests/test_groups_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.groups_page import groups_page
 
-def test_groups_page_is_async():
+@pytest.mark.asyncio
+async def test_groups_page_is_async():
     assert inspect.iscoroutinefunction(groups_page)

--- a/transcendental-resonance-frontend/tests/test_login_page.py
+++ b/transcendental-resonance-frontend/tests/test_login_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.login_page import login_page
 
-def test_login_page_is_async():
+@pytest.mark.asyncio
+async def test_login_page_is_async():
     assert inspect.iscoroutinefunction(login_page)

--- a/transcendental-resonance-frontend/tests/test_messages_page.py
+++ b/transcendental-resonance-frontend/tests/test_messages_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.messages_page import messages_page
 
-def test_messages_page_is_async():
+@pytest.mark.asyncio
+async def test_messages_page_is_async():
     assert inspect.iscoroutinefunction(messages_page)

--- a/transcendental-resonance-frontend/tests/test_network_analysis_page.py
+++ b/transcendental-resonance-frontend/tests/test_network_analysis_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.network_analysis_page import network_page
 
-def test_network_page_is_async():
+@pytest.mark.asyncio
+async def test_network_page_is_async():
     assert inspect.iscoroutinefunction(network_page)

--- a/transcendental-resonance-frontend/tests/test_notifications_page.py
+++ b/transcendental-resonance-frontend/tests/test_notifications_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.notifications_page import notifications_page
 
-def test_notifications_page_is_async():
+@pytest.mark.asyncio
+async def test_notifications_page_is_async():
     assert inspect.iscoroutinefunction(notifications_page)

--- a/transcendental-resonance-frontend/tests/test_profile_page.py
+++ b/transcendental-resonance-frontend/tests/test_profile_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.profile_page import profile_page
 
-def test_profile_page_is_async():
+@pytest.mark.asyncio
+async def test_profile_page_is_async():
     assert inspect.iscoroutinefunction(profile_page)

--- a/transcendental-resonance-frontend/tests/test_proposals_page.py
+++ b/transcendental-resonance-frontend/tests/test_proposals_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.proposals_page import proposals_page
 
-def test_proposals_page_is_async():
+@pytest.mark.asyncio
+async def test_proposals_page_is_async():
     assert inspect.iscoroutinefunction(proposals_page)

--- a/transcendental-resonance-frontend/tests/test_status_page.py
+++ b/transcendental-resonance-frontend/tests/test_status_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.status_page import status_page
 
-def test_status_page_is_async():
+@pytest.mark.asyncio
+async def test_status_page_is_async():
     assert inspect.iscoroutinefunction(status_page)

--- a/transcendental-resonance-frontend/tests/test_upload_page.py
+++ b/transcendental-resonance-frontend/tests/test_upload_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.upload_page import upload_page
 
-def test_upload_page_is_async():
+@pytest.mark.asyncio
+async def test_upload_page_is_async():
     assert inspect.iscoroutinefunction(upload_page)

--- a/transcendental-resonance-frontend/tests/test_vibenodes_page.py
+++ b/transcendental-resonance-frontend/tests/test_vibenodes_page.py
@@ -1,5 +1,7 @@
 import inspect
+import pytest
 from pages.vibenodes_page import vibenodes_page
 
-def test_vibenodes_page_is_async():
+@pytest.mark.asyncio
+async def test_vibenodes_page_is_async():
     assert inspect.iscoroutinefunction(vibenodes_page)


### PR DESCRIPTION
## Summary
- refactor frontend API utility to use `httpx.AsyncClient`
- make periodic ping awaitable
- update page modules to await API calls
- mark page tests with `pytest.mark.asyncio`
- replace requests with httpx in frontend requirements

## Testing
- `pip install httpx python-dateutil`
- `pip install scikit-learn`
- `pytest -q` *(fails: async def functions are not natively supported and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885680bb83883209693ef3785529231