### PR TITLE
Add Python version check

### DIFF
--- a/install.py
+++ b/install.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 
 def main() -> None:
+    if sys.version_info < (3, 12):
+        print(
+            "Error: Python 3.12 or newer is required to run this installer.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     root = Path(__file__).resolve().parent
     system = platform.system()
 


### PR DESCRIPTION
## Summary
- ensure installer only runs on Python 3.12+

## Testing
- `pytest -q` *(fails: TypeError 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6885b35891e483209825cebee60935bb