### PR TITLE
Install from local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ supernova-validate --validations sample_validations.json
    ```bash
    python install.py
    ```
-  Or install the published wheel directly from PyPI:
+Or install the package from this repository using the helper scripts:
   ```bash
   # Linux/macOS
   ./online_install.sh

--- a/online_install.ps1
+++ b/online_install.ps1
@@ -16,7 +16,7 @@ if (-not $env:VIRTUAL_ENV) {
 }
 
 pip install --upgrade pip
-pip install supernova-2177
+pip install .
 
 if (Test-Path '.env.example' -and -not (Test-Path '.env')) {
     Copy-Item '.env.example' '.env'

--- a/online_install.sh
+++ b/online_install.sh
@@ -18,7 +18,7 @@ if [[ -z "${VIRTUAL_ENV:-}" ]]; then
 fi
 
 pip install --upgrade pip
-pip install supernova-2177
+pip install .
 
 if [ -f ".env.example" ] && [ ! -f ".env" ]; then
     cp .env.example .env


### PR DESCRIPTION
## Summary
- install supernova from the current repository in installation helpers
- update README wording for the new installation method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885b8c064808320abab52f7e71c833a