### PR TITLE
Fix pytest discovery and async tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+markers =
+    asyncio: mark a test as using asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-asyncio
 sqlalchemy>=2.0
 networkx
 numpy
@@ -9,3 +10,4 @@ isort
 flake8
 mypy
 bandit
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-asyncio
 sqlalchemy>=2.0
 networkx
 python-dateutil
@@ -37,3 +38,4 @@ streamlit>=1.28
 qrcode
 asyncpg
 email-validator
+httpx


### PR DESCRIPTION
## Summary
- ensure pytest picks up tests under `tests/`
- add test deps for async tests and HTTP client

## Testing
- `pytest tests/test_hook_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68869414b780832093d2403cdc5aa650