### PR TITLE
Add persistent layout with navigation

### DIFF
--- a/transcendental-resonance-frontend/src/layout.py
+++ b/transcendental-resonance-frontend/src/layout.py
@@ -1,0 +1,40 @@
+from nicegui import ui, element
+
+from utils.styles import set_theme, get_theme_name
+
+
+def toggle_theme() -> None:
+    """Switch between light and dark themes."""
+    current = get_theme_name()
+    new_name = "light" if current == "dark" else "dark"
+    set_theme(new_name)
+
+
+def build_layout() -> element.Element:
+    """Construct the persistent header and navigation drawer."""
+    drawer = ui.left_drawer().classes("bg-gray-900 text-white")
+    with drawer:
+        links = [
+            ("Profile", "/profile"),
+            ("VibeNodes", "/vibenodes"),
+            ("Groups", "/groups"),
+            ("Events", "/events"),
+            ("Messages", "/messages"),
+            ("Proposals", "/proposals"),
+            ("Notifications", "/notifications"),
+            ("Music", "/music"),
+            ("Network", "/network"),
+            ("Status", "/status"),
+            ("System Insights", "/system-insights"),
+            ("Upload", "/upload"),
+        ]
+        for label, path in links:
+            ui.link(label, path).classes("block px-4 py-2")
+
+    header = ui.header().classes("items-center justify-between")
+    with header:
+        ui.button(icon="menu", on_click=drawer.toggle).props("flat color=white")
+        ui.label("Transcendental Resonance").classes("text-lg font-bold")
+        ui.button("Toggle Theme", on_click=toggle_theme).props("flat")
+
+    return header

--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -4,19 +4,14 @@ from nicegui import ui, background_tasks
 import asyncio
 
 from .utils.api import clear_token, api_call
-from .utils.styles import apply_global_styles, set_theme, get_theme, THEMES
+from .utils.styles import apply_global_styles
 from .pages import *  # register all pages
 from .pages.system_insights_page import system_insights_page  # noqa: F401
+from .layout import build_layout
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
-
-
-def toggle_theme() -> None:
-    """Switch between light and dark themes."""
-    current = get_theme()
-    new_name = "light" if current is THEMES["dark"] else "dark"
-    set_theme(new_name)
+build_layout()
 
 
 async def keep_backend_awake() -> None:
@@ -24,12 +19,6 @@ async def keep_backend_awake() -> None:
     while True:
         api_call('GET', '/status')
         await asyncio.sleep(300)
-
-
-ui.button(
-    "Toggle Theme",
-    on_click=toggle_theme,
-).classes("fixed top-0 right-0 m-2")
 
 ui.on_startup(lambda: background_tasks.create(keep_backend_awake(), name='backend-pinger'))
 

--- a/transcendental-resonance-frontend/tests/test_layout.py
+++ b/transcendental-resonance-frontend/tests/test_layout.py
@@ -1,0 +1,7 @@
+from layout import build_layout
+from nicegui import element
+
+
+def test_build_layout_returns_ui_element():
+    layout_el = build_layout()
+    assert isinstance(layout_el, element.Element)


### PR DESCRIPTION
## Summary
- introduce `layout.py` with header and drawer navigation
- apply layout in `main.py`
- test that `build_layout()` returns a NiceGUI element

## Testing
- `pytest -q transcendental-resonance-frontend/tests/test_layout.py`
- `pytest -q transcendental-resonance-frontend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68857d30d89c83209eb0acf2c3fa50b7