### PR TITLE
Add music generation page

### DIFF
--- a/transcendental-resonance-frontend/src/pages/__init__.py
+++ b/transcendental-resonance-frontend/src/pages/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "messages_page",
     "ai_assist_page",
     "upload_page",
+    "music_page",
     "status_page",
     "network_page",
 ]

--- a/transcendental-resonance-frontend/src/pages/music_page.py
+++ b/transcendental-resonance-frontend/src/pages/music_page.py
@@ -1,0 +1,52 @@
+"""Interactive music generation page."""
+
+from nicegui import ui
+
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
+from .login_page import login_page
+
+
+@ui.page('/music')
+async def music_page():
+    """Generate music based on harmony settings."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with ui.column().classes('w-full p-4').style(
+        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
+    ):
+        ui.label('Music Generator').classes('text-2xl font-bold mb-4').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        harmony_slider = ui.slider(min=0, max=100, value=50).classes('w-full')
+        harmony_label = ui.label(f'Harmony: {harmony_slider.value}').classes('mb-4')
+        harmony_slider.on(
+            'update:model-value',
+            lambda e: harmony_label.set_text(f'Harmony: {e.value}')
+        )
+
+        length_input = ui.number('Length (bars)', value=8).classes('w-full mb-4')
+
+        download_link = ui.link('Download MIDI', '#').props('download').classes('hidden')
+
+        async def generate():
+            data = {
+                'harmony': harmony_slider.value,
+                'length': length_input.value,
+            }
+            resp = api_call('POST', '/generate-music', data)
+            if resp and 'url' in resp:
+                download_link.href = resp['url']
+                download_link.classes(remove='hidden')
+                ui.notify('Music generated!', color='positive')
+            else:
+                ui.notify('Music generation failed', color='negative')
+
+        ui.button('Generate Music', on_click=generate).classes('w-full mb-4').style(
+            f'background: {THEME["primary"]}; color: {THEME["text"]};'
+        )
+        download_link

--- a/transcendental-resonance-frontend/tests/test_music_page.py
+++ b/transcendental-resonance-frontend/tests/test_music_page.py
@@ -1,0 +1,6 @@
+import inspect
+from pages.music_page import music_page
+
+
+def test_music_page_is_async():
+    assert inspect.iscoroutinefunction(music_page)


### PR DESCRIPTION
## Summary
- add new `music_page` to control harmony settings and download MIDI
- register `music_page` in pages package
- test that `music_page` is async

## Testing
- `pytest transcendental-resonance-frontend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68856b1c791c83208c5864a16fdfb735