### PR TITLE
Add websocket channels

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,7 @@ for mod_name in [
                 pass
 
             stub.Session = Session
-            stub.sessionmaker = lambda *a, **kw: None
+            stub.sessionmaker = lambda *a, **kw: Session
             stub.relationship = lambda *a, **kw: None
             class DeclarativeBase:
                 metadata = types.SimpleNamespace(

--- a/transcendental-resonance-frontend/requirements.txt
+++ b/transcendental-resonance-frontend/requirements.txt
@@ -1,5 +1,6 @@
 nicegui
 requests
+websockets
 pytest
 pytest-asyncio
 sentence-transformers

--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -1,11 +1,12 @@
 """Main entry point for the Transcendental Resonance frontend."""
 
-from nicegui import ui, background_tasks
+from nicegui import ui, background_tasks, app
 import asyncio
+from fastapi import WebSocket, WebSocketDisconnect
 
-from .utils.api import clear_token, api_call
-from .utils.styles import apply_global_styles, set_theme, get_theme, THEMES
-from .pages import *  # register all pages
+from utils.api import clear_token, api_call
+from utils.styles import apply_global_styles, set_theme, get_theme, THEMES
+from pages import *  # register all pages
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
@@ -25,12 +26,61 @@ async def keep_backend_awake() -> None:
         await asyncio.sleep(300)
 
 
+# --- WebSocket support ---
+notification_clients: set[WebSocket] = set()
+message_clients: set[WebSocket] = set()
+
+
+@app.websocket('/ws/notifications')
+async def notifications_ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    notification_clients.add(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        notification_clients.discard(websocket)
+
+
+@app.websocket('/ws/messages')
+async def messages_ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    message_clients.add(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        message_clients.discard(websocket)
+
+
+async def emit_fake_events() -> None:
+    count = 0
+    while True:
+        await asyncio.sleep(10)
+        for ws in list(notification_clients):
+            try:
+                await ws.send_json({'message': f'Notification #{count}'})
+            except Exception:
+                notification_clients.discard(ws)
+        for ws in list(message_clients):
+            try:
+                await ws.send_json({'sender': 'system', 'content': f'Hello #{count}'})
+            except Exception:
+                message_clients.discard(ws)
+        count += 1
+
+
 ui.button(
     "Toggle Theme",
     on_click=toggle_theme,
 ).classes("fixed top-0 right-0 m-2")
 
 ui.on_startup(lambda: background_tasks.create(keep_backend_awake(), name='backend-pinger'))
+ui.on_startup(lambda: background_tasks.create(emit_fake_events(), name='fake-events'))
 
 # Potential future enhancements:
 # - Real-time updates via WebSockets

--- a/transcendental-resonance-frontend/src/pages/messages_page.py
+++ b/transcendental-resonance-frontend/src/pages/messages_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.ws_client import start_client
 from .login_page import login_page
 
 
@@ -46,6 +47,14 @@ async def messages_page():
                     with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
                         ui.label(f"From: {m['sender_id']}").classes('text-sm')
                         ui.label(m['content']).classes('text-sm')
+
+        async def handle_ws(data: dict) -> None:
+            with messages_list:
+                with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    ui.label(f"From: {data.get('sender', 'system')}").classes('text-sm')
+                    ui.label(data.get('content', '')).classes('text-sm')
+
+        start_client('/ws/messages', handle_ws)
 
         await refresh_messages()
         ui.timer(30, refresh_messages)

--- a/transcendental-resonance-frontend/src/pages/notifications_page.py
+++ b/transcendental-resonance-frontend/src/pages/notifications_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.ws_client import start_client
 from .login_page import login_page
 
 
@@ -38,6 +39,13 @@ async def notifications_page():
                             ui.button('Mark Read', on_click=mark_read).style(
                                 f'background: {THEME["primary"]}; color: {THEME["text"]};'
                             )
+
+        async def handle_ws(data: dict) -> None:
+            with notifs_list:
+                with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    ui.label(data.get('message', '')).classes('text-sm')
+
+        start_client('/ws/notifications', handle_ws)
 
         await refresh_notifs()
         ui.timer(30, refresh_notifs)

--- a/transcendental-resonance-frontend/src/utils/ws_client.py
+++ b/transcendental-resonance-frontend/src/utils/ws_client.py
@@ -1,0 +1,23 @@
+import asyncio
+import json
+from typing import Callable, Awaitable
+
+import websockets
+
+HOST = 'ws://localhost:8080'
+
+
+def start_client(path: str, handler: Callable[[dict], Awaitable[None]]) -> None:
+    async def _run() -> None:
+        uri = f"{HOST}{path}"
+        try:
+            async with websockets.connect(uri) as ws:
+                async for msg in ws:
+                    try:
+                        data = json.loads(msg)
+                    except json.JSONDecodeError:
+                        data = {'message': msg}
+                    await handler(data)
+        except Exception:
+            pass
+    asyncio.create_task(_run())

--- a/transcendental-resonance-frontend/tests/test_websockets.py
+++ b/transcendental-resonance-frontend/tests/test_websockets.py
@@ -1,0 +1,19 @@
+import ast
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
+MAIN_FILE = SRC_DIR / 'main.py'
+
+def _has_async_func(name: str) -> bool:
+    tree = ast.parse(MAIN_FILE.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return True
+    return False
+
+def test_notifications_ws_defined():
+    assert _has_async_func('notifications_ws')
+
+
+def test_messages_ws_defined():
+    assert _has_async_func('messages_ws')


### PR DESCRIPTION
## Summary
- add `websockets` dependency for the frontend
- create websocket endpoints in `main.py` and start fake event generator
- auto-connect from notifications and messages pages
- helper for websocket client
- simple tests confirming websocket handlers exist
- adjust SQLAlchemy stub to return a Session

## Testing
- `pytest -q` *(fails: 18 failed, 61 passed, 73 warnings, 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885680f56bc8320ab1ba11c2631c5fb