### PR TITLE
Build installers on CI

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -1,0 +1,53 @@
+name: Build Installers
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        if: runner.os == 'Windows'
+        run: choco install nsis -y
+      - name: Install AppImage tool
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2
+          wget https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          sudo mv appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
+      - name: Build executable
+        run: bash scripts/build_executable.sh
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-installer
+          path: |
+            dist/*.msi
+            dist/*.dmg
+            dist/*.AppImage
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./artifacts/**

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Unix systems or `supernova-cli.exe` on Windows.
 
 ### Running the Installer
 
-If you're on Windows, download `supernova-cli.exe` from the GitHub Releases page
+If you're on Windows, download `supernova-cli.exe` from the [GitHub Releases page](https://github.com/BP-H/superNova_2177/releases/latest)
 or build it yourself with the script above. Before launching, set the required
 environment variables so the application can connect to its services. `SECRET_KEY`
 is optional because a secure one will be generated if omitted:
@@ -201,8 +201,8 @@ After setting the variables, execute the binary directly:
 
 ### One-Click Installers
 
-Prebuilt installers for each platform can be found in the `dist/` directory. The
-installer bundles Python 3.12 and all dependencies so it works offline:
+Prebuilt installers for each platform are published under the [Releases page](https://github.com/BP-H/superNova_2177/releases).
+Each installer bundles Python 3.12 and all dependencies so it works offline:
 
 * **Windows** – run `SuperNova_2177.msi` to install the CLI.
 * **macOS** – open `supernova-cli.dmg` and drag the app to `Applications`.


### PR DESCRIPTION
## Summary
- add a workflow to build installers on Linux, macOS and Windows
- upload the generated installers to Releases
- mention Releases in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885afbf083083209e5fa38cd4728a04