### PR TITLE
Add predictions page for frontend

### DIFF
--- a/transcendental-resonance-frontend/src/pages/__init__.py
+++ b/transcendental-resonance-frontend/src/pages/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "upload_page",
     "status_page",
     "network_page",
+    "predictions_page",
 ]
 
 

--- a/transcendental-resonance-frontend/src/pages/predictions_page.py
+++ b/transcendental-resonance-frontend/src/pages/predictions_page.py
@@ -1,0 +1,58 @@
+"""Predictions dashboard page."""
+
+from nicegui import ui
+
+from utils.api import api_call, TOKEN, clear_token
+from utils.styles import get_theme
+from .login_page import login_page
+
+
+@ui.page('/predictions')
+async def predictions_page():
+    """Display user and system level predictions."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    user_data = api_call('GET', '/users/me')
+    if not user_data:
+        clear_token()
+        ui.open(login_page)
+        return
+
+    user_id = user_data.get('id')
+    user_pred = api_call('GET', f'/api/predict-user/{user_id}') or {}
+    system_pred = api_call('GET', '/api/system-predictions') or {}
+
+    THEME = get_theme()
+    with ui.column().classes('w-full p-4').style(
+        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
+    ):
+        ui.label('Predictions').classes('text-2xl font-bold mb-4').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        with ui.card().classes('w-full mb-4').style('border: 1px solid #333; background: #1e1e1e;'):
+            ui.label('Your Predicted Interactions').classes('text-lg mb-2')
+            if user_pred:
+                preds = user_pred.get('prediction', {}).get('predictions', {})
+                for action, info in preds.items():
+                    prob = info.get('probability', 0.0)
+                    ui.label(f'{action}: {prob:.2f}').classes('text-sm')
+            else:
+                ui.label('No data').classes('text-sm')
+
+        with ui.card().classes('w-full').style('border: 1px solid #333; background: #1e1e1e;'):
+            ui.label('System Predictions').classes('text-lg mb-2')
+            if system_pred:
+                experiments = system_pred.get('experiments', [])
+                if experiments:
+                    ui.label('Experiments:').classes('text-sm')
+                    for exp in experiments:
+                        ui.label(str(exp)).classes('text-sm break-words')
+                prediction = system_pred.get('prediction')
+                if prediction:
+                    ui.label('Prediction:').classes('text-sm mt-2')
+                    ui.label(str(prediction)).classes('text-sm break-words')
+            else:
+                ui.label('No data').classes('text-sm')

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -11,6 +11,7 @@ from .events_page import events_page
 from .proposals_page import proposals_page
 from .notifications_page import notifications_page
 from .messages_page import messages_page
+from .predictions_page import predictions_page
 
 
 @ui.page('/profile')
@@ -65,6 +66,9 @@ async def profile_page():
             f'background: {THEME["accent"]}; color: {THEME["background"]};'
         )
         ui.button('Messages', on_click=lambda: ui.open(messages_page)).classes('w-full mb-2').style(
+            f'background: {THEME["accent"]}; color: {THEME["background"]};'
+        )
+        ui.button('Predictions', on_click=lambda: ui.open(predictions_page)).classes('w-full mb-2').style(
             f'background: {THEME["accent"]}; color: {THEME["background"]};'
         )
         ui.button(

--- a/transcendental-resonance-frontend/tests/test_predictions_page.py
+++ b/transcendental-resonance-frontend/tests/test_predictions_page.py
@@ -1,0 +1,5 @@
+import inspect
+from pages.predictions_page import predictions_page
+
+def test_predictions_page_is_async():
+    assert inspect.iscoroutinefunction(predictions_page)


### PR DESCRIPTION
## Summary
- implement `predictions_page` to show user and system predictions
- link predictions page from profile
- expose page module in `__init__`
- add async test for predictions page

## Testing
- `pytest transcendental-resonance-frontend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68856809901483208bd6fb3cccb27352