### PR TITLE
Document extras for running tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,6 +24,20 @@ Tests are written with `pytest`. After installing dependencies you can run:
 pytest
 ```
 
+If you want the tests to use the real authentication libraries instead of
+the lightweight stubs provided in `tests/conftest.py`, install the
+optional packages first:
+
+```bash
+pip install redis passlib[bcrypt] python-jose[cryptography]
+```
+
+You can also install both requirement files to match the CI environment:
+
+```bash
+pip install -r requirements-minimal.txt -r requirements-dev.txt
+```
+
 The GitHub Actions workflows (`.github/workflows/ci.yml` and `pr-tests.yml`) run these commands automatically whenever you push or open a pull request.
 
 ## Pre-commit Hooks

--- a/README.md
+++ b/README.md
@@ -280,6 +280,25 @@ pip install -r requirements-minimal.txt
 `email-validator`). With these installed, running `pytest` should
 succeed (`99 passed`).
 
+### Real Module Dependencies
+
+The test suite falls back to lightweight stubs when optional packages
+are missing. To exercise the real authentication module, install the
+actual libraries:
+
+```bash
+pip install redis passlib[bcrypt] python-jose[cryptography]
+```
+
+Installing both requirement files ensures all dependencies used in CI
+are available:
+
+```bash
+pip install -r requirements-minimal.txt -r requirements-dev.txt
+```
+
+Run `pytest` after installing the packages to validate your setup.
+
 ### Makefile Commands
 
 For a quicker workflow you can use the provided `Makefile`:


### PR DESCRIPTION
## Summary
- describe additional packages needed when running the tests with the real auth module in `DEVELOPMENT.md`
- add new *Real Module Dependencies* section in README

## Testing
- `pre-commit run --files README.md DEVELOPMENT.md`
- `pytest -q` *(fails: NameError in LogChain et al.)*

------
https://chatgpt.com/codex/tasks/task_e_6886c19ef8208320a0b2ba352d3177e0