### PR TITLE
Prevent duplicate branch votes

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     Table,
     Float,
     JSON,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import sessionmaker, relationship, Session
 
@@ -510,6 +511,10 @@ class BranchVote(Base):
     """Vote for or against a universe branch."""
 
     __tablename__ = "branch_votes"
+
+    __table_args__ = (
+        UniqueConstraint("branch_id", "voter_id", name="uix_branch_vote"),
+    )
 
     id = Column(Integer, primary_key=True)
     branch_id = Column(ForeignKey("universe_branches.id"), nullable=False)

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -110,6 +110,13 @@ def vote_fork(args: argparse.Namespace) -> None:
         if not fork or not voter:
             print("Fork or voter not found")
             return
+        if (
+            db.query(BranchVote)
+            .filter_by(branch_id=fork.id, voter_id=voter.id)
+            .first()
+        ):
+            print("Voter has already voted on this branch")
+            return
         vote_bool = args.vote.lower() == "yes"
         record = BranchVote(
             branch_id=fork.id,

--- a/migrations/001_add_branchvote_unique_constraint.py
+++ b/migrations/001_add_branchvote_unique_constraint.py
@@ -1,0 +1,17 @@
+from sqlalchemy import text
+from db_models import engine
+
+
+def migrate() -> None:
+    """Add unique constraint on branch_votes(branch_id, voter_id)."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ux_branch_vote_branch_voter ON branch_votes (branch_id, voter_id)"
+            )
+        )
+
+
+if __name__ == "__main__":
+    migrate()
+    print("Added unique constraint on branch_votes(branch_id, voter_id)")

--- a/tests/test_branch_vote.py
+++ b/tests/test_branch_vote.py
@@ -1,0 +1,84 @@
+import argparse
+import datetime
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from db_models import (
+    SessionLocal,
+    init_db,
+    Base,
+    engine,
+    Harmonizer,
+    UniverseBranch,
+    BranchVote,
+)
+from federation_cli import vote_fork
+
+
+def test_branch_vote_unique_constraint():
+    init_db()
+    db = SessionLocal()
+    try:
+        h = Harmonizer(
+            id=1,
+            username="alice",
+            email="alice@example.com",
+            hashed_password="x",
+            karma_score=0,
+        )
+        b = UniverseBranch(
+            id="b1",
+            creator_id=1,
+            karma_at_fork=0,
+            config={},
+            timestamp=datetime.datetime.utcnow(),
+            status="active",
+        )
+        db.add_all([h, b])
+        db.commit()
+
+        vote1 = BranchVote(branch_id="b1", voter_id=1, vote=True)
+        db.add(vote1)
+        db.commit()
+
+        vote2 = BranchVote(branch_id="b1", voter_id=1, vote=False)
+        db.add(vote2)
+        with pytest.raises(IntegrityError):
+            db.commit()
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def test_vote_fork_prevents_duplicate(capsys):
+    init_db()
+    db = SessionLocal()
+    try:
+        h = Harmonizer(
+            id=2,
+            username="bob",
+            email="bob@example.com",
+            hashed_password="y",
+            karma_score=0,
+        )
+        b = UniverseBranch(
+            id="b2",
+            creator_id=2,
+            karma_at_fork=0,
+            config={},
+            timestamp=datetime.datetime.utcnow(),
+            status="active",
+        )
+        db.add_all([h, b])
+        db.commit()
+    finally:
+        db.close()
+
+    args = argparse.Namespace(fork_id="b2", voter="bob", vote="yes")
+    vote_fork(args)
+    vote_fork(args)
+    out = capsys.readouterr().out.lower()
+    assert "already voted" in out
+    Base.metadata.drop_all(bind=engine)
+
+


### PR DESCRIPTION
## Summary
- enforce uniqueness on branch votes by `(branch_id, voter_id)`
- prevent duplicate voting in the CLI
- provide migration script for existing databases
- add tests for branch vote uniqueness and CLI behaviour

## Testing
- `mypy`
- `pytest -q` *(fails: test_network_coordination_detector::test_analyze_coordination_patterns_detects_clusters, test_network_coordination_detector::test_detect_semantic_coordination_embeddings)*

------
https://chatgpt.com/codex/tasks/task_e_6885b68014d48320ae3dc02768b92fc6