### PR TITLE
Improve .env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ supernova-validate --validations sample_validations.json
    ```bash
    ./online_install.sh
    ```
+   These installers also copy `.env.example` to `.env` if it is missing.
 3. **Activate the environment**:
    ```bash
    # Linux/macOS
@@ -90,7 +91,8 @@ strong random value is recommended:
 export SECRET_KEY="your-random-secret"
 ```
 
-Copy `.env.example` to `.env` and set values for `SECRET_KEY`, `DATABASE_URL`,
+The installer creates `.env` from `.env.example` if needed.
+Edit the placeholder values for `SECRET_KEY`, `DATABASE_URL`,
 and `BACKEND_URL` before running the app.
 
 ## 🐳 Docker

--- a/online_install.sh
+++ b/online_install.sh
@@ -7,3 +7,8 @@ else
     pip install supernova-2177
 fi
 
+# Copy example environment file if needed
+if [ -f ".env.example" ] && [ ! -f ".env" ]; then
+    cp .env.example .env
+fi
+

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -14,6 +14,7 @@ if (Test-Path 'requirements.txt') {
 
 pip install .
 
+# Copy example environment file if needed
 if (Test-Path '.env.example' -and -not (Test-Path '.env')) {
     Copy-Item '.env.example' '.env'
 }


### PR DESCRIPTION
## Summary
- ensure online installer copies `.env.example` if `.env` is missing
- document the automatic `.env` creation in README
- add comment in Powershell setup script for `.env` copy logic

## Testing
- `pytest -q` *(fails: TypeError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885967a51148320a82afb9dd2300b8a