### PR TITLE
Handle percentile bounds in karma cutoff

### DIFF
--- a/governance_config.py
+++ b/governance_config.py
@@ -86,8 +86,10 @@ def karma_percentile_cutoff(percentile: float, db: Session | None = None) -> flo
         if not values:
             return 0.0
         values.sort()
-        index = int((1 - percentile) * len(values))
-        index = max(0, min(index, len(values) - 1))
+        # Clamp percentile-derived index so ``percentile`` values of exactly 0
+        # or 1 map to the list bounds rather than falling outside them.
+        index = round((1 - percentile) * (len(values) - 1))
+        index = max(0, min(int(index), len(values) - 1))
         return values[index]
     finally:
         if close_session:

--- a/tests/test_governance_config.py
+++ b/tests/test_governance_config.py
@@ -49,3 +49,17 @@ def test_karma_percentile_cutoff_edge_cases(test_db):
 
     assert high_cutoff == pytest.approx(30.0)
     assert low_cutoff == pytest.approx(10.0)
+
+
+def test_karma_percentile_cutoff_single_user_bounds(test_db):
+    user = Harmonizer(
+        username="solo",
+        email="solo@example.com",
+        hashed_password="x",
+        karma_score=42.0,
+    )
+    test_db.add(user)
+    test_db.commit()
+
+    assert karma_percentile_cutoff(0.0, db=test_db) == pytest.approx(42.0)
+    assert karma_percentile_cutoff(1.0, db=test_db) == pytest.approx(42.0)


### PR DESCRIPTION
## Summary
- clamp percentile index for karma cutoff so 0/1 stay within bounds
- test karma cutoff boundary cases including a single user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865373e43c8320ae891c97d7e216d7