### PR TITLE
Add cross-platform installer scripts

### DIFF
--- a/one_click_install.py
+++ b/one_click_install.py
@@ -1,0 +1,84 @@
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+
+def _download(url: str, dest: str) -> None:
+    print(f"Downloading {url}...")
+    urllib.request.urlretrieve(url, dest)
+
+
+def _ensure_python312() -> str:
+    """Return path to a Python 3.12 interpreter, installing if necessary."""
+    if sys.version_info >= (3, 12):
+        return sys.executable
+
+    for exe in ("python3.12", "python312", "python3.12.exe", "python.exe"):
+        path = shutil.which(exe)
+        if path:
+            try:
+                out = subprocess.check_output([path, "--version"], text=True)
+            except Exception:
+                continue
+            if out.startswith("Python 3.12"):
+                return path
+
+    system = platform.system()
+    tmp = tempfile.gettempdir()
+    if system == "Windows":
+        installer = os.path.join(tmp, "python312.exe")
+        _download(
+            "https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe",
+            installer,
+        )
+        subprocess.check_call([installer, "/quiet", "InstallAllUsers=1", "PrependPath=1"])
+    elif system == "Darwin":
+        pkg = os.path.join(tmp, "python312.pkg")
+        _download(
+            "https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg",
+            pkg,
+        )
+        subprocess.check_call(["sudo", "installer", "-pkg", pkg, "-target", "/"])
+    else:  # Linux and others
+        if shutil.which("apt-get"):
+            subprocess.check_call(["sudo", "apt-get", "update"])
+            subprocess.check_call(["sudo", "apt-get", "install", "-y", "python3.12", "python3.12-venv"])
+        else:
+            tarball = os.path.join(tmp, "Python-3.12.0.tgz")
+            _download(
+                "https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz",
+                tarball,
+            )
+            build_dir = os.path.join(tmp, "python-build")
+            os.makedirs(build_dir, exist_ok=True)
+            subprocess.check_call(["tar", "xf", tarball, "-C", build_dir])
+            src = os.path.join(build_dir, "Python-3.12.0")
+            subprocess.check_call(
+                ["bash", "-c", f"cd {src} && ./configure --prefix=/usr/local && make -j$(nproc) && sudo make install"]
+            )
+
+    # After installation attempt
+    path = shutil.which("python3.12")
+    if path:
+        return path
+    raise RuntimeError("Python 3.12 installation failed")
+
+
+def main() -> None:
+    python_path = _ensure_python312()
+    env = os.environ.copy()
+    env["PYTHON"] = python_path
+    script = os.path.join(os.path.dirname(__file__), "scripts", "build_executable.sh")
+    if platform.system() == "Windows":
+        cmd = ["bash", script]
+    else:
+        cmd = ["bash", script]
+    subprocess.check_call(cmd, env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP=supernova-cli
+APPDIR=AppDir
+
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+
+cp "dist/$APP" "$APPDIR/usr/bin/"
+
+cat > "$APPDIR/AppRun" <<'EOR'
+#!/bin/sh
+DIR="$(dirname "$0")"
+exec "$DIR/usr/bin/supernova-cli" "$@"
+EOR
+chmod +x "$APPDIR/AppRun"
+
+appimagetool "$APPDIR" "dist/${APP}.AppImage"
+
+echo "AppImage created at dist/${APP}.AppImage"

--- a/scripts/build_executable.sh
+++ b/scripts/build_executable.sh
@@ -1,12 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a standalone executable using PyInstaller
-# The resulting binary will be placed in the dist/ directory
-# Ensure PyInstaller is installed
-pip install pyinstaller
+# Build the superNova_2177 CLI into a platform specific package.
+# This script relies on PyInstaller and additional packaging tools
+# depending on the operating system.  The PYTHON environment variable
+# can be used to explicitly specify the Python executable (defaults
+# to "python3").
 
-# Package the CLI entry point validate_hypothesis.py
-pyinstaller --onefile validate_hypothesis.py --name supernova-cli
+PYTHON="${PYTHON:-python3}"
 
-echo "Executable created in dist/ directory"
+"$PYTHON" -m pip install --upgrade pip
+"$PYTHON" -m pip install --upgrade pyinstaller >/dev/null
+
+echo "Building standalone executable with PyInstaller..."
+"$PYTHON" -m PyInstaller \
+  --onefile \
+  --name supernova-cli \
+  --hidden-import=sqlalchemy \
+  --hidden-import=networkx \
+  --hidden-import=numpy \
+  validate_hypothesis.py
+
+echo "Executable created in dist/"
+
+OS_NAME=$(uname -s)
+case "$OS_NAME" in
+    Darwin*)
+        echo "Packaging macOS .app with py2app..."
+        "$PYTHON" -m pip install --upgrade py2app >/dev/null
+        "$PYTHON" scripts/py2app_setup.py py2app
+        ;;
+    Linux*)
+        echo "Packaging AppImage..."
+        bash scripts/build_appimage.sh
+        ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT*)
+        echo "Packaging Windows installer with NSIS..."
+        makensis scripts/supernova_installer.nsi
+        ;;
+    *)
+        echo "No additional packaging steps for $OS_NAME"
+        ;;
+esac
+

--- a/scripts/py2app_setup.py
+++ b/scripts/py2app_setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+APP = ['validate_hypothesis.py']
+OPTIONS = {
+    'argv_emulation': True,
+    'plist': {'CFBundleName': 'SuperNova 2177'},
+}
+
+setup(
+    app=APP,
+    options={'py2app': OPTIONS},
+    setup_requires=['py2app'],
+)

--- a/scripts/supernova_installer.nsi
+++ b/scripts/supernova_installer.nsi
@@ -1,0 +1,16 @@
+!define APPNAME "SuperNova 2177"
+!define APPEXE "supernova-cli.exe"
+!define OUTPUT "superNova_2177_Installer.exe"
+
+OutFile "${OUTPUT}"
+InstallDir "$PROGRAMFILES\SuperNova2177"
+RequestExecutionLevel admin
+
+Page directory
+Page instfiles
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File "dist\\${APPEXE}"
+    CreateShortCut "$DESKTOP\\${APPNAME}.lnk" "$INSTDIR\\${APPEXE}"
+SectionEnd


### PR DESCRIPTION
## Summary
- enhance `build_executable.sh` with hidden imports and platform packaging
- add NSIS, py2app and AppImage build helpers
- introduce `one_click_install.py` for automatic build and Python 3.12 setup

## Testing
- `python -m py_compile one_click_install.py scripts/py2app_setup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68859d1f14788320b0227c2bd5b5323a