### PR TITLE
Optimize detection modules with caching

### DIFF
--- a/diversity_analyzer.py
+++ b/diversity_analyzer.py
@@ -6,39 +6,71 @@ and recommend certification levels for scientific hypotheses.
 
 This module provides the foundation for automated peer review and consensus
 tracking in the superNova_2177 scientific reasoning system.
+
+This module can be profiled with ``cProfile`` to inspect NumPy-based
+sentiment scoring or other bottlenecks::
+
+    python -m cProfile -s time diversity_analyzer.py
 """
 
 import logging
 from typing import List, Dict, Any
+from functools import lru_cache
 from datetime import datetime
 from statistics import mean
 
 logger = logging.getLogger("superNova_2177.certifier")
+
 
 # --- Configuration ---
 class Config:
     """Configurable thresholds and weights for validation certification."""
 
     # Certification thresholds (0.0 - 1.0)
-    STRONG_THRESHOLD = 0.85          # High confidence, peer-reviewed quality
-    PROVISIONAL_THRESHOLD = 0.65     # Moderate confidence, needs more evidence
-    EXPERIMENTAL_THRESHOLD = 0.45    # Low confidence, early stage
+    STRONG_THRESHOLD = 0.85  # High confidence, peer-reviewed quality
+    PROVISIONAL_THRESHOLD = 0.65  # Moderate confidence, needs more evidence
+    EXPERIMENTAL_THRESHOLD = 0.45  # Low confidence, early stage
 
     # Validation requirements
-    MIN_VALIDATIONS = 2              # Minimum validations for certification
+    MIN_VALIDATIONS = 2  # Minimum validations for certification
 
     # Keyword sets for sentiment analysis
     CONTRADICTION_KEYWORDS = ["contradict", "disagree", "refute", "oppose"]
     AGREEMENT_KEYWORDS = ["support", "agree", "confirm", "verify"]
 
     # Scoring weights (must sum to 1.0)
-    SIGNAL_WEIGHT = 0.3              # Weight for signal_strength field
-    CONFIDENCE_WEIGHT = 0.4          # Weight for confidence field  
-    NOTE_MATCH_WEIGHT = 0.3          # Weight for note sentiment analysis
+    SIGNAL_WEIGHT = 0.3  # Weight for signal_strength field
+    CONFIDENCE_WEIGHT = 0.4  # Weight for confidence field
+    NOTE_MATCH_WEIGHT = 0.3  # Weight for note sentiment analysis
 
     # Reputation system (placeholder)
     DEFAULT_VALIDATOR_REPUTATION = 0.5  # Until reputation tracking implemented
-    MAX_NOTE_SCORE = 1.0             # Maximum boost/penalty from note analysis
+    MAX_NOTE_SCORE = 1.0  # Maximum boost/penalty from note analysis
+
+
+@lru_cache(maxsize=512)
+def _note_sentiment(note: str) -> float:
+    """Return sentiment score for a note."""
+    score = 0.0
+    for keyword in Config.AGREEMENT_KEYWORDS:
+        if keyword in note:
+            score += 0.5
+    for keyword in Config.CONTRADICTION_KEYWORDS:
+        if keyword in note:
+            score -= 0.5
+    return max(min(score, Config.MAX_NOTE_SCORE), -Config.MAX_NOTE_SCORE)
+
+
+@lru_cache(maxsize=512)
+def _score_validation_cached(confidence: float, signal: float, note: str) -> float:
+    """Memoized scoring helper used by :func:`score_validation`."""
+    note_score = _note_sentiment(note)
+    return (
+        Config.CONFIDENCE_WEIGHT * confidence
+        + Config.SIGNAL_WEIGHT * signal
+        + Config.NOTE_MATCH_WEIGHT * (note_score + 1) / 2
+    )
+
 
 def compute_diversity_score(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Compute a simple diversity metric for a list of validations.
@@ -60,6 +92,8 @@ def compute_diversity_score(validations: List[Dict[str, Any]]) -> Dict[str, Any]
         optional ``flags`` if low diversity is detected.  Counts of unique
         fields are also returned for debugging purposes.
     """
+    # For very large datasets consider numpy vectorization; profile with
+    # ``cProfile`` to identify any set-building bottlenecks.
 
     total = len(validations) or 1
 
@@ -84,19 +118,20 @@ def compute_diversity_score(validations: List[Dict[str, Any]]) -> Dict[str, Any]
         "flags": flags,
     }
 
+
 def score_validation(val: Dict[str, Any]) -> float:
     """
     Score a single validation based on confidence, signal strength, and note sentiment.
-    
+
     Args:
         val: Validation dictionary with optional fields:
              - confidence (float): Validator's confidence level (0.0-1.0)
-             - signal_strength (float): Strength of supporting evidence (0.0-1.0)  
+             - signal_strength (float): Strength of supporting evidence (0.0-1.0)
              - note (str): Free-text validation commentary
-             
+
     Returns:
         float: Quality score between 0.0 and 1.0
-        
+
     Scientific Basis:
         Combines quantitative metrics (confidence, signal) with qualitative
         analysis (note sentiment) using configurable weights.
@@ -106,24 +141,7 @@ def score_validation(val: Dict[str, Any]) -> float:
         signal = float(val.get("signal_strength", 0.5))
         note = str(val.get("note", "")).lower()
 
-        # Sentiment analysis on validation note
-        note_score = 0.0
-        for keyword in Config.AGREEMENT_KEYWORDS:
-            if keyword in note:
-                note_score += 0.5
-        for keyword in Config.CONTRADICTION_KEYWORDS:
-            if keyword in note:
-                note_score -= 0.5
-
-        # Clamp note score to reasonable bounds
-        note_score = max(min(note_score, Config.MAX_NOTE_SCORE), -Config.MAX_NOTE_SCORE)
-
-        # Weighted combination of all factors
-        final_score = (
-            Config.CONFIDENCE_WEIGHT * confidence +
-            Config.SIGNAL_WEIGHT * signal +
-            Config.NOTE_MATCH_WEIGHT * (note_score + 1) / 2  # Normalize to 0-1 range
-        )
+        final_score = _score_validation_cached(confidence, signal, note)
 
         return max(0.0, min(1.0, final_score))  # Ensure valid range
 
@@ -131,13 +149,14 @@ def score_validation(val: Dict[str, Any]) -> float:
         logger.warning(f"Malformed validation dict: {val} — {e}")
         return 0.0
 
+
 def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Analyze a list of validations and return certification summary.
-    
+
     Args:
         validations: List of validation dictionaries
-        
+
     Returns:
         Dict containing:
         - certified_validations: Original validations (for transparency)
@@ -145,10 +164,10 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
         - recommended_certification: Certification level string
         - flags: List of detected issues
         - diversity: Diversity analysis results
-        
+
     Certification Levels:
         - "strong": High consensus, peer-reviewed quality
-        - "provisional": Moderate consensus, needs more evidence  
+        - "provisional": Moderate consensus, needs more evidence
         - "experimental": Low consensus, early stage research
         - "disputed": Contains contradictions
         - "weak": Below experimental threshold
@@ -160,7 +179,7 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
             "consensus_score": 0.0,
             "recommended_certification": "insufficient_data",
             "flags": ["too_few_validations"],
-            "diversity": {}
+            "diversity": {},
         }
 
     # Score each validation
@@ -169,7 +188,10 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     # Check for contradictions
     contradictory = any(
-        any(keyword in str(v.get("note", "")).lower() for keyword in Config.CONTRADICTION_KEYWORDS)
+        any(
+            keyword in str(v.get("note", "")).lower()
+            for keyword in Config.CONTRADICTION_KEYWORDS
+        )
         for v in validations
     )
 
@@ -190,7 +212,10 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
         diversity_result = compute_diversity_score(validations)
     except Exception as e:
         logger.warning(f"Diversity analysis failed: {e}")
-        diversity_result = {"diversity_score": 0.0, "flags": ["diversity_analysis_failed"]}
+        diversity_result = {
+            "diversity_score": 0.0,
+            "flags": ["diversity_analysis_failed"],
+        }
 
     # Adjust certification based on low diversity
     if diversity_result.get("diversity_score", 0) < 0.3 and certification == "strong":
@@ -202,7 +227,7 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
         "consensus_score": round(avg_score, 3),
         "recommended_certification": certification,
         "flags": [],
-        "diversity": diversity_result
+        "diversity": diversity_result,
     }
 
     if contradictory:
@@ -212,13 +237,32 @@ def certify_validations(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
     if "low_diversity" in diversity_result.get("flags", []):
         result["flags"].append("low_diversity")
 
-    logger.info(f"Certified {len(validations)} validations: {certification} (score: {avg_score:.3f})")
+    logger.info(
+        f"Certified {len(validations)} validations: {certification} (score: {avg_score:.3f})"
+    )
 
     return result
 
+
 # TODO v4.3 Enhancements:
 # - Add validator reputation tracking
-# - Implement temporal consistency analysis  
+# - Implement temporal consistency analysis
 # - Add cross-validation detection
 # - Include diversity scoring (multiple validator types)
 # - Add semantic contradiction detection beyond keywords
+
+# Basic profiling hook. Execute this file directly to profile certification
+# over a ``sample_validations.json`` dataset.
+if __name__ == "__main__":  # pragma: no cover - manual profiling
+    import cProfile
+    import json
+    import pstats
+    from pathlib import Path
+
+    sample = Path("sample_validations.json")
+    data = json.loads(sample.read_text()) if sample.exists() else []
+    profiler = cProfile.Profile()
+    profiler.enable()
+    certify_validations(data)
+    profiler.disable()
+    pstats.Stats(profiler).sort_stats("cumtime").print_stats(10)


### PR DESCRIPTION
## Summary
- memoize timestamp parsing in network coordination detector
- cache expensive sentence embeddings
- add profiling hooks and suggestions in comments
- memoize note sentiment and scoring in diversity analyzer
- add basic profiling entry points for both modules

## Testing
- `pytest tests/test_network_coordination_detector.py::test_analyze_coordination_patterns_detects_clusters tests/test_diversity_analyzer.py::test_compute_diversity_score_basic -q`
- `pytest -q` *(fails: TypeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68859d46c5088320a0128e0db90227bb