### PR TITLE
Remove stray pass in threshold method

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -453,13 +453,13 @@ class RemixAgent:
         self, total_voters: int, is_constitutional: bool, avg_yes: Decimal
     ) -> Decimal:
         """
-        Dynamically adjust threshold: for constitutional, increase as engagement (total voters) rises.
+        Dynamically adjust threshold: for constitutional, increase as engagement
+        (total voters) rises.
         - Base: 0.9
         - Medium (>20 voters): 0.92
         - High (>50 voters): 0.95
         Normal proposals stay at 0.5.
         """
-        pass
 
         if not is_constitutional:
             return self.NORMAL_THRESHOLD


### PR DESCRIPTION
## Summary
- clean up `_get_dynamic_threshold` implementation by removing the extraneous `pass`

## Testing
- `pytest tests/test_tri_species_agent.py::test_dynamic_threshold_levels -q`
- `pytest tests/test_tri_species_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68869b20f1b883208960ec0d02b385b2