### PR TITLE
Fix metrics config for superNova_2177

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -217,6 +217,13 @@ RemixAgent handles event-sourced logic and state management for a single univers
 CosmicNexus orchestrates the multiverse, coordinating forks, entropy reduction, and cross-universe bridges.
 """
 # Core Imports from all files
+try:
+    from config import Config as SystemConfig
+    CONFIG = SystemConfig
+except ImportError:
+    class TempConfig:
+        METRICS_PORT = 8001
+    CONFIG = TempConfig
 import sys
 import json
 import uuid


### PR DESCRIPTION
## Summary
- configure metrics port at runtime via `CONFIG` import fallback

## Testing
- `pytest -q`
- manual run of metrics startup snippet

------
https://chatgpt.com/codex/tasks/task_e_68867ce65bd88320a1cc5c58f6f07b9e