### PR TITLE
Specify pytest-asyncio version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-asyncio
+pytest-asyncio>=0.23
 sqlalchemy>=2.0
 networkx
 numpy

--- a/requirements.lock
+++ b/requirements.lock
@@ -84,6 +84,7 @@ Pygments==2.19.2
 pyparsing==3.2.3
 pyright==1.1.403
 pytest==8.4.1
+pytest-asyncio==0.23.6
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-jose==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-asyncio
+pytest-asyncio>=0.23
 sqlalchemy>=2.0
 networkx
 python-dateutil


### PR DESCRIPTION
## Summary
- tighten pytest-asyncio requirement in `requirements.txt`
- tighten pytest-asyncio requirement in `requirements-dev.txt`
- update lock file for pytest-asyncio version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', 'numpy', 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68869b263a70832092d5a9fd01d1623a