### PR TITLE
Add Development Setup guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,31 @@
+# Development Setup
+
+This repository targets **Python 3.12** and uses standard tooling for managing dependencies and tests.
+
+## Prerequisites
+
+1. Install Python 3.12.
+2. Create a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # on Windows use .\venv\Scripts\activate
+   ```
+3. Install the package and its dependencies:
+   ```bash
+   pip install .
+   pip install -r requirements.txt
+   ```
+
+## Running Tests
+
+Tests are written with `pytest`. After installing dependencies you can run:
+
+```bash
+pytest
+```
+
+The GitHub Actions workflows (`.github/workflows/ci.yml` and `pr-tests.yml`) run these commands automatically whenever you push or open a pull request.
+
+## Optional Frontend
+
+The `transcendental-resonance-frontend/` directory contains a NiceGUI-based UI. Follow its README to install `pip install -r transcendental-resonance-frontend/requirements.txt` and run the frontend if desired.


### PR DESCRIPTION
## Summary
- add DEVELOPMENT.md with instructions for Python 3.12 env, installing packages, running tests and optional frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885791edb6883209e1122565a53fe03