### PR TITLE
Add python-multipart dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "networkx",
     "python-dateutil",
     "fastapi",
+    "python-multipart",
     "uvicorn",
     "pydantic",
     "pydantic-settings",

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,6 +18,7 @@ cycler==0.12.1
 ecdsa==0.19.1
 email-validator==2.2.0
 fastapi==0.116.1
+python-multipart==0.0.20
 filelock==3.18.0
 fonttools==4.59.0
 fsspec==2025.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sqlalchemy>=2.0
 networkx
 python-dateutil
 fastapi
+python-multipart
 uvicorn
 pydantic
 pydantic-settings


### PR DESCRIPTION
## Summary
- include `python-multipart` with FastAPI requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68868611183083209c512c6af28c2be5