### PR TITLE
Add install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ supernova-validate --validations sample_validations.json
 1. **Install Python 3.12** from [python.org](https://www.python.org/) if it isn't
    already on your machine. You can check by running `python --version` in your
    terminal.
-2. **Create a virtual environment** so all required packages stay organized:
+2. **Run the install script** to set up a virtual environment and install all
+   dependencies:
    ```bash
-   python -m venv venv
+   ./install.sh
+   ```
+   On Windows use:
+   ```powershell
+   ./install.ps1
+   ```
+3. **Activate the environment**:
+   ```bash
    # Linux/macOS
    source venv/bin/activate
    # Windows
    .\venv\Scripts\activate
-   ```
-3. **Install the project**:
-   ```bash
-   pip install .
    ```
 4. You're ready to run the demo commands shown in [Quick Start](#-quick-start).
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+
+$envDir = 'venv'
+if (-not (Test-Path $envDir)) {
+    python -m venv $envDir
+}
+
+& "$envDir/Scripts/Activate.ps1"
+
+pip install --upgrade pip
+pip install .
+if (Test-Path 'requirements.txt') {
+    pip install -r requirements.txt
+}
+
+if (Test-Path '.env.example' -and -not (Test-Path '.env')) {
+    Copy-Item '.env.example' '.env'
+}
+
+Write-Host 'Installation complete. Activate with venv\Scripts\activate'
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+# Activate the virtual environment
+source venv/bin/activate
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install the package
+pip install .
+
+# Install additional dependencies
+if [ -f "requirements.txt" ]; then
+    pip install -r requirements.txt
+fi
+
+# Copy example environment file if needed
+if [ -f ".env.example" ] && [ ! -f ".env" ]; then
+    cp .env.example .env
+fi
+
+echo "Installation complete. Activate the environment with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add `install.sh` for UNIX systems
- add `install.ps1` for Windows
- mention the new scripts in the installation docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68858c157b988320a18f929b39c5591b