### PR TITLE
Add linting tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt mypy
+      - run: pip install -r requirements.txt mypy black ruff
+      - run: black --check .
+      - run: ruff .
       - run: mypy
       - run: pytest -q

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,5 +12,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt black ruff
+      - run: black --check .
+      - run: ruff .
       - run: pytest -q

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,3 +29,14 @@ The GitHub Actions workflows (`.github/workflows/ci.yml` and `pr-tests.yml`) run
 ## Optional Frontend
 
 The `transcendental-resonance-frontend/` directory contains a NiceGUI-based UI. Follow its README to install `pip install -r transcendental-resonance-frontend/requirements.txt` and run the frontend if desired.
+
+## Linting and Formatting
+
+Run the linters before committing changes:
+
+```bash
+make lint
+```
+
+This executes `black --check`, `ruff`, and `mypy` using the configuration in `pyproject.toml`.
+

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,6 @@ test:
 	pytest -q
 
 lint:
+	black --check .
+	ruff .
 	mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,11 @@ supernova-milestone = "milestone_cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["*"]
+
+[tool.black]
+target-version = ["py312"]
+line-length = 88
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ midiutil
 torch
 scikit-learn
 streamlit>=1.28
+
+black
+ruff


### PR DESCRIPTION
## Summary
- integrate `black` and `ruff` into CI
- run the new tools from `make lint`
- document local lint usage
- configure tools in `pyproject.toml`
- list `black` and `ruff` in requirements

## Testing
- `black --check .` *(fails: would reformat files)*
- `ruff check .` *(fails: many lint errors)*
- `mypy`
- `pytest -q` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6885b3472c3483209f84d6981c07ae47