### PR TITLE
Fix commentary for missing path_nodes

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -123,10 +123,11 @@ def generate_commentary_from_trace(trace: Dict[str, Any]) -> str:
     """
     Heuristic commentary generation based on node sequence and entropy.
     """
-    if not trace["path_nodes"]:
+    path_nodes = trace.get("path_nodes")
+    if not path_nodes:
         return "No significant causal chain found."
 
-    chain = " → ".join(trace["path_nodes"])
+    chain = " → ".join(path_nodes)
     highlights = trace.get("highlights", [])
     highlight_text = (
         f" Notable nodes: {', '.join(highlights)}." if highlights else ""

--- a/tests/test_audit_bridge.py
+++ b/tests/test_audit_bridge.py
@@ -215,3 +215,13 @@ def test_attach_trace_to_logentry_invalid_json_does_not_modify(test_db, caplog):
     refreshed = test_db.query(LogEntry).filter(LogEntry.id == log.id).first()
     assert refreshed.payload == bad_payload
     assert any("Failed to parse JSON payload" in rec.message for rec in caplog.records)
+
+
+def test_generate_commentary_from_trace_missing_path_nodes():
+    """generate_commentary_from_trace should handle missing 'path_nodes' key."""
+    from audit_bridge import generate_commentary_from_trace
+
+    trace = {"highlights": ["A"]}
+    commentary = generate_commentary_from_trace(trace)
+
+    assert commentary == "No significant causal chain found."


### PR DESCRIPTION
## Summary
- safely access `path_nodes` in `generate_commentary_from_trace`
- add regression test for missing `path_nodes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864e50805c8320aaf6fd5b48fd2cc4