### PR TITLE
Fix deterministic measurement in QuantumContext

### DIFF
--- a/quantum_sim.py
+++ b/quantum_sim.py
@@ -146,7 +146,7 @@ class QuantumContext:
                 settings.FUZZINESS_RANGE_LOW, settings.FUZZINESS_RANGE_HIGH
             )
         else:
-            outcome = 1.0
+            outcome = input_value
 
         # interference from entangled pairs
         interference = sum(self.entangled_pairs.values()) * settings.INTERFERENCE_FACTOR

--- a/tests/test_scientific.py
+++ b/tests/test_scientific.py
@@ -181,6 +181,13 @@ def test_quantum_context_superposition():
     assert 0.0 <= val["value"] <= 1.0
     assert val["distribution"] is not None
 
+def test_measure_superposition_deterministic():
+    """Measurement should return the input value when fuzziness is disabled."""
+    qc = QuantumContext(fuzzy_enabled=False, simulate=True)
+    val = qc.measure_superposition(0.25)
+    assert val["value"] == pytest.approx(0.25)
+    assert val["distribution"] == [0.75, 0.25]
+
 def test_query_influence():
     if not nx:
         pytest.skip("networkx not installed")


### PR DESCRIPTION
## Summary
- measure_superposition should use input_value when fuzziness is disabled
- add unit test covering deterministic measurement

## Testing
- `pytest tests/test_scientific.py::test_measure_superposition_deterministic -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886542cff6483208afbbc8627f5f997