### PR TITLE
Add RFC for LLM integration

### DIFF
--- a/rfcs/008-llm-integration/README.md
+++ b/rfcs/008-llm-integration/README.md
@@ -1,0 +1,20 @@
+# LLM Integration
+
+## Problem Statement
+The current validation workflow depends on manually crafted hypotheses and step-by-step user input. This limits the speed and variety of checks that can be performed because every scenario must be typed out or pre‑written.
+
+## Proposed Solution
+Introduce a `llm_analyzer.py` module that interfaces with open‑source language models. The script would accept historical logs and hypothesis templates, send them to a local or Hugging Face model, and return suggested hypotheses or validations. Results could then be fed back into existing pipelines for automated exploration.
+
+## Alternatives
+* Use a hosted API service to generate suggestions, which reduces local requirements but creates network dependencies.
+* Ship lightweight local models only, which avoids external calls but may reduce output quality.
+
+## Impact
+Adding an optional LLM layer increases modularity by separating natural‑language reasoning from core analytics. There will be a performance cost when models are loaded, but this can be mitigated with caching and asynchronous execution.
+
+## Implementation Steps
+1. Create `llm_analyzer.py` with functions to load a model and produce hypothesis suggestions.
+2. Add configuration options for choosing between Hugging Face endpoints or local weights.
+3. Extend validation scripts to optionally call the LLM module for augmented checks.
+4. Document usage and provide examples in the demos directory.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -49,3 +49,9 @@ Explain the expected benefits and any potential downsides.
 | Number | Title |
 |-------|-------|
 | [001](001-gui-integration/README.md) | Streamlit GUI Integration |
+
+### LLM Integration
+
+| Number | Title |
+|-------|-------|
+| [008](008-llm-integration/README.md) | LLM Integration |


### PR DESCRIPTION
## Summary
- propose using open-source language models to generate hypotheses
- document optional LLM analyzer
- list RFC in the main index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885a3b2028883209d8b7e6fe014a788