### PR TITLE
Improve logging of entropy divergence

### DIFF
--- a/governance_config.py
+++ b/governance_config.py
@@ -94,7 +94,11 @@ def calculate_entropy_divergence(config: dict, base: object | None = None) -> fl
                 base_v = float(getattr(base, k))
                 v_val = float(v)
             except ValueError:
-                logging.warning("Ignoring non-numeric configuration for key %s", k)
+                logging.warning(
+                    "Ignoring non-numeric configuration for key %s with value %r",
+                    k,
+                    v,
+                )
                 continue
             diffs.append(abs(v_val - base_v))
     if not diffs:


### PR DESCRIPTION
## Summary
- log ignored `calculate_entropy_divergence` values in `governance_config`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885ba1816ac83209cbd4921b36876eb