### PR TITLE
Fix half-life zero handling

### DIFF
--- a/tests/test_validator_reputation_decay.py
+++ b/tests/test_validator_reputation_decay.py
@@ -25,3 +25,14 @@ def test_reputation_decays_with_age():
     rep_old = old["validator_reputations"].get("a")
 
     assert rep_recent > rep_old
+
+
+def test_half_life_zero_defaults_to_config():
+    now = datetime.datetime.utcnow().replace(microsecond=0)
+    vals = _build_validations(now)
+    consensus = {"h1": 0.8}
+
+    default_result = compute_validator_reputations(vals, consensus, current_time=now)
+    zero_result = compute_validator_reputations(vals, consensus, current_time=now, half_life_days=0)
+
+    assert zero_result["validator_reputations"] == default_result["validator_reputations"]

--- a/validators/reputation_influence_tracker.py
+++ b/validators/reputation_influence_tracker.py
@@ -83,6 +83,8 @@ def compute_validator_reputations(
     diversity_scores = diversity_scores or {}
     current_time = current_time or datetime.utcnow()
     half_life = half_life_days or Config.DECAY_HALF_LIFE_DAYS
+    if half_life <= 0:
+        half_life = Config.DECAY_HALF_LIFE_DAYS
 
     validator_scores = defaultdict(list)
     validator_deviations = defaultdict(list)


### PR DESCRIPTION
## Summary
- prevent divide-by-zero when half_life_days <= 0
- test that half-life of 0 falls back to default value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886542d247c8320bab9ca741df246de