### PR TITLE
Add Dockerfile and Docker usage instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies first
+COPY requirements.txt pyproject.toml ./
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir .
+
+# Copy project files
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ pytest
 The test suite requires packages like `SQLAlchemy`, `networkx`, and `numpy`.
 If `pytest` fails with missing module errors, run `pip install -r requirements.txt` again.
 
+## 🐳 Docker
+
+Build the API container and expose it on port 8000:
+
+```bash
+docker build -t supernova-api .
+docker run -p 8000:8000 supernova-api
+```
+
+The service will be available at `http://localhost:8000`.
+
 ## ✨ Features
 
 * **🧠 Smart Scoring** — Combines confidence, signal strength, and NLP sentiment


### PR DESCRIPTION
## Summary
- add a Dockerfile to run the FastAPI application with uvicorn
- document how to build and run the container in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885792402e88320a2c76a794cc844bf