### PR TITLE
Fix pytest plugin name clash

### DIFF
--- a/transcendental-resonance-frontend/tests/__init__.py
+++ b/transcendental-resonance-frontend/tests/__init__.py
@@ -1,1 +1,0 @@
-# Package marker


### PR DESCRIPTION
## Summary
- remove the `tests/__init__.py` package marker from the frontend test suite to avoid duplicate plugin names

## Testing
- `pytest -q` *(fails: 27 failed, 78 passed, 39 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886b33a89bc83209a3af5faf2788f70