### PR TITLE
Add Windows script for building executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ PyInstaller. Run the helper script:
 scripts/build_executable.sh
 ```
 
+On Windows, use the PowerShell version:
+
+```powershell
+scripts/build_executable.ps1
+```
+
 The generated executable will be placed under `dist/` as `supernova-cli` on
 Unix systems or `supernova-cli.exe` on Windows.
 

--- a/scripts/build_executable.ps1
+++ b/scripts/build_executable.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+
+# Build a standalone executable using PyInstaller
+pip install pyinstaller
+
+# Package the CLI entry point validate_hypothesis.py
+pyinstaller --onefile validate_hypothesis.py --name supernova-cli
+
+Write-Host "Executable created in dist/ directory"


### PR DESCRIPTION
## Summary
- provide a PowerShell script `scripts/build_executable.ps1` to build the standalone executable
- document how to use the new script when building on Windows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68859ad1b9e08320bc7c2fb3a65c9f8f