### PR TITLE
Add pre-commit configuration and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        language_version: python3
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.8
+    hooks:
+      - id: bandit
+        language_version: python3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,21 @@ pytest
 
 The GitHub Actions workflows (`.github/workflows/ci.yml` and `pr-tests.yml`) run these commands automatically whenever you push or open a pull request.
 
+## Pre-commit Hooks
+
+Install the development tools and enable the git hooks so code is automatically formatted and linted:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Run all hooks manually with:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Optional Frontend
 
 The `transcendental-resonance-frontend/` directory contains a NiceGUI-based UI. Follow its README to install `pip install -r transcendental-resonance-frontend/requirements.txt` and run the frontend if desired.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ make test     # run tests
 make lint     # run mypy type checks
 ```
 
+### Pre-commit Hooks
+
+Set up pre-commit to automatically format and lint the code:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+You can run all checks manually with:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Platform Quick Commands
 
 **Windows PowerShell**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,9 @@ sqlalchemy>=2.0
 networkx
 numpy
 python-dateutil
+pre-commit
+black
+isort
+flake8
+mypy
+bandit


### PR DESCRIPTION
## Summary
- add a pre-commit configuration running black, isort, flake8, mypy and bandit
- document how to enable pre-commit hooks in DEVELOPMENT.md
- add pre-commit instructions to README
- include pre-commit and linter tools in `requirements-dev.txt`

## Testing
- `pre-commit run --files README.md DEVELOPMENT.md requirements-dev.txt .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688653af39c08320bf312c64c65a2769