### PR TITLE
Fix RemixAgent init in create_app

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2103,7 +2103,11 @@ def create_app() -> FastAPI:
     Base.metadata.create_all(bind=engine)
 
     cosmic_nexus = CosmicNexus(SessionLocal, SystemStateService(SessionLocal()))
-    agent = RemixAgent(cosmic_nexus=cosmic_nexus)
+    agent = RemixAgent(
+        cosmic_nexus=cosmic_nexus,
+        filename="logchain_main.log",
+        snapshot="snapshot_main.json",
+    )
 
     app.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
## Summary
- pass logchain filename and snapshot to RemixAgent in `create_app`

## Testing
- `pytest -q` *(fails: LogChain NameError and other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_6886a5d7bcec83209159c10fbc0d3851