### PR TITLE
Isolate annual audit task

### DIFF
--- a/annual_audit.py
+++ b/annual_audit.py
@@ -1,0 +1,20 @@
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Config:
+    """Default configuration for the audit task."""
+    ANNUAL_AUDIT_INTERVAL_SECONDS = 86400 * 365
+
+async def annual_audit_task(cosmic_nexus):
+    """Trigger a yearly quantum audit proposal."""
+    while True:
+        try:
+            await asyncio.sleep(Config.ANNUAL_AUDIT_INTERVAL_SECONDS)
+            cosmic_nexus.quantum_audit()
+        except asyncio.CancelledError:
+            logger.info("annual_audit_task cancelled")
+            break
+        except Exception:
+            logger.error("annual_audit_task error", exc_info=True)

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -243,6 +243,7 @@ import signal
 import immutable_tri_species_adjust
 import random
 import optimization_engine
+from annual_audit import annual_audit_task
 from collections import defaultdict, deque, Counter
 from decimal import (
     Decimal,
@@ -4212,22 +4213,6 @@ async def adaptive_optimization_task(db_session_factory):
                 db.close()
             except Exception:
                 pass
-
-
-async def annual_audit_task(cosmic_nexus: CosmicNexus):
-    """Trigger a yearly quantum audit proposal."""
-    while True:
-        try:
-            await asyncio.sleep(Config.ANNUAL_AUDIT_INTERVAL_SECONDS)
-            cosmic_nexus.quantum_audit()
-        except asyncio.CancelledError:
-            logger.info("annual_audit_task cancelled")
-            break
-        except Exception as exc:
-            logger.error("annual_audit_task error", exc_info=True)
-
-
-@app.on_event("startup")
 async def startup_event():
     loop = asyncio.get_event_loop()
     loop.create_task(passive_aura_resonance_task(SessionLocal))

--- a/tests/test_annual_audit_task.py
+++ b/tests/test_annual_audit_task.py
@@ -1,23 +1,9 @@
 import asyncio
-import ast
-from pathlib import Path
 import types
 import pytest
+import annual_audit
 
-# Dynamically load the annual_audit_task definition without importing heavy deps
-src = Path(__file__).resolve().parents[1] / "superNova_2177.py"
-text = src.read_text()
-tree = ast.parse(text)
-func_code = None
-for node in tree.body:
-    if isinstance(node, ast.AsyncFunctionDef) and node.name == "annual_audit_task":
-        func_code = ast.get_source_segment(text, node)
-        break
-namespace = {}
-globals()['CosmicNexus'] = object
-globals()['logger'] = types.SimpleNamespace(info=lambda *a, **k: None)
-exec(func_code, globals(), namespace)
-annual_audit_task = namespace["annual_audit_task"]
+annual_audit_task = annual_audit.annual_audit_task
 
 class DummyConfig:
     ANNUAL_AUDIT_INTERVAL_SECONDS = 0.01
@@ -25,11 +11,18 @@ class DummyConfig:
 class DummyNexus:
     def __init__(self):
         self.calls = 0
+
     def quantum_audit(self):
         self.calls += 1
 
-def test_annual_audit_task_triggers_quantum_audit():
-    globals()["Config"] = DummyConfig
+def test_annual_audit_task_triggers_quantum_audit(monkeypatch):
+    monkeypatch.setattr(annual_audit, "Config", DummyConfig, raising=False)
+    monkeypatch.setattr(
+        annual_audit,
+        "logger",
+        types.SimpleNamespace(info=lambda *a, **k: None, error=lambda *a, **k: None),
+        raising=False,
+    )
     nexus = DummyNexus()
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Summary
- extract `annual_audit_task` into standalone `annual_audit` module
- call `annual_audit_task` from `superNova_2177.py`
- simplify test to import the new module directly

## Testing
- `pytest tests/test_annual_audit_task.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688653aed10c8320ae55c9312dda02c7