### PR TITLE
Introduce async-aware HookManager

### DIFF
--- a/hook_manager.py
+++ b/hook_manager.py
@@ -1,0 +1,64 @@
+import asyncio
+import inspect
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List
+
+
+@dataclass
+class HookManager:
+    """Mystical plugin bus to orchestrate quantum hooks across the metaverse."""
+
+    hooks: Dict[str, List[Callable[..., Any]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+    def register_hook(self, name: str, func: Callable[..., Any]) -> None:
+        """Safely register a hook callback under a cosmic name."""
+        if not callable(func):
+            raise TypeError("Hook must be callable")
+        self.hooks[name].append(func)
+        logging.debug("🔮 Registered hook '%s' -> %s", name, getattr(func, "__name__", repr(func)))
+
+    async def _invoke(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        try:
+            if inspect.iscoroutinefunction(func):
+                return await func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        except Exception:  # pragma: no cover - we log but never raise
+            logging.exception("💥 Hook '%s' raised an exception", getattr(func, "__name__", repr(func)))
+            return None
+
+    async def trigger(self, name: str, *args: Any, **kwargs: Any) -> List[Any]:
+        """Invoke all callbacks bound to *name* with given arguments."""
+        callbacks = list(self.hooks.get(name, []))
+        logging.debug("✨ Triggering hook '%s' with %d callbacks", name, len(callbacks))
+        results: List[Any] = []
+        for func in callbacks:
+            result = await self._invoke(func, *args, **kwargs)
+            results.append(result)
+            logging.debug(
+                "🌠 Hook '%s' executed %s -> %r",
+                name,
+                getattr(func, "__name__", repr(func)),
+                result,
+            )
+        return results
+
+    def fire_hooks(self, name: str, *args: Any, **kwargs: Any) -> List[Any]:
+        """Public entry point to trigger hooks synchronously or asynchronously."""
+        coro = self.trigger(name, *args, **kwargs)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        else:
+            return loop.run_until_complete(coro)
+
+    def dump_hooks(self) -> Dict[str, List[str]]:
+        """Inspect current hook bindings for audit clarity."""
+        return {n: [getattr(f, "__name__", repr(f)) for f in cbs] for n, cbs in self.hooks.items()}

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -3969,19 +3969,7 @@ async def proactive_intervention_task(cosmic_nexus: CosmicNexus):
 
 
 # --- MODULE: hook_manager.py ---
-class HookManager:
-    def __init__(self):
-        self.hooks = defaultdict(list)
-
-    def register_hook(self, event_type: str, callback: Callable):
-        self.hooks[event_type].append(callback)
-
-    def fire_hooks(self, event_type: str, data: Any):
-        for cb in self.hooks[event_type]:
-            try:
-                cb(data)
-            except Exception as e:
-                logging.error(f"Hook callback failed for {event_type}: {e}")
+from hook_manager import HookManager
 
 
 if __name__ == "__main__":

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -1,0 +1,35 @@
+import asyncio
+import logging
+import pytest
+
+from hook_manager import HookManager
+
+
+@pytest.mark.asyncio
+async def test_hook_manager_basic_async_and_sync():
+    hm = HookManager()
+    results = []
+
+    def sync_hook(x):
+        results.append(x + 1)
+        return x + 1
+
+    async def async_hook(x):
+        await asyncio.sleep(0)
+        results.append(x + 2)
+        return x + 2
+
+    hm.register_hook("event", sync_hook)
+    hm.register_hook("event", async_hook)
+
+    out = await hm.trigger("event", 1)
+    assert results == [2, 3]
+    assert out == [2, 3]
+
+
+def test_dump_hooks():
+    hm = HookManager()
+    hm.register_hook("alpha", lambda: None)
+    dump = hm.dump_hooks()
+    assert "alpha" in dump
+    assert dump["alpha"]


### PR DESCRIPTION
## Summary
- add new `hook_manager.py` module
- wire `superNova_2177` to import the new HookManager
- add tests for HookManager functionality

## Testing
- `pytest tests/test_hook_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886920b40cc83208ad5e17a157aa910