### PR TITLE
Handle missing tqdm in offline installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ docker-compose up --build
 python one_click_install.py
 ```
 
+This script automatically installs the `tqdm` package if it isn't available so
+that progress bars work out of the box.
+
 This project relies on features introduced in **SQLAlchemy 2.x** such as
 `DeclarativeBase`. Ensure you have `sqlalchemy>=2.0` installed. The code also
 requires `python-dateutil` for timestamp parsing.

--- a/one_click_install.py
+++ b/one_click_install.py
@@ -6,7 +6,12 @@ import sys
 import tempfile
 import urllib.request
 import hashlib
-from tqdm import tqdm
+
+try:
+    from tqdm import tqdm
+except ImportError:  # pragma: no cover - only triggered in rare cases
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "tqdm"])
+    from tqdm import tqdm
 
 OFFLINE_DIR = "offline_deps"
 ENV_DIR = "venv"


### PR DESCRIPTION
## Summary
- ensure `one_click_install.py` installs `tqdm` if it's missing
- document this automatic install in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b8c674f88320b76bf67ce79b2678