### PR TITLE
Add scikit-learn to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pygame
 mido
 midiutil
 torch
+scikit-learn


### PR DESCRIPTION
## Summary
- add scikit-learn to the dependency list so that `network_coordination_detector`'s fallback TF‑IDF vectorizer works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856ebf57408320967337052f187401