### PR TITLE
Fix Python detection in desktop installer

### DIFF
--- a/install/install_desktop.sh
+++ b/install/install_desktop.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-set -e
-python3 -m venv venv
+set -euo pipefail
+
+PYTHON="${PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    PYTHON=python
+fi
+
+"$PYTHON" -m venv venv
 source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- improve `install_desktop.sh` reliability
  - use `set -euo pipefail`
  - detect python interpreter via `${PYTHON:-python3}` like in `online_install.sh`
  - create virtualenv using the detected interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b2e45f888320a9dab7f722c836b3