### PR TITLE
Fix metrics port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ not set, a secure random value will be generated automatically:
 export SECRET_KEY="your-random-secret"
 ```
 
+`METRICS_PORT` configures the Prometheus metrics server port. Override it if the
+default `8001` is unavailable:
+
+```bash
+export METRICS_PORT=9000
+```
+
 Copy `.env.example` to `.env` and set values for `SECRET_KEY` and
 `BACKEND_URL`. Provide your own connection string for `DATABASE_URL` via
 environment variables rather than hard-coding it. Set `DB_MODE=central` if you

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 # --- MODULE: config.py ---
 from decimal import Decimal
 from typing import Dict, List
+import os
 
 class Config:
     ROOT_INITIAL_VALUE: Decimal = Decimal("1000000")
@@ -75,7 +76,7 @@ class Config:
     SCIENTIFIC_REASONING_CYCLE_INTERVAL_SECONDS: int = 3600
     ADAPTIVE_OPTIMIZATION_INTERVAL_SECONDS: int = 3600
     ANNUAL_AUDIT_INTERVAL_SECONDS: int = 86400 * 365
-    METRICS_PORT: int = 8001
+    METRICS_PORT: int = int(os.environ.get("METRICS_PORT", "8001"))
 
     # Cooldown to prevent excessive universe forking
     FORK_COOLDOWN_SECONDS: int = 3600

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -547,7 +547,15 @@ if "total_vibenodes" in REGISTRY._names_to_collectors:
     vibenodes_gauge = REGISTRY._names_to_collectors["total_vibenodes"]
 else:
     vibenodes_gauge = prom.Gauge("total_vibenodes", "Total number of vibenodes")
-prom.start_http_server(Config.METRICS_PORT)  # Metrics endpoint
+
+try:
+    prom.start_http_server(Config.METRICS_PORT)  # Metrics endpoint
+except OSError as exc:  # pragma: no cover - system specific
+    logger.warning(
+        "Prometheus metrics server could not start on port %s: %s",
+        Config.METRICS_PORT,
+        exc,
+    )
 
 # --- MODULE: models.py ---
 # Database setup from FastAPI files


### PR DESCRIPTION
## Summary
- allow overriding `METRICS_PORT` with an environment variable
- guard Prometheus server startup so the app continues if the port is unavailable
- document how to set `METRICS_PORT`

## Testing
- `python -m py_compile config.py superNova_2177.py`
- `pytest -k metrics -q`

------
https://chatgpt.com/codex/tasks/task_e_68867f291a4c8320a312a1ce8fe32312