### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,42 @@
+# Ignore virtual environments and development artifacts
 venv/
 .venv/
+
+# Version control
 .git/
+
+# Python cache and compiled artifacts
 __pycache__/
 *.pyc
 *.pyo
 *.pyd
 *.db
 *.log
+
+# Runtime configuration files
+*.env
+
+# Docker and compose files themselves
 .dockerignore
 Dockerfile
 docker-compose.yml
-tests/
+
+# Tests and documentation
+/tests/
+/docs/
+
+# IDE settings
+.vscode/
+.idea/
+
+# Auxiliary directories not required at runtime
+transcendental-resonance-frontend/
+transcendental_resonance_frontend/
+demos/
+scripts/
+rfcs/
+network/
+reports/
+introspection/
+federation/
 


### PR DESCRIPTION
## Summary
- add a `.dockerignore` at project root that ignores tests, docs, pyc files, virtualenvs, and other nonessential directories

## Testing
- `pip install python-dateutil`
- `pytest -q` *(fails: ModuleNotFoundError and TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6885923b98b88320b5daebfadb0c9ee6