### PR TITLE
Add RFC template and GUI example

### DIFF
--- a/rfcs/001-gui-integration/README.md
+++ b/rfcs/001-gui-integration/README.md
@@ -1,0 +1,14 @@
+# Streamlit GUI Integration
+
+## Problem Statement
+The validation toolkit currently requires command-line interaction, which can be a barrier for non-technical users who want to run or review validations.
+
+## Proposed Solution
+Introduce a `app.py` module built with Streamlit that exposes the existing `validate_hypothesis` logic through a simple web interface. Users can select a hypothesis file, trigger validation, and view the resulting reports directly in the browser.
+
+## Alternatives
+- Continue relying solely on the command-line interface.
+- Build a custom React or Django front‑end instead of Streamlit.
+
+## Impact
+A lightweight GUI makes the validation pipeline more accessible and provides a starting point for future web-based features. Deployment can be as easy as running `streamlit run app.py` on a server or container.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -10,6 +10,24 @@ new RFC:
 3. Update the table below with your RFC number and title.
 4. Open a pull request so the community can review it.
 
+## RFC Template
+
+Create your RFC README using the following structure:
+
+```markdown
+## Problem Statement
+Describe the issue or limitation motivating the proposal.
+
+## Proposed Solution
+Detail the recommended approach and any implementation notes.
+
+## Alternatives
+Summarize other options that were considered.
+
+## Impact
+Explain the expected benefits and any potential downsides.
+```
+
 ## Index
 
 ### Validators
@@ -30,4 +48,4 @@ new RFC:
 
 | Number | Title |
 |-------|-------|
-| _None yet_ |
+| [001](001-gui-integration/README.md) | Streamlit GUI Integration |


### PR DESCRIPTION
## Summary
- document a simple RFC template in `rfcs/README.md`
- index new example RFC
- add `001-gui-integration` proposal for a Streamlit GUI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil', later multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_68859d2871188320a4d395fa9438032f