### PR TITLE
Fix timestamp parsing in nonce cleanup

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2388,8 +2388,12 @@ class RemixAgent:
                     n
                     for n, t in self.processed_nonces.items()
                     if (
-                        datetime.datetime.fromisoformat(now)
-                        - datetime.datetime.fromisoformat(t)
+                        datetime.datetime.fromisoformat(
+                            now.replace("Z", "+00:00")
+                        )
+                        - datetime.datetime.fromisoformat(
+                            t.replace("Z", "+00:00")
+                        )
                     ).total_seconds()
                     > self.config.NONCE_EXPIRATION_SECONDS
                 ]


### PR DESCRIPTION
## Summary
- handle UTC timestamp strings ending with `Z`
- ensure `_cleanup_nonces` parses timestamps correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c3a325288320b661f89614f69b0d