### PR TITLE
Fix test module registration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ The import is performed via file location to avoid ``ImportPathMismatchError``
 when other ``tests`` packages (e.g. the frontend) are also present.
 """
 
+import sys
 from importlib import util
 from pathlib import Path
 
@@ -11,7 +12,9 @@ ROOT_TESTS_CONFTST = Path(__file__).resolve().parent / "tests" / "conftest.py"
 spec = util.spec_from_file_location("root_tests_conftest", ROOT_TESTS_CONFTST)
 _module = util.module_from_spec(spec)
 assert spec.loader is not None
+sys.modules[spec.name] = _module
 spec.loader.exec_module(_module)
 
-globals().update({name: getattr(_module, name) for name in dir(_module) if not name.startswith("_")})
-
+globals().update(
+    {name: getattr(_module, name) for name in dir(_module) if not name.startswith("_")}
+)


### PR DESCRIPTION
## Summary
- ensure tests' conftest is added to `sys.modules` before loading
- run lint and tests

## Testing
- `pre-commit run --files conftest.py`
- `pytest -q` *(fails: Plugin already registered)*

------
https://chatgpt.com/codex/tasks/task_e_6886b25df6d08320a41feb9151487c56