### PR TITLE
Fix PyPI wheel note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ supernova-validate --validations sample_validations.json
    ```bash
    python install.py
    ```
-  Or install the published wheel directly from PyPI:
+  A PyPI wheel is currently unavailable. Run `python setup_env.py` or use the online installer scripts:
   ```bash
   # Linux/macOS
   ./online_install.sh


### PR DESCRIPTION
## Summary
- clarify that a PyPI wheel is not yet available
- direct users to run `python setup_env.py` or the online installers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885b8b6c8a48320a13336a2819545d2