### PR TITLE
Implement semantic contradiction resolver and diversity persistence

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -401,6 +401,16 @@ class ValidatorReputation(Base):
                         onupdate=datetime.datetime.utcnow)
 
 
+class ValidatorProfile(Base):
+    """Stores specialty and affiliation metadata for validators."""
+
+    __tablename__ = "validator_profiles"
+
+    validator_id = Column(String, primary_key=True)
+    specialty = Column(String, nullable=True)
+    affiliation = Column(String, nullable=True)
+
+
 # Add this below the SystemState class but before Coin to maintain ordering:
 class HypothesisRecord(Base):
     """

--- a/semantic_contradiction_resolver.py
+++ b/semantic_contradiction_resolver.py
@@ -1,0 +1,28 @@
+"""Simple semantic contradiction resolver for validator notes."""
+from __future__ import annotations
+
+from typing import Iterable
+
+# Basic set of terms indicating contradiction or disagreement.  This avoids
+# heavy NLP dependencies so it works in constrained test environments.
+CONTRADICTION_TERMS = {
+    "contradict",
+    "refute",
+    "oppose",
+    "disagree",
+    "inconsistent",
+    "conflict",
+    "counter",
+    "denies",
+}
+
+
+def semantic_contradiction_resolver(text: str | None) -> bool:
+    """Return ``True`` if the text semantically indicates a contradiction."""
+    if not text:
+        return False
+    lower = text.lower()
+    return any(term in lower for term in CONTRADICTION_TERMS)
+
+
+__all__ = ["semantic_contradiction_resolver"]

--- a/tests/test_validator_reputation_tracker.py
+++ b/tests/test_validator_reputation_tracker.py
@@ -1,0 +1,55 @@
+import pytest
+
+from validator_reputation_tracker import (
+    update_validator_reputations,
+    load_validator_profiles,
+)
+from db_models import ValidatorReputation
+
+
+def test_semantic_contradiction_penalty():
+    vals_good = [
+        {"validator_id": "v1", "score": 0.5, "note": "supports"},
+        {"validator_id": "v1", "score": 0.5, "note": "agrees"},
+    ]
+    good_rep = update_validator_reputations(vals_good)["reputations"]["v1"]
+
+    vals_bad = [
+        {"validator_id": "v2", "score": 0.5, "note": "supports"},
+        {"validator_id": "v2", "score": 0.5, "note": "I refute this"},
+    ]
+    bad_rep = update_validator_reputations(vals_bad)["reputations"]["v2"]
+
+    assert bad_rep < good_rep
+
+
+def test_diversity_tracking():
+    vals = [
+        {"validator_id": "a", "score": 0.6, "specialty": "s1", "affiliation": "x"},
+        {"validator_id": "a", "score": 0.6, "specialty": "s1", "affiliation": "x"},
+        {"validator_id": "b", "score": 0.6, "specialty": "s2", "affiliation": "x"},
+        {"validator_id": "b", "score": 0.6, "specialty": "s2", "affiliation": "x"},
+        {"validator_id": "c", "score": 0.6, "specialty": "s1", "affiliation": "y"},
+        {"validator_id": "c", "score": 0.6, "specialty": "s1", "affiliation": "y"},
+    ]
+    res = update_validator_reputations(vals)
+    div = res["diversity"]
+    assert div["unique_specialties"] == 2
+    assert div["unique_affiliations"] == 2
+    assert div["validator_count"] == 3
+
+
+def test_persistence_with_profiles(test_db):
+    vals = [
+        {"validator_id": "p1", "score": 0.8, "specialty": "astro", "affiliation": "uni"},
+        {"validator_id": "p1", "score": 0.9, "specialty": "astro", "affiliation": "uni"},
+    ]
+    result = update_validator_reputations(vals, db=test_db)
+
+    # reputations persisted
+    rows = {r.validator_id: r.reputation for r in test_db.query(ValidatorReputation).all()}
+    assert rows == result["reputations"]
+
+    profiles = load_validator_profiles(test_db)
+    assert profiles["p1"]["specialty"] == "astro"
+    assert profiles["p1"]["affiliation"] == "uni"

--- a/validator_reputation_tracker.py
+++ b/validator_reputation_tracker.py
@@ -12,6 +12,9 @@ from datetime import datetime, timedelta
 from statistics import mean
 from exceptions import DataAccessError
 
+from diversity_analyzer import compute_diversity_score
+from semantic_contradiction_resolver import semantic_contradiction_resolver
+
 
 logger = logging.getLogger("superNova_2177.reputation")
 
@@ -32,7 +35,10 @@ class Config:
     MIN_VALIDATIONS_FOR_SCORING = 2
 
 # --- Main Function ---
-def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str, float]:
+def update_validator_reputations(
+    validations: List[Dict[str, Any]],
+    db=None,
+) -> Dict[str, Any]:
     """
     Updates validator reputations based on validation quality and certification.
 
@@ -46,10 +52,11 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
             - specialty: str (optional)
 
     Returns:
-        Dict[str, float]: Updated validator reputation map.
+        Dict with ``reputations`` and ``diversity`` information.
     """
     reputations: Dict[str, List[float]] = {}
     specialties: Dict[str, str] = {}
+    affiliations: Dict[str, str] = {}
 
     for v in validations:
         validator_id = v.get("validator_id")
@@ -57,6 +64,7 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
         cert = v.get("certification", "experimental")
         timestamp_str = v.get("timestamp")
         specialty = v.get("specialty")
+        affiliation = v.get("affiliation")
 
         # Validate ID
         if not validator_id or not isinstance(validator_id, str):
@@ -65,6 +73,8 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
         # Store specialty for diversity analysis
         if specialty:
             specialties[validator_id] = specialty
+        if affiliation:
+            affiliations[validator_id] = affiliation
 
         # Decay modifier based on timestamp
         decay_factor = 1.0
@@ -79,7 +89,8 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
 
         # Reputation delta
         reward = Config.CERTIFICATION_REWARD.get(cert, 0.0)
-        penalty = -Config.CONTRADICTION_PENALTY if "contradict" in v.get("note", "").lower() else 0.0
+        note_text = v.get("note", "")
+        penalty = -Config.CONTRADICTION_PENALTY if semantic_contradiction_resolver(note_text) else 0.0
         delta = (score + reward + penalty) * decay_factor
 
         reputations.setdefault(validator_id, []).append(delta)
@@ -90,13 +101,37 @@ def update_validator_reputations(validations: List[Dict[str, Any]]) -> Dict[str,
         if len(deltas) >= Config.MIN_VALIDATIONS_FOR_SCORING:
             rep = min(
                 Config.MAX_REPUTATION,
-                max(Config.MIN_REPUTATION, mean(deltas) + Config.DEFAULT_REPUTATION)
+                max(
+                    Config.MIN_REPUTATION,
+                    mean(deltas) + Config.DEFAULT_REPUTATION,
+                ),
             )
             final_scores[vid] = rep
-            logger.info(f"Validator {vid} updated reputation: {rep:.3f} — Specialty: {specialties.get(vid, 'N/A')}")
+            logger.info(
+                f"Validator {vid} updated reputation: {rep:.3f} — Specialty: {specialties.get(vid, 'N/A')}"
+            )
+
+    diversity = {
+        "unique_specialties": len(set(specialties.values())),
+        "unique_affiliations": len(set(affiliations.values())),
+        "validator_count": len(final_scores),
+    }
 
     logger.info(f"Updated reputations for {len(final_scores)} validators")
-    return final_scores
+
+    if db is not None:
+        save_reputations(final_scores, db)
+        profile_map = {
+            vid: {
+                "specialty": specialties.get(vid),
+                "affiliation": affiliations.get(vid),
+            }
+            for vid in final_scores.keys()
+        }
+        if profile_map:
+            save_validator_profiles(profile_map, db)
+
+    return {"reputations": final_scores, "diversity": diversity}
 
 # --- Placeholder Persistence Functions ---
 def save_reputations(reputations: Dict[str, float], db) -> None:
@@ -133,7 +168,45 @@ def load_reputations(db) -> Dict[str, float]:
     rows = db.query(ValidatorReputation).all()
     return {row.validator_id: float(row.reputation) for row in rows}
 
-# TODO (v4.2):
-# - Implement semantic_contradiction_resolver integration
-# - Add specialty/affiliation diversity tracking
-# - Replace placeholders with real DB persistence layer
+
+def save_validator_profiles(profiles: Dict[str, Dict[str, str]], db) -> None:
+    """Persist validator specialty and affiliation data."""
+
+    try:
+        from db_models import ValidatorProfile
+    except Exception as e:  # pragma: no cover - fallback handling
+        logger.error(f"DB models unavailable: {e}")
+        return
+
+    for vid, info in profiles.items():
+        row = db.query(ValidatorProfile).filter_by(validator_id=vid).first()
+        if row:
+            if info.get("specialty"):
+                row.specialty = info["specialty"]
+            if info.get("affiliation"):
+                row.affiliation = info["affiliation"]
+        else:
+            row = ValidatorProfile(
+                validator_id=vid,
+                specialty=info.get("specialty"),
+                affiliation=info.get("affiliation"),
+            )
+            db.add(row)
+
+    db.commit()
+
+
+def load_validator_profiles(db) -> Dict[str, Dict[str, str]]:
+    """Load validator specialty and affiliation information."""
+
+    try:
+        from db_models import ValidatorProfile
+    except Exception as e:  # pragma: no cover - fallback handling
+        logger.error(f"DB models unavailable: {e}")
+        raise DataAccessError("ValidatorProfile model unavailable") from e
+
+    rows = db.query(ValidatorProfile).all()
+    return {
+        row.validator_id: {"specialty": row.specialty, "affiliation": row.affiliation}
+        for row in rows
+    }


### PR DESCRIPTION
## Summary
- add `semantic_contradiction_resolver` module for note analysis
- extend `update_validator_reputations` to track specialty/affiliation diversity
- persist validator profile data in new `ValidatorProfile` table
- update DB models and unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688653a9f2708320b5410eacd9b5711d