### PR TITLE
Add numeric validation in fork CLI

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -34,9 +34,22 @@ def create_fork(args: argparse.Namespace) -> None:
             print("Creator not eligible for forking")
             return
         config = dict(pair.split("=", 1) for pair in args.config or [])
-        invalid_keys = [k for k in config if not hasattr(Config, k)]
+        invalid_keys = [k for k in config if not hasattr(Config, k) and k != "entropy_threshold"]
         if invalid_keys:
             print(f"Invalid config keys: {', '.join(invalid_keys)}")
+            return
+
+        numeric_errors = []
+        for key, value in config.items():
+            try:
+                if float(value) <= 0:
+                    numeric_errors.append(key)
+            except ValueError:
+                # Non-numeric values are ignored
+                continue
+        if numeric_errors:
+            joined = ", ".join(numeric_errors)
+            print(f"Parameters must be > 0: {joined}")
             return
         cooldown = Config.FORK_COOLDOWN_SECONDS
         if (

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,0 +1,20 @@
+import argparse
+from federation_cli import create_fork
+from db_models import Harmonizer
+
+
+def test_create_fork_numeric_validation(monkeypatch, capsys, test_db):
+    user = Harmonizer(
+        username="alice",
+        email="a@example.com",
+        hashed_password="pw",
+        karma_score=100.0,
+    )
+    test_db.add(user)
+    test_db.commit()
+    monkeypatch.setattr("federation_cli.SessionLocal", lambda: test_db)
+
+    args = argparse.Namespace(creator="alice", config=["entropy_threshold=-1"])
+    create_fork(args)
+    out = capsys.readouterr().out
+    assert "Parameters must be > 0" in out


### PR DESCRIPTION
## Summary
- validate numeric parameters in `create_fork`
- allow `entropy_threshold` as custom key
- test CLI validation for invalid numeric input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885b896883083208042261602e1b82c