### PR TITLE
Add database mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ export SECRET_KEY="your-random-secret"
 ```
 
 Copy `.env.example` to `.env` and set values for `SECRET_KEY`, `DATABASE_URL`,
-and `BACKEND_URL` before running the app.
+and `BACKEND_URL` before running the app. Set `DB_MODE=central` if you want to
+use a shared PostgreSQL instance instead of the default local SQLite file.
 
 ## 🐳 Docker
 
@@ -161,6 +162,9 @@ export SECRET_KEY="your-secret"
 export DATABASE_URL="postgresql+asyncpg://user:password@localhost/transcendental_resonance"
 export BACKEND_URL="http://localhost:8000"
 ```
+
+To connect to a central database instead of the local file, pass
+`--db-mode central` when launching the application or set `DB_MODE=central`.
 
 After setting the variables, execute the binary directly:
 

--- a/db_models.py
+++ b/db_models.py
@@ -1,6 +1,7 @@
 # --- MODULE: db_models.py ---
 # Database setup from FastAPI files
-import os # Added for DATABASE_URL environment variable
+import os  # Added for DATABASE_URL environment variable
+import uuid
 from sqlalchemy import (
     create_engine,
     Column,
@@ -27,12 +28,21 @@ import datetime # Ensure datetime is imported for default values
 # NOTE: In a real project, DATABASE_URL and SessionLocal would typically be imported from a central config/db module.
 # For this extraction, we'll keep it self-contained for clarity, assuming it would be integrated.
 # DATABASE_URL = "postgresql+asyncpg://user:password@localhost/transcendental_resonance" # Original hardcoded line
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///:memory:")  # Refined: Get from environment or use in-memory SQLite
+DB_MODE = os.getenv("DB_MODE", "local")
+UNIVERSE_ID = os.getenv("UNIVERSE_ID", str(uuid.uuid4()))
+
+if DB_MODE == "central":
+    DATABASE_URL = os.getenv("DATABASE_URL", "")
+    if not DATABASE_URL:
+        raise RuntimeError("DATABASE_URL must be set in central mode")
+else:
+    DATABASE_URL = os.getenv(
+        "DATABASE_URL", f"sqlite:///universe_{UNIVERSE_ID}.db"
+    )
+
 engine = create_engine(
     DATABASE_URL,
-    connect_args=(
-        {"check_same_thread": False} if "sqlite" in DATABASE_URL else {}
-    ),
+    connect_args={"check_same_thread": False} if "sqlite" in DATABASE_URL else {},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- support local vs central DB configuration via DB_MODE env and CLI flag
- store universe ID metadata
- expose `/universe/info` endpoint to show DB configuration
- add sync_to_mainchain stub
- document DB_MODE usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68859752d3988320aab2b96676f706b7