### PR TITLE
Fix pytest paths in config and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements-minimal.txt mypy
       - run: mypy
-      - run: pytest -q
+      - run: pytest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -r requirements-minimal.txt -r requirements-dev.txt
-      - run: pytest -q
+      - run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
-testpaths = tests
+testpaths =
+    tests
+    transcendental-resonance-frontend/tests
+python_files = test_*.py
 markers =
     asyncio: mark a test as using asyncio


### PR DESCRIPTION
## Summary
- update pytest.ini test paths for new locations
- run `pytest` directly in CI jobs

## Testing
- `pytest --collect-only`

------
https://chatgpt.com/codex/tasks/task_e_6886aa304c188320bcc9eee5e3047e97