### PR TITLE
Update .gitignore to handle Python cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+**/__pycache__/
 *.pyc
 # Virtual environments
 venv/


### PR DESCRIPTION
## Summary
- add recursive `__pycache__` directory pattern to `.gitignore`
- ensure `*.pyc` entries remain

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68869c109c648320b0f4fe843fbd94f8