### PR TITLE
Handle missing path nodes

### DIFF
--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -136,7 +136,9 @@ def generate_commentary_from_trace(trace: Dict[str, Any]) -> str:
     """
     Heuristic commentary generation based on node sequence and entropy.
     """
-    path_nodes = trace.get("path_nodes")
+    # Safely pull the path information from the trace. ``get`` avoids raising
+    # ``KeyError`` when the calling code provides incomplete data.
+    path_nodes = trace.get("path_nodes") or []
     if not path_nodes:
         return "No significant causal chain found."
 

--- a/tests/test_audit_bridge.py
+++ b/tests/test_audit_bridge.py
@@ -253,3 +253,12 @@ def test_generate_commentary_from_trace_missing_path_nodes():
     commentary = generate_commentary_from_trace(trace)
 
     assert commentary == "No significant causal chain found."
+
+
+def test_generate_commentary_from_trace_no_path_nodes_key():
+    """An empty trace should also yield the default commentary message."""
+    from audit_bridge import generate_commentary_from_trace
+
+    commentary = generate_commentary_from_trace({})
+
+    assert commentary == "No significant causal chain found."


### PR DESCRIPTION
## Summary
- improve commentary generation safety for missing trace info
- add regression test for missing `path_nodes` key

## Testing
- `pytest tests/test_audit_bridge.py::test_generate_commentary_from_trace_missing_path_nodes tests/test_audit_bridge.py::test_generate_commentary_from_trace_no_path_nodes_key -vv`
- `pytest -k generate_commentary_from_trace -vv` *(fails: ModuleNotFoundError: numpy, dateutil)*

------
https://chatgpt.com/codex/tasks/task_e_6886537285788320aa9fec99e5f5ccf5