### PR TITLE
Enforce Python 3.12 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ supernova-validate --validations sample_validations.json
 
 ### Step-by-Step
 
-1. **Install Python 3.12** from [python.org](https://www.python.org/) if it isn't
-   already on your machine. You can check by running `python --version` in your
-   terminal.
+1. **Install Python 3.12 or newer** from [python.org](https://www.python.org/)
+   if it isn't already on your machine. This project requires Python 3.12+.
+   You can check by running `python --version` in your terminal.
 2. **Run the setup script** to create the virtual environment and install all
    dependencies locally. You can also pass `--locked` to install packages from
    `requirements.lock` for deterministic builds. Additional flags `--run-app`

--- a/setup_env.py
+++ b/setup_env.py
@@ -72,6 +72,8 @@ def build_web_ui(pip: list) -> None:
 
 
 def main() -> None:
+    if sys.version_info < (3, 12):
+        sys.exit("Python 3.12 or newer is required.")
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(description='Set up the environment')
     parser.add_argument('--run-app', action='store_true', help='start the API after installation')


### PR DESCRIPTION
## Summary
- exit if running `setup_env.py` under Python older than 3.12
- clarify the Python requirement in the installation instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b8c495ac8320b3685136f5ce59d3