### PR TITLE
Deduplicate Config attributes

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,12 +21,6 @@ class Config:
     VAX_FUZZY_THRESHOLD: int = 2
     REACTOR_KARMA_PER_REACT: Decimal = Decimal("1")
     CREATOR_KARMA_PER_REACT: Decimal = Decimal("2")
-    SNAPSHOT_INTERVAL: int = 100
-    KARMA_MINT_THRESHOLD: Decimal = Decimal("100")
-    MIN_IMPROVEMENT_LEN: int = 50
-    DAILY_DECAY: Decimal = Decimal("0.99")
-    VAX_PATTERNS: Dict[str, List[str]] = {"block": [r"\b(blocked_word)\b"]}
-    MAX_INPUT_LENGTH: int = 10000
 
     # --- Named constants for network effects and simulations ---
     NETWORK_CENTRALITY_BONUS_MULTIPLIER: Decimal = Decimal("5")

--- a/tests/test_config_duplicates.py
+++ b/tests/test_config_duplicates.py
@@ -1,0 +1,21 @@
+import ast
+from pathlib import Path
+
+
+def test_no_duplicate_config_attributes():
+    source = Path("config.py").read_text()
+    module = ast.parse(source)
+    cfg_class = next(
+        node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "Config"
+    )
+    seen = set()
+    duplicates = set()
+    for node in cfg_class.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    if target.id in seen:
+                        duplicates.add(target.id)
+                    seen.add(target.id)
+    assert not duplicates, f"Duplicate attributes found: {sorted(duplicates)}"


### PR DESCRIPTION
## Summary
- remove duplicate class attributes in `config.Config`
- check that Config attributes are unique via new unit test

## Testing
- `pytest tests/test_config_duplicates.py -q`
- `pytest -q` *(fails: IntegrityError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886a0bd8e388320803b1b040ecb2ee0