### PR TITLE
Add email-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,13 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
   ```bash
   python install.py
   ```
-  This project depends on `numpy`, `python-dateutil`, and
-  `sqlalchemy>=2.0`. These packages are listed in `requirements.txt` and
+  This project depends on `numpy`, `python-dateutil`, `sqlalchemy>=2.0`, and `email-validator`. These packages are listed in `requirements.txt` and
   also in a pared-down `requirements-minimal.txt` that is sufficient for
   running the unit tests.
   If you prefer to manage the environment manually, install the required
   packages yourself using `requirements.txt`:
   ```bash
-  pip install -r requirements.txt  # installs numpy, python-dateutil, etc.
+  pip install -r requirements.txt  # installs numpy, python-dateutil, email-validator, etc.
   ```
    A PyPI wheel is currently unavailable. Run `python setup_env.py` or use the online installer scripts:
    ```bash

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,6 +16,7 @@ cramjam==2.10.0
 cryptography==45.0.5
 cycler==0.12.1
 ecdsa==0.19.1
+email-validator==2.2.0
 fastapi==0.116.1
 filelock==3.18.0
 fonttools==4.59.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ scikit-learn
 streamlit>=1.28
 qrcode
 asyncpg
+email-validator


### PR DESCRIPTION
## Summary
- add `email-validator` as a dependency
- regenerate lockfile and mention new package in README

## Testing
- `pip install -r requirements.txt` *(partial output shown)*
- `pre-commit run --files README.md requirements.txt requirements.lock`

------
https://chatgpt.com/codex/tasks/task_e_68867f9d203483208a5c9e3fd175014e