### PR TITLE
Fix federation_cli JSON serialization

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -69,9 +69,13 @@ def list_forks(_args: argparse.Namespace) -> None:
     try:
         forks = db.query(UniverseBranch).all()
         for f in forks:
+            try:
+                config_json = json.dumps(f.config, default=str)
+            except TypeError as exc:  # pragma: no cover - unexpected type error
+                config_json = f"<serialization error: {exc}>"
             print(
                 f.id,
-                json.dumps(f.config),
+                config_json,
                 f"consensus={f.consensus:.2f}",
                 f"divergence={f.entropy_divergence:.2f}",
             )
@@ -96,7 +100,10 @@ def fork_info(args: argparse.Namespace) -> None:
             "entropy_divergence": fork.entropy_divergence,
             "consensus": fork.consensus,
         }
-        print(json.dumps(info, indent=2))
+        try:
+            print(json.dumps(info, indent=2, default=str))
+        except TypeError as exc:  # pragma: no cover - unexpected type error
+            print(f"Error serializing fork info: {exc}")
     finally:
         db.close()
 

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,0 +1,67 @@
+import argparse
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import federation_cli
+from federation_cli import list_forks, fork_info
+
+
+class DummySession:
+    def __init__(self, fork):
+        self.fork = fork
+        self.filter_id = None
+
+    def query(self, _model):
+        session = self
+
+        class DummyQuery:
+            def all(self):
+                return [session.fork]
+
+            def filter_by(self, **kw):
+                session.filter_id = kw.get("id")
+                return self
+
+            def first(self):
+                if session.filter_id is None or session.filter_id == session.fork.id:
+                    return session.fork
+                return None
+
+        return DummyQuery()
+
+    def close(self):
+        pass
+
+
+def _patch_session(monkeypatch, fork):
+    monkeypatch.setattr(federation_cli, "SessionLocal", lambda: DummySession(fork))
+
+
+def _make_fork():
+    return SimpleNamespace(
+        id="fid",
+        creator_id=1,
+        karma_at_fork=0.0,
+        config={"d": Decimal("1.5")},
+        timestamp=datetime.datetime.utcnow(),
+        status="active",
+        entropy_divergence=0.0,
+        consensus=0.0,
+    )
+
+
+def test_list_forks_serializes_decimal_config(monkeypatch, capsys):
+    fork = _make_fork()
+    _patch_session(monkeypatch, fork)
+    list_forks(argparse.Namespace())
+    out = capsys.readouterr().out
+    assert '"d": "1.5"' in out
+
+
+def test_fork_info_serializes_decimal_config(monkeypatch, capsys):
+    fork = _make_fork()
+    _patch_session(monkeypatch, fork)
+    fork_info(argparse.Namespace(fork_id=fork.id))
+    out = capsys.readouterr().out
+    assert '"d": "1.5"' in out


### PR DESCRIPTION
## Summary
- serialize fork config via `json.dumps(..., default=str)` when listing forks or showing fork info
- handle serialization `TypeError`s with user-friendly output
- add tests for `federation_cli` JSON serialization with non-serializable config values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885b65c01488320a5c9d79848d50cea