### PR TITLE
Update Docker build and add installer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+venv/
+.venv/
+.git/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.log
+.dockerignore
+Dockerfile
+docker-compose.yml
+tests/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
+# Builder stage
+FROM python:3.12-slim AS builder
+WORKDIR /install
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Final stage
 FROM python:3.12-slim
 WORKDIR /app
+COPY --from=builder /install /usr/local
 COPY . /app
-RUN pip install --no-cache-dir -r requirements.txt
 CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ supernova-validate --validations sample_validations.json
    already on your machine. You can check by running `python --version` in your
    terminal.
 2. **Run the install script** to set up a virtual environment and install all
-   dependencies:
+   dependencies locally:
    ```bash
    ./install.sh
    ```
    On Windows use:
    ```powershell
    ./install.ps1
+   ```
+   Or install the published wheel directly from PyPI:
+   ```bash
+   ./online_install.sh
    ```
 3. **Activate the environment**:
    ```bash
@@ -85,9 +89,15 @@ and `BACKEND_URL` before running the app.
 
 ## 🐳 Docker
 
-You can run the API along with its Postgres and Redis services using
-`docker-compose`:
+You can build a standalone Docker image or run the API with Postgres and Redis
+via `docker-compose`.
 
+Build the image:
+```bash
+docker build -t supernova-2177 .
+```
+
+Or bring up the full stack:
 ```bash
 cp .env.example .env  # set your own secrets
 docker-compose up

--- a/online_install.sh
+++ b/online_install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v pipx >/dev/null 2>&1; then
+    pipx install supernova-2177
+else
+    pip install supernova-2177
+fi
+


### PR DESCRIPTION
## Summary
- ignore unnecessary files when building Docker images
- convert Dockerfile to multi-stage build
- provide script for installing from PyPI
- document new installer and Docker usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68858e8faa8483209c434d774440787f