### PR TITLE
Update CryptContext stub for hashing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,12 +223,24 @@ for mod_name in [
                 def __init__(self, *a, **kw):
                     pass
 
+                def hash(self, value: str) -> str:
+                    return f"hashed-{value}"
+
+                def verify(self, value: str, hashed: str) -> bool:
+                    return hashed == f"hashed-{value}"
+
             ctx_mod = types.ModuleType("passlib.context")
             ctx_mod.CryptContext = CryptContext
             stub.context = ctx_mod
             sys.modules["passlib.context"] = ctx_mod
         if mod_name == "jose":
-            stub.jwt = types.SimpleNamespace(encode=lambda *a, **kw: "", decode=lambda *a, **kw: {})
+            def _encode(payload: dict, *a, **kw) -> str:
+                return payload.get("sub", "")
+
+            def _decode(token: str, *a, **kw) -> dict:
+                return {"sub": token}
+
+            stub.jwt = types.SimpleNamespace(encode=_encode, decode=_decode)
             stub.JWTError = type("JWTError", (), {})
         if mod_name == "governance_reviewer":
             def _noop(*_a, **_kw):


### PR DESCRIPTION
## Summary
- enhance passlib CryptContext stub used for tests with `hash` and `verify` methods
- implement minimal JWT encode/decode in jose stub so authentication tests run without external deps

## Testing
- `pytest -q tests/test_app.py::test_get_me_success`
- `pytest -q tests/test_app.py::test_login_success tests/test_app.py::test_login_bad_password tests/test_app.py::test_login_nonexistent -s`


------
https://chatgpt.com/codex/tasks/task_e_6886a83a58848320b507e19edfb9d559