### PR TITLE
Update CI install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements-minimal.txt mypy
+      - run: |
+          pip install -r requirements-minimal.txt -r requirements-dev.txt
+          pip install -e .
       - run: mypy
       - run: pytest


### PR DESCRIPTION
## Summary
- adjust CI workflow dependency install

## Testing
- `mypy`
- `pytest -q` *(fails: ImportError in tests/test_audit_bridge.py)*

------
https://chatgpt.com/codex/tasks/task_e_6886adc4c9248320b703877c371eb344