### PR TITLE
Add entanglement parameter to quantum consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,29 @@ Flags: ['limited_consensus', 'low_diversity']
 - Check timestamp clustering for coordination risks
 ```
 
+## 🔮 Advanced Quantum Consensus
+
+The `quantum_consensus` helper accepts an optional entanglement parameter to
+model correlated votes. Pass either a global correlation factor or an
+``NxN`` entanglement matrix:
+
+```python
+from governance_config import quantum_consensus
+
+votes = [True, False, True, True]
+score = quantum_consensus(votes, 0.8)  # global factor
+
+matrix = [
+    [0, 1, 0, 0],
+    [1, 0, 0.5, 0],
+    [0, 0.5, 0, 1],
+    [0, 0, 1, 0],
+]
+score_matrix = quantum_consensus(votes, matrix)
+```
+
+When ``qutip`` is not installed the function falls back to a classical average.
+
 ## 📓 Jupyter Examples
 
 Two notebooks in `docs/` showcase how to run the validation pipeline and plot

--- a/governance_config.py
+++ b/governance_config.py
@@ -7,9 +7,9 @@ import numpy as np
 import logging
 
 try:  # optional quantum consensus engine
-    from qutip import basis, tensor, sigmaz, expect
+    from qutip import basis, tensor, sigmaz, expect, qeye, bell_state
 except Exception:  # pragma: no cover - qutip may be missing in minimal env
-    basis = tensor = sigmaz = expect = None
+    basis = tensor = sigmaz = expect = qeye = bell_state = None
 
 from db_models import Harmonizer, SessionLocal, SystemState
 
@@ -103,14 +103,65 @@ def calculate_entropy_divergence(config: dict, base: object | None = None) -> fl
     return float(arr.mean())
 
 
-def quantum_consensus(votes: list[bool]) -> float:
-    """Compute consensus level using a simple quantum-inspired model."""
+def quantum_consensus(
+    votes: list[bool], entanglement: float | list[list[float]] | None = None
+) -> float:
+    """Compute consensus level with optional entanglement modeling.
+
+    Parameters
+    ----------
+    votes:
+        List of boolean votes.
+    entanglement:
+        Either a global correlation factor ``0 <= f <= 1`` or an ``NxN`` matrix
+        describing pairwise entanglement strengths.
+    """
+
     if not votes:
         return 0.0
+
     if basis is None:
         return sum(votes) / len(votes)
+
     states = [basis(2, 1 if v else 0) for v in votes]
     joint = tensor(states)
-    obs = tensor([sigmaz()] * len(votes))
-    expectation = expect(obs, joint)
-    return float((expectation + 1) / 2)
+
+    if entanglement is None:
+        obs = tensor([sigmaz()] * len(votes))
+        expectation = expect(obs, joint)
+        return float((expectation + 1) / 2)
+
+    if not isinstance(entanglement, (int, float)):
+        arr = np.array(entanglement, dtype=float)
+        if arr.shape != (len(votes), len(votes)):
+            raise ValueError("entanglement matrix must match vote count")
+        corr = float(np.clip(arr.mean(), 0.0, 1.0))
+    else:
+        corr = float(entanglement)
+        if not 0.0 <= corr <= 1.0:
+            raise ValueError("correlation factor must be between 0 and 1")
+
+    pairs: list = []
+    i = 0
+    while i < len(votes) - 1:
+        if votes[i] == votes[i + 1]:
+            pair = bell_state("00")
+        else:
+            pair = bell_state("10")
+        pairs.append(pair)
+        i += 2
+
+    if len(votes) % 2 == 1:
+        pairs.append(basis(2, 1 if votes[-1] else 0))
+
+    ent_state = tensor(pairs)
+    joint = (1 - corr) * joint + corr * ent_state
+
+    expectations = []
+    for idx in range(len(votes)):
+        obs = tensor(
+            [sigmaz() if i == idx else qeye(2) for i in range(len(votes))]
+        )
+        expectations.append(expect(obs, joint))
+    mean_exp = sum(expectations) / len(votes)
+    return float((mean_exp + 1) / 2)

--- a/tests/test_governance_config.py
+++ b/tests/test_governance_config.py
@@ -3,7 +3,7 @@ import sys
 import builtins
 import pytest
 
-from governance_config import calculate_entropy_divergence
+from governance_config import calculate_entropy_divergence, quantum_consensus, basis
 from superNova_2177 import Config
 
 
@@ -28,3 +28,26 @@ def test_calculate_entropy_divergence_import_error(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(ImportError):
         calculate_entropy_divergence({})
+
+
+def test_quantum_consensus_entanglement_factor():
+    if basis is None:
+        pytest.skip("qutip not installed")
+    votes = [True, True]
+    baseline = quantum_consensus(votes)
+    entangled = quantum_consensus(votes, 1.0)
+    assert entangled != pytest.approx(baseline)
+    assert 0.0 <= entangled <= 1.0
+
+
+def test_quantum_consensus_entanglement_matrix():
+    if basis is None:
+        pytest.skip("qutip not installed")
+    votes = [True, False, True]
+    matrix = [
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ]
+    result = quantum_consensus(votes, matrix)
+    assert 0.0 <= result <= 1.0


### PR DESCRIPTION
## Summary
- extend `quantum_consensus` with optional entanglement modeling
- document advanced usage in README
- add tests for entanglement factor and matrix

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'sentence_transformers', scikit-learn)*

------
https://chatgpt.com/codex/tasks/task_e_6885ba116ae4832081fc5f611e6240dd