### PR TITLE
Add asyncpg dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "midiutil",
     "torch",
     "scikit-learn",
-    "streamlit"
+    "streamlit",
+    "asyncpg"
 ]
 
 [project.scripts]

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,7 @@
 altair==5.5.0
 annotated-types==0.7.0
 anyio==4.9.0
+asyncpg==0.30.0
 attrs==25.3.0
 bcrypt==4.3.0
 black==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ torch
 scikit-learn
 streamlit>=1.28
 qrcode
+asyncpg


### PR DESCRIPTION
## Summary
- add `asyncpg` dependency to requirements
- include asyncpg in pyproject
- update lock file

## Testing
- `pip install python-dateutil numpy`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6885b8bea308832082fba8e35a85e2b7