### PR TITLE
Add influence score fetch in profile page

### DIFF
--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -26,6 +26,8 @@ async def profile_page():
         ui.open(login_page)
         return
 
+    score_data = api_call('GET', '/users/me/influence-score') or {}
+
     THEME = get_theme()
     with ui.column().classes('w-full p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
@@ -36,6 +38,9 @@ async def profile_page():
 
         ui.label(f'Harmony Score: {user_data["harmony_score"]}').classes('mb-2')
         ui.label(f'Creative Spark: {user_data["creative_spark"]}').classes('mb-2')
+        ui.label(
+            f'Influence Score: {score_data.get("influence_score", "N/A")}'
+        ).classes('mb-2')
         ui.label(f'Species: {user_data["species"]}').classes('mb-2')
 
         bio = ui.input('Bio', value=user_data.get('bio', '')).classes('w-full mb-2')

--- a/transcendental-resonance-frontend/tests/test_profile_page.py
+++ b/transcendental-resonance-frontend/tests/test_profile_page.py
@@ -3,3 +3,8 @@ from pages.profile_page import profile_page
 
 def test_profile_page_is_async():
     assert inspect.iscoroutinefunction(profile_page)
+
+
+def test_profile_page_calls_influence_score_api():
+    source = inspect.getsource(profile_page)
+    assert "/users/me/influence-score" in source


### PR DESCRIPTION
## Summary
- display user's influence score on profile page
- check for new API call in profile page tests

## Testing
- `pytest -q transcendental-resonance-frontend/tests/test_profile_page.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688568022a248320ac3cf116413f08e1