### PR TITLE
Enforce uniqueness of branch votes

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
+    UniqueConstraint,
     Table,
     Float,
     JSON,
@@ -516,6 +517,10 @@ class BranchVote(Base):
     voter_id = Column(ForeignKey("harmonizers.id"), nullable=False)
     vote = Column(Boolean, nullable=False)
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("branch_id", "voter_id", name="unique_branch_voter"),
+    )
 
 
 class TokenListing(Base):

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -110,6 +110,13 @@ def vote_fork(args: argparse.Namespace) -> None:
         if not fork or not voter:
             print("Fork or voter not found")
             return
+        # Avoid duplicate votes from the same harmonizer
+        existing = db.query(BranchVote).filter_by(
+            branch_id=fork.id, voter_id=voter.id
+        ).first()
+        if existing:
+            print("Vote already recorded for this fork")
+            return
         vote_bool = args.vote.lower() == "yes"
         record = BranchVote(
             branch_id=fork.id,

--- a/tests/test_branch_vote.py
+++ b/tests/test_branch_vote.py
@@ -1,0 +1,32 @@
+import datetime
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from db_models import Harmonizer, UniverseBranch, BranchVote
+
+
+def test_branch_vote_unique_constraint(test_db):
+    fork = UniverseBranch(
+        id="f1",
+        creator_id=None,
+        karma_at_fork=0.0,
+        config={},
+        timestamp=datetime.datetime.utcnow(),
+        status="active",
+    )
+    voter = Harmonizer(username="alice", email="a@example.com", hashed_password="x")
+    test_db.add_all([fork, voter])
+    test_db.commit()
+
+    vote1 = BranchVote(branch_id=fork.id, voter_id=voter.id, vote=True)
+    test_db.add(vote1)
+    test_db.commit()
+
+    vote2 = BranchVote(branch_id=fork.id, voter_id=voter.id, vote=False)
+    test_db.add(vote2)
+    with pytest.raises(IntegrityError):
+        test_db.commit()
+    test_db.rollback()
+
+    votes = test_db.query(BranchVote).filter_by(branch_id=fork.id).all()
+    assert len(votes) == 1


### PR DESCRIPTION
## Summary
- ensure BranchVote records are unique per `(branch_id, voter_id)`
- reject duplicate votes in the federation CLI
- test BranchVote uniqueness

## Testing
- `pytest -q tests/test_branch_vote.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b66403cc83208bd57c1b243dbc20