### PR TITLE
Fix stub reloading condition in tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,7 @@ import sys
 import superNova_2177 as sn
 
 # Reload the real module if a lightweight stub was installed by conftest
-if getattr(sn, "__file__", None) is None:
+if getattr(sn, "__file__", "") in (None, "superNova_2177_stub") or str(getattr(sn, "__file__", "")).endswith("_stub"):
     for mod in list(sys.modules):
         if mod.startswith("fastapi") or mod.startswith("pydantic") or mod.startswith("sqlalchemy"):
             sys.modules.pop(mod, None)

--- a/tests/test_orm_consistency.py
+++ b/tests/test_orm_consistency.py
@@ -5,7 +5,7 @@ import superNova_2177 as sn
 from sqlalchemy import create_engine
 
 # Reload the real module if a lightweight stub is installed
-if getattr(sn, "__file__", None) is None:
+if getattr(sn, "__file__", "") in (None, "superNova_2177_stub") or str(getattr(sn, "__file__", "")).endswith("_stub"):
     for mod in list(sys.modules):
         if mod.startswith("fastapi") or mod.startswith("pydantic") or mod.startswith("sqlalchemy"):
             sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- update stub detection logic in `tests/test_app.py`
- update stub detection logic in `tests/test_orm_consistency.py`

## Testing
- `pip install fastapi sqlalchemy pydantic pydantic-settings structlog email-validator python-multipart`
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886bffa5e58832091e2a5fcef3a89c4