### PR TITLE
Fix root logger setup

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -501,7 +501,7 @@ console_handler.setFormatter(
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 )
-logging.getRoot().addHandler(console_handler)
+logging.getLogger().addHandler(console_handler)
 
 file_handler = logging.FileHandler("transcendental_resonance.log", encoding="utf-8")
 file_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary
- fix AttributeError due to `logging.getRoot()` by using `logging.getLogger()` instead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886625c4ed48320895fb45802ea98af