### PR TITLE
Handle metrics port collision

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -547,7 +547,13 @@ if "total_vibenodes" in REGISTRY._names_to_collectors:
     vibenodes_gauge = REGISTRY._names_to_collectors["total_vibenodes"]
 else:
     vibenodes_gauge = prom.Gauge("total_vibenodes", "Total number of vibenodes")
-prom.start_http_server(Config.METRICS_PORT)  # Metrics endpoint
+
+try:
+    prom.start_http_server(Config.METRICS_PORT)  # Metrics endpoint
+except OSError as e:  # pragma: no cover - port likely already bound
+    logging.warning(
+        "Metrics server failed to bind on port %s: %s", Config.METRICS_PORT, e
+    )
 
 # --- MODULE: models.py ---
 # Database setup from FastAPI files


### PR DESCRIPTION
## Summary
- avoid crash if metrics port is already in use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867f291a4c8320a312a1ce8fe32312