### PR TITLE
Add qrcode to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ midiutil
 torch
 scikit-learn
 streamlit>=1.28
+qrcode


### PR DESCRIPTION
## Summary
- include `qrcode` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885b2de09a883209bbffafdbfa4cbe1