### PR TITLE
Add Makefile with install/test/lint commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install test lint
+
+install:
+	./setup.sh
+
+test:
+	pytest -q
+
+lint:
+	mypy

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ pytest
 The test suite requires packages like `SQLAlchemy`, `networkx`, and `numpy`.
 If `pytest` fails with missing module errors, run `pip install -r requirements.txt` again.
 
+### Makefile Commands
+
+For a quicker workflow you can use the provided `Makefile`:
+
+```bash
+# install project dependencies
+make install
+
+# run the full test suite
+make test
+
+# run static type checks
+make lint
+```
+
 ## ✨ Features
 
 * **🧠 Smart Scoring** — Combines confidence, signal strength, and NLP sentiment

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Simple setup script for local development
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add Makefile with install, test and lint targets
- provide simple `setup.sh` to install project dependencies
- document Makefile usage in the README

## Testing
- `make install`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688577c6c8088320baf94416e3b36cc0