### PR TITLE
Add python-based installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A modular intelligence pipeline that evaluates hypotheses through evidence-based
 ## 🚀 Quick Start
 
 ```bash
-./scripts/setup_env.sh  # set up environment
+python install.py  # set up environment
 # Try demo mode
 supernova-validate --demo
 
@@ -35,14 +35,10 @@ supernova-validate --validations sample_validations.json
 1. **Install Python 3.12** from [python.org](https://www.python.org/) if it isn't
    already on your machine. You can check by running `python --version` in your
    terminal.
-2. **Run the install script** to set up a virtual environment and install all
+2. **Run the installer** to set up a virtual environment and install all
    dependencies locally:
    ```bash
-   ./install.sh
-   ```
-   On Windows use:
-   ```powershell
-   ./install.ps1
+   python install.py
    ```
    Or install the published wheel directly from PyPI:
    ```bash

--- a/install.py
+++ b/install.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import venv
+import shutil
+
+
+def create_env(env_dir: Path) -> None:
+    if not env_dir.exists():
+        builder = venv.EnvBuilder(with_pip=True)
+        builder.create(env_dir)
+
+
+def run(cmd):
+    print('Running:', ' '.join(cmd))
+    subprocess.check_call(cmd)
+
+
+def main():
+    env_dir = Path('venv')
+    create_env(env_dir)
+
+    if os.name == 'nt':
+        bin_dir = env_dir / 'Scripts'
+    else:
+        bin_dir = env_dir / 'bin'
+
+    pip = bin_dir / ('pip.exe' if os.name == 'nt' else 'pip')
+
+    # Upgrade pip then install requirements
+    run([str(pip), 'install', '--upgrade', 'pip'])
+
+    req = Path('requirements.txt')
+    if req.exists():
+        run([str(pip), 'install', '-r', str(req)])
+
+    # Copy .env.example if .env doesn't exist
+    example = Path('.env.example')
+    target = Path('.env')
+    if example.exists() and not target.exists():
+        shutil.copy(example, target)
+        print('Copied .env.example to .env')
+
+    activation = 'venv\\Scripts\\activate' if os.name == 'nt' else 'source venv/bin/activate'
+    print(f"Installation complete. Activate the environment with '{activation}'")
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed with exit code {exc.returncode}")
+        sys.exit(exc.returncode)


### PR DESCRIPTION
## Summary
- introduce `install.py` to set up a venv via `venv` and install deps
- copy `.env.example` automatically if `.env` doesn't exist
- update quick start and installation docs to use `python install.py`

## Testing
- `python install.py` *(fails: Command failed with exit code 1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885923c31788320910f85f7edcbc420