### PR TITLE
Add validation for fuzziness range

### DIFF
--- a/quantum_sim.py
+++ b/quantum_sim.py
@@ -77,6 +77,18 @@ class QuantumContext:
             f"QuantumContext initialized with fuzzy_enabled={fuzzy_enabled}, decoherence_rate={decoherence_rate}, simulate={simulate}"
         )
 
+        if FUZZINESS_RANGE_LOW > FUZZINESS_RANGE_HIGH:
+            logging.error(
+                "Invalid fuzziness range",
+                extra={
+                    "FUZZINESS_RANGE_LOW": FUZZINESS_RANGE_LOW,
+                    "FUZZINESS_RANGE_HIGH": FUZZINESS_RANGE_HIGH,
+                },
+            )
+            raise ValueError(
+                "FUZZINESS_RANGE_LOW must be <= FUZZINESS_RANGE_HIGH"
+            )
+
     def step(self, dt: float = 1.0) -> None:
         """Apply decoherence decay over ``dt`` time units."""
         decay = math.exp(-self.decoherence_rate * dt)


### PR DESCRIPTION
## Summary
- validate FUZZINESS_RANGE_LOW <= FUZZINESS_RANGE_HIGH during `QuantumContext` init
- log invalid configuration and raise `ValueError`

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886543c90808320a352670eafdf3563