### PR TITLE
Add build_all_installers script

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ On Windows, use the PowerShell version:
 scripts/build_executable.ps1
 ```
 
+To build installers for all supported platforms in one step, execute:
+
+```bash
+scripts/build_all_installers.sh
+```
+
+This wrapper calls `build_executable.sh`, `build_executable.ps1`,
+`build_appimage.sh`, and `supernova_installer.nsi` in sequence to create the
+`.msi`, `.dmg`, and `.AppImage` files inside `dist/`.
+
 The generated executable will be placed under `dist/` as `supernova-cli` on
 Unix systems or `supernova-cli.exe` on Windows.
 

--- a/scripts/build_all_installers.sh
+++ b/scripts/build_all_installers.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build installers for all supported platforms.
+# This script sequentially invokes:
+#   1. build_executable.sh     - builds the CLI and packages for the current OS
+#   2. build_executable.ps1    - Windows executable via PowerShell
+#   3. build_appimage.sh       - AppImage packaging
+#   4. supernova_installer.nsi - MSI installer via NSIS
+#
+# The resulting .dmg, .AppImage and .msi files will be placed in the dist/ directory.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Step 1: Build the executable for the current platform
+bash scripts/build_executable.sh
+
+# Step 2: Build Windows executable using PowerShell if available
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh -File scripts/build_executable.ps1
+else
+    echo "Warning: pwsh not found; skipping Windows executable build"
+fi
+
+# Step 3: Build AppImage if on Linux
+if [[ "$(uname -s)" == "Linux" ]]; then
+    bash scripts/build_appimage.sh
+fi
+
+# Step 4: Build Windows MSI installer with NSIS if available
+if command -v makensis >/dev/null 2>&1; then
+    makensis scripts/supernova_installer.nsi
+else
+    echo "Warning: makensis not found; skipping MSI installer"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/build_all_installers.sh` to orchestrate packaging
- document the new script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ae1d43bc8320803b03cbc9d7fe05