### PR TITLE
Add cross-platform installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ supernova-validate --validations sample_validations.json
    # python setup_env.py --run-app    # launch API after install
    # python setup_env.py --build-ui   # build NiceGUI frontend assets
    ```
+   You can also let `install.py` choose the appropriate installer for your
+   platform:
+   ```bash
+   python install.py
+   ```
   Or install the published wheel directly from PyPI:
   ```bash
   # Linux/macOS

--- a/install.py
+++ b/install.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    system = platform.system()
+
+    if system == "Windows":
+        ps1 = root / "online_install.ps1"
+        bat = root / "install" / "install_desktop.bat"
+        if shutil.which("powershell"):
+            cmd = ["powershell", "-ExecutionPolicy", "Bypass", str(ps1)]
+        else:
+            cmd = ["cmd", "/c", str(bat)]
+    elif system == "Darwin":
+        cmd = ["bash", str(root / "install" / "install_desktop.sh")]
+    elif system == "Linux":
+        if os.environ.get("ANDROID_ROOT") or os.environ.get("TERMUX_VERSION"):
+            cmd = ["bash", str(root / "install" / "install_desktop.sh")]
+        else:
+            cmd = ["bash", str(root / "online_install.sh")]
+    else:
+        print(f"Unsupported operating system: {system}", file=sys.stderr)
+        sys.exit(1)
+
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `install.py` wrapper that chooses the right installer script
- update installation docs to mention `python install.py`

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: dateutil)*
- `pytest -q` *(fails: ModuleNotFoundError: dateutil)*

------
https://chatgpt.com/codex/tasks/task_e_6885afbd79f0832095c394e3cdc0dbf9