### PR TITLE
Add cross-platform env setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install test lint
 
 install:
-        ./setup_env.sh
+python setup_env.py
 
 test:
 	pytest -q

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A modular intelligence pipeline that evaluates hypotheses through evidence-based
 ## 🚀 Quick Start
 
 ```bash
-./setup_env.sh  # set up environment (use setup_env.ps1 on Windows)
+python setup_env.py  # set up environment on any platform
 # Try demo mode
 supernova-validate --demo
 
@@ -38,15 +38,7 @@ supernova-validate --validations sample_validations.json
 2. **Run the setup script** to create the virtual environment and install all
    dependencies locally:
    ```bash
-   ./setup_env.sh
-   ```
-   On Windows run:
-   ```powershell
-   ./setup_env.ps1
-   ```
-   Or execute the batch wrapper:
-   ```cmd
-   setup_env.bat
+   python setup_env.py
    ```
    Or install the published wheel directly from PyPI:
    ```bash

--- a/online_install.sh
+++ b/online_install.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v pipx >/dev/null 2>&1; then
-    pipx install supernova-2177
-else
-    pip install supernova-2177
+ENV_DIR="venv"
+PYTHON="${PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    PYTHON=python
 fi
 
+CREATED_ENV=0
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+    if [ ! -d "$ENV_DIR" ]; then
+        "$PYTHON" -m venv "$ENV_DIR"
+        CREATED_ENV=1
+    fi
+    # shellcheck disable=SC1090
+    source "$ENV_DIR/bin/activate"
+fi
+
+pip install --upgrade pip
+pip install supernova-2177
+
+if [ -f ".env.example" ] && [ ! -f ".env" ]; then
+    cp .env.example .env
+fi
+
+echo "Installation complete." 
+if [[ $CREATED_ENV -eq 1 ]]; then
+    echo "Activate the environment with 'source $ENV_DIR/bin/activate'"
+fi
+echo "Set SECRET_KEY in the environment or the .env file before running the app."

--- a/setup_env.py
+++ b/setup_env.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import shutil
+import subprocess
+
+ENV_DIR = 'venv'
+
+
+def in_virtualenv() -> bool:
+    return sys.prefix != getattr(sys, 'base_prefix', sys.prefix)
+
+
+def venv_bin(path: str) -> str:
+    return os.path.join(ENV_DIR, 'Scripts' if os.name == 'nt' else 'bin', path)
+
+
+def ensure_env() -> bool:
+    """Create the virtual environment if not already active. Returns True if a
+    new environment was created."""
+    if in_virtualenv():
+        return False
+    if not os.path.isdir(ENV_DIR):
+        print(f'Creating virtual environment in {ENV_DIR}...')
+        subprocess.check_call([sys.executable, '-m', 'venv', ENV_DIR])
+        return True
+    return False
+
+
+def pip_cmd() -> list:
+    if in_virtualenv():
+        return [sys.executable, '-m', 'pip']
+    return [venv_bin('pip')]
+
+
+def main() -> None:
+    env_created = ensure_env()
+
+    pip = pip_cmd()
+    subprocess.check_call(pip + ['install', '--upgrade', 'pip'])
+    subprocess.check_call(pip + ['install', 'supernova-2177'])
+
+    if os.path.isfile('.env.example') and not os.path.isfile('.env'):
+        shutil.copy('.env.example', '.env')
+        print('Copied .env.example to .env')
+
+    print('Installation complete.')
+    if env_created:
+        if os.name == 'nt':
+            activate = f'{ENV_DIR}\\Scripts\\activate'
+        else:
+            activate = f'source {ENV_DIR}/bin/activate'
+        print(f'Activate the environment with "{activate}"')
+    print('Set SECRET_KEY in the environment or the .env file before running the app.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `setup_env.py` as a Python environment installer
- extend `online_install.sh` to create a venv if needed and copy `.env.example`
- update README and Makefile to call the new Python script

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859670db4883208be85aefa514be21