### PR TITLE
Prevent duplicate branch votes

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -117,20 +117,24 @@ def vote_fork(args: argparse.Namespace) -> None:
         if not fork or not voter:
             print("Fork or voter not found")
             return
+
+        vote_bool = args.vote.lower() == "yes"
+
         # Avoid duplicate votes from the same harmonizer
         existing = db.query(BranchVote).filter_by(
             branch_id=fork.id, voter_id=voter.id
         ).first()
         if existing:
-            print("Vote already recorded for this fork")
-            return
-        vote_bool = args.vote.lower() == "yes"
-        record = BranchVote(
-            branch_id=fork.id,
-            voter_id=voter.id,
-            vote=vote_bool,
-        )
-        db.add(record)
+            existing.vote = vote_bool
+            existing.timestamp = datetime.utcnow()
+        else:
+            record = BranchVote(
+                branch_id=fork.id,
+                voter_id=voter.id,
+                vote=vote_bool,
+            )
+            db.add(record)
+
         db.commit()
 
         votes = [v.vote for v in db.query(BranchVote).filter_by(branch_id=fork.id).all()]

--- a/tests/test_branch_vote.py
+++ b/tests/test_branch_vote.py
@@ -2,6 +2,8 @@ import datetime
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+import argparse
+import federation_cli
 from db_models import Harmonizer, UniverseBranch, BranchVote
 
 
@@ -30,3 +32,43 @@ def test_branch_vote_unique_constraint(test_db):
 
     votes = test_db.query(BranchVote).filter_by(branch_id=fork.id).all()
     assert len(votes) == 1
+
+
+def test_vote_fork_updates_existing_vote(monkeypatch, test_db):
+    """vote_fork should update duplicate votes rather than create a new record."""
+    fork = UniverseBranch(
+        id="f2",
+        creator_id=None,
+        karma_at_fork=0.0,
+        config={},
+        timestamp=datetime.datetime.utcnow(),
+        status="active",
+    )
+    voter = Harmonizer(username="bob", email="b@example.com", hashed_password="x")
+    test_db.add_all([fork, voter])
+    test_db.commit()
+
+    class NonClosingSession:
+        def __init__(self, db):
+            self._db = db
+
+        def __getattr__(self, name):
+            return getattr(self._db, name)
+
+        def close(self):  # override to keep session open
+            pass
+
+    monkeypatch.setattr(federation_cli, "SessionLocal", lambda: NonClosingSession(test_db))
+
+    args = argparse.Namespace(fork_id=fork.id, voter=voter.username, vote="yes")
+    federation_cli.vote_fork(args)
+
+    args = argparse.Namespace(fork_id=fork.id, voter=voter.username, vote="no")
+    federation_cli.vote_fork(args)
+
+    votes = test_db.query(BranchVote).filter_by(branch_id=fork.id, voter_id=voter.id).all()
+    assert len(votes) == 1
+    assert votes[0].vote is False
+
+    updated_fork = test_db.query(UniverseBranch).filter_by(id=fork.id).first()
+    assert updated_fork.consensus == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- update `vote_fork` to overwrite an existing vote instead of failing
- test duplicate vote updates consensus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ba0c73708320a4e203f2b3e9e268