### PR TITLE
Add __init__ for frontend tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,17 @@
-from tests.conftest import *
+"""Proxy module to load shared fixtures from ``tests/conftest.py``.
+
+The import is performed via file location to avoid ``ImportPathMismatchError``
+when other ``tests`` packages (e.g. the frontend) are also present.
+"""
+
+from importlib import util
+from pathlib import Path
+
+ROOT_TESTS_CONFTST = Path(__file__).resolve().parent / "tests" / "conftest.py"
+spec = util.spec_from_file_location("root_tests_conftest", ROOT_TESTS_CONFTST)
+_module = util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(_module)
+
+globals().update({name: getattr(_module, name) for name in dir(_module) if not name.startswith("_")})
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ testpaths =
 python_files = test_*.py
 markers =
     asyncio: mark a test as using asyncio
+addopts = --import-mode=importlib

--- a/transcendental-resonance-frontend/README.md
+++ b/transcendental-resonance-frontend/README.md
@@ -27,7 +27,7 @@ Replace the backend URL with the `BACKEND_URL` environment variable if your API 
 - `src/pages/` – individual UI pages (login, profile, VibeNodes, etc.)
 - `src/utils/` – shared utilities for API calls and styling
 - `src/main.py` – entry point registering pages and launching the app
-- `tests/` – pytest-based unit tests
+- `tests/` – pytest-based unit tests (package marked by `__init__.py`)
 
 ## Notes
 

--- a/transcendental-resonance-frontend/tests/__init__.py
+++ b/transcendental-resonance-frontend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker


### PR DESCRIPTION
## Summary
- mark `transcendental-resonance-frontend/tests` as a Python package
- load shared fixtures via file path to avoid `ImportPathMismatchError`
- enable importlib mode for pytest
- document new package marker

## Testing
- `pytest transcendental-resonance-frontend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6886ae12920c83209d443b5a784eedbf