### PR TITLE
Add ORM consistency test

### DIFF
--- a/tests/test_orm_consistency.py
+++ b/tests/test_orm_consistency.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+
+import superNova_2177 as sn
+from sqlalchemy import create_engine
+
+# Reload the real module if a lightweight stub is installed
+if getattr(sn, "__file__", None) is None:
+    for mod in list(sys.modules):
+        if mod.startswith("fastapi") or mod.startswith("pydantic") or mod.startswith("sqlalchemy"):
+            sys.modules.pop(mod, None)
+    sys.modules.pop("superNova_2177", None)
+    sn = importlib.import_module("superNova_2177")
+
+
+def test_orm_consistency():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    sn.Base.metadata.create_all(engine)
+    session = sn.SessionLocal(bind=engine)
+    try:
+        session.query(sn.Harmonizer).all()
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add test to ensure ORM basics work with in-memory SQLite

## Testing
- `pytest -q tests/test_orm_consistency.py`

------
https://chatgpt.com/codex/tasks/task_e_6886a6c460ac83209869c402831c8175