### PR TITLE
Improve Dockerfile security and clarity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,34 @@
 # Builder stage
+# Use slim Python image for smaller footprint
 FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /install
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # Final stage
 FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /app
+
+# Create non-root user for security
+RUN adduser --disabled-password --gecos "" appuser
+
 COPY --from=builder /install /usr/local
 COPY . /app
+
+# Change ownership to the non-root user
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+# Expose FastAPI default port
+EXPOSE 8000
+
 CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- use environment flags to avoid root pyc files
- add non-root user for runtime safety
- expose port 8000 for FastAPI

## Testing
- `docker build` *(fails: no permission to network)*

------
https://chatgpt.com/codex/tasks/task_e_68859283d09c83209f89e7a0a624bcb9