### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ export SECRET_KEY="your-random-secret"
 Copy `.env.example` to `.env` and set values for `SECRET_KEY`, `DATABASE_URL`,
 and `BACKEND_URL` before running the app.
 
+## 🐳 Docker
+
+You can run the API along with its Postgres and Redis services using
+`docker-compose`:
+
+```bash
+cp .env.example .env  # set your own secrets
+docker-compose up
+```
+
+The application will be available at [http://localhost:8000](http://localhost:8000).
+
 ## 🧪 Running Tests
 
 Install all dependencies first:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: example
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7-alpine
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add `Dockerfile` for uvicorn app
- add `docker-compose.yml` with Postgres and Redis
- document Docker usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68858c100c588320a46d314f026e4ab3