### PR TITLE
Add one-click installer and platform builds

### DIFF
--- a/one_click_install.py
+++ b/one_click_install.py
@@ -1,0 +1,65 @@
+"""One-click installer for superNova_2177."""
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+PYTHON_VERSION = (3, 12)
+
+
+def ensure_python() -> str:
+    """Ensure Python 3.12 is available. Download installer if missing."""
+    if sys.version_info >= PYTHON_VERSION:
+        return sys.executable
+
+    if shutil.which("python3.12"):
+        return "python3.12"
+
+    system = platform.system()
+    tmp_dir = Path(tempfile.mkdtemp())
+    if system == "Windows":
+        url = "https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe"
+        installer = tmp_dir / "python-3.12.exe"
+    elif system == "Darwin":
+        url = "https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg"
+        installer = tmp_dir / "python-3.12.pkg"
+    else:
+        url = "https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz"
+        installer = tmp_dir / "Python-3.12.tgz"
+
+    print(f"Downloading Python 3.12 from {url} ...")
+    try:
+        urllib.request.urlretrieve(url, installer)
+        print(f"Installer downloaded to {installer}")
+    except Exception as exc:
+        print(f"Failed to download Python: {exc}")
+        return sys.executable
+
+    if system == "Linux":
+        print("Please install Python 3.12 manually from the downloaded archive.")
+    else:
+        subprocess.run([str(installer)], check=False)
+    return shutil.which("python3.12") or sys.executable
+
+
+def main() -> None:
+    python_bin = ensure_python()
+    os.environ.setdefault("PYTHON_BIN", python_bin)
+
+    system = platform.system()
+    build_script = Path("scripts/build_executable.sh").resolve()
+
+    if system == "Windows":
+        subprocess.check_call(["bash", str(build_script)])
+    elif system == "Darwin":
+        subprocess.check_call(["bash", str(build_script)])
+    else:
+        subprocess.check_call(["bash", str(build_script)])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_executable.sh
+++ b/scripts/build_executable.sh
@@ -1,12 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a standalone executable using PyInstaller
-# The resulting binary will be placed in the dist/ directory
-# Ensure PyInstaller is installed
-pip install pyinstaller
+# Build a standalone executable using PyInstaller and create a
+# platform specific installer. Requires Python 3.12.
 
-# Package the CLI entry point validate_hypothesis.py
-pyinstaller --onefile validate_hypothesis.py --name supernova-cli
+PYTHON_BIN=${PYTHON_BIN:-python3}
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "Python interpreter '$PYTHON_BIN' not found."
+    exit 1
+fi
 
-echo "Executable created in dist/ directory"
+# Ensure PyInstaller and platform helpers are installed
+"$PYTHON_BIN" -m pip install --upgrade pyinstaller >/dev/null
+
+# Build the CLI entry point with hidden imports
+"$PYTHON_BIN" -m PyInstaller \
+    --onefile \
+    --name supernova-cli \
+    --hidden-import sqlalchemy \
+    --hidden-import networkx \
+    --hidden-import numpy \
+    validate_hypothesis.py
+
+OS_NAME=$(uname -s)
+
+case "$OS_NAME" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        if command -v makensis >/dev/null 2>&1; then
+            makensis scripts/supernova.nsi
+        else
+            echo "NSIS not found. Skipping Windows installer creation."
+        fi
+        ;;
+    Darwin)
+        "$PYTHON_BIN" -m pip install --upgrade py2app >/dev/null || true
+        if [ -f setup.py ]; then
+            "$PYTHON_BIN" setup.py py2app -A
+        else
+            echo "setup.py not found for py2app build"
+        fi
+        ;;
+    Linux)
+        if command -v appimagetool >/dev/null 2>&1; then
+            APPDIR=dist/AppDir
+            mkdir -p "$APPDIR/usr/bin"
+            cp dist/supernova-cli "$APPDIR/usr/bin/"
+            appimagetool "$APPDIR" dist/supernova-cli.AppImage
+        else
+            echo "appimagetool not found. Skipping AppImage creation."
+        fi
+        ;;
+    *)
+        echo "Unknown platform $OS_NAME. Only the executable will be built."
+        ;;
+esac
+
+echo "Build artifacts created in the dist/ directory"

--- a/scripts/supernova.nsi
+++ b/scripts/supernova.nsi
@@ -1,0 +1,16 @@
+; NSIS installer script for superNova_2177
+OutFile "supernova-setup.exe"
+InstallDir "$PROGRAMFILES\superNova_2177"
+Page directory
+Page instfiles
+Section "Install"
+  SetOutPath $INSTDIR
+  File "dist\supernova-cli.exe"
+  CreateShortcut "$DESKTOP\superNova.lnk" "$INSTDIR\supernova-cli.exe"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$DESKTOP\superNova.lnk"
+  Delete "$INSTDIR\supernova-cli.exe"
+  RMDir $INSTDIR
+SectionEnd


### PR DESCRIPTION
## Summary
- enhance `scripts/build_executable.sh` to create platform installers
- add NSIS script for Windows builds
- add `one_click_install.py` to orchestrate the installer

## Testing
- `pip install python-dateutil`
- `pytest -q` *(fails: ModuleNotFoundError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68859d1f14788320b0227c2bd5b5323a