### PR TITLE
Refactor metrics port usage

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -528,7 +528,7 @@ if "total_vibenodes" in REGISTRY._names_to_collectors:
     vibenodes_gauge = REGISTRY._names_to_collectors["total_vibenodes"]
 else:
     vibenodes_gauge = prom.Gauge("total_vibenodes", "Total number of vibenodes")
-prom.start_http_server(Config.METRICS_PORT)  # Metrics endpoint
+prom.start_http_server(CONFIG.METRICS_PORT)  # Metrics endpoint
 
 # --- MODULE: models.py ---
 # Database setup from FastAPI files


### PR DESCRIPTION
## Summary
- reference the common CONFIG variable for metrics port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68867981b43c8320881ebd3af77653ac