### PR TITLE
Improve federation CLI error handling

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -69,9 +69,14 @@ def list_forks(_args: argparse.Namespace) -> None:
     try:
         forks = db.query(UniverseBranch).all()
         for f in forks:
+            try:
+                config_str = json.dumps(f.config)
+            except TypeError as exc:  # pragma: no cover - rare edge
+                print(f"Warning: failed to serialize config for {f.id}: {exc}")
+                config_str = repr(f.config)
             print(
                 f.id,
-                json.dumps(f.config),
+                config_str,
                 f"consensus={f.consensus:.2f}",
                 f"divergence={f.entropy_divergence:.2f}",
             )
@@ -96,7 +101,12 @@ def fork_info(args: argparse.Namespace) -> None:
             "entropy_divergence": fork.entropy_divergence,
             "consensus": fork.consensus,
         }
-        print(json.dumps(info, indent=2))
+        try:
+            print(json.dumps(info, indent=2))
+        except TypeError as exc:  # pragma: no cover - rare edge
+            print(f"Warning: failed to serialize info: {exc}")
+            info["config"] = repr(fork.config)
+            print(json.dumps(info, indent=2))
     finally:
         db.close()
 

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,0 +1,46 @@
+import argparse
+import datetime
+
+import federation_cli as cli
+
+class _Fork:
+    id = "f1"
+    creator_id = None
+    karma_at_fork = 0.0
+    config = {"bad": {1}}
+    timestamp = datetime.datetime.utcnow()
+    status = "active"
+    entropy_divergence = 0.0
+    consensus = 0.0
+
+class _Query:
+    def all(self):
+        return [_Fork]
+
+    def filter_by(self, **_kw):
+        return self
+
+    def first(self):
+        return _Fork
+
+class _Session:
+    def query(self, *_a, **_kw):
+        return _Query()
+
+    def close(self):
+        pass
+
+def _factory():
+    return _Session()
+
+def test_serialization_fallback(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "SessionLocal", _factory)
+    cli.list_forks(argparse.Namespace())
+    out = capsys.readouterr().out
+    assert "Warning: failed to serialize config" in out
+    assert "{1}" in out
+
+    cli.fork_info(argparse.Namespace(fork_id="f1"))
+    out = capsys.readouterr().out
+    assert "Warning: failed to serialize info" in out
+    assert "{1}" in out


### PR DESCRIPTION
## Summary
- improve serialization handling in `list_forks` and `fork_info`
- warn and fallback to `repr` on JSON encoding errors
- add regression test for CLI serialization failures

## Testing
- `pytest tests/test_federation_cli.py::test_serialization_fallback -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b905f1e48320bba24f0e305ec524