### PR TITLE
Fix PyTest discovery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,4 @@
 [pytest]
-testpaths =
-    tests
-    transcendental-resonance-frontend/tests
 python_files = test_*.py
 markers =
     asyncio: mark a test as using asyncio


### PR DESCRIPTION
## Summary
- remove explicit `testpaths` so PyTest finds all tests automatically

## Testing
- `pip install -r requirements-minimal.txt`
- `pytest --collect-only -q`

------
https://chatgpt.com/codex/tasks/task_e_6886adc8331c83208e0e20822fb5b00a