### PR TITLE
Add Streamlit demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,25 @@ jupyter notebook docs/Validation_Pipeline.ipynb
 jupyter notebook docs/Network_Graph_Visualization.ipynb
 ```
 
+## ☁️ Streamlit Cloud Deployment
+
+The `app.py` script provides a simple web interface for the validation
+pipeline. To deploy it on **Streamlit Cloud**:
+
+1. Fork this repository or push it to your own GitHub account.
+2. Visit [Streamlit Cloud](https://streamlit.io/cloud) and create a **New app**.
+3. Select your repository, choose the branch to deploy, and set `app.py` as the
+   entry point.
+4. Ensure `requirements.txt` is included so dependencies install automatically.
+5. Click **Deploy**. After the build completes you'll receive a public URL for
+   your hosted app.
+
+You can also run the interface locally with:
+
+```bash
+streamlit run app.py
+```
+
 ## 🏗️ Architecture (v4.6)
 
 * `validation_integrity_pipeline.py` — Orchestrator for full validation logic

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+import json
+import networkx as nx
+import matplotlib.pyplot as plt
+import streamlit as st
+
+from validation_integrity_pipeline import analyze_validation_integrity
+from validate_hypothesis import generate_demo_validations
+from network.network_coordination_detector import build_validation_graph
+
+
+def load_validations(file):
+    data = json.load(file)
+    if isinstance(data, list):
+        return data
+    return data.get("validations", [])
+
+
+def run_analysis(validations):
+    result = analyze_validation_integrity(validations)
+    graph_info = build_validation_graph(validations)
+    edges = graph_info.get("edges", [])
+    nodes = list(graph_info.get("nodes", []))
+
+    G = nx.Graph()
+    G.add_nodes_from(nodes)
+    G.add_weighted_edges_from(edges)
+
+    fig, ax = plt.subplots()
+    pos = nx.spring_layout(G, seed=42)
+    nx.draw_networkx(G, pos, ax=ax, with_labels=True, node_color="#7fa9d6")
+    ax.set_axis_off()
+    return result, fig
+
+
+def main():
+    st.title("superNova_2177 Validation Demo")
+    st.write("Upload a JSON validation file or run with demo data.")
+
+    option = st.radio("Input Source", ["Demo Data", "Upload JSON"])
+    uploaded_file = None
+    if option == "Upload JSON":
+        uploaded_file = st.file_uploader("Select validation JSON", type="json")
+
+    if st.button("Run Analysis"):
+        if option == "Demo Data":
+            validations = generate_demo_validations()
+        else:
+            if uploaded_file is None:
+                st.error("Please upload a JSON file.")
+                return
+            try:
+                validations = load_validations(uploaded_file)
+            except Exception as e:
+                st.error(f"Invalid JSON: {e}")
+                return
+
+        with st.spinner("Running analysis..."):
+            result, fig = run_analysis(validations)
+
+        st.subheader("Analysis Result")
+        st.json(result)
+
+        st.subheader("Validation Graph")
+        st.pyplot(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "mido",
     "midiutil",
     "torch",
-    "scikit-learn"
+    "scikit-learn",
+    "streamlit"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ mido
 midiutil
 torch
 scikit-learn
+streamlit

--- a/validation_integrity_pipeline.py
+++ b/validation_integrity_pipeline.py
@@ -1,0 +1,1 @@
+from validation_certifier import *


### PR DESCRIPTION
## Summary
- add Streamlit-based `app.py` for running the validation demo
- add alias `validation_integrity_pipeline.py` for compatibility
- document Streamlit Cloud deployment
- include Streamlit dependency

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859d57241083209c6beeffd9b5a3ca