### PR TITLE
Address mint logic in simplified agent

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -264,13 +264,20 @@ class RemixAgent:
                     "root_coin_id": event.get("root_coin_id") or "root",
                     "karma": event.get("karma", "0"),
                     "consent_given": event.get("consent", True),
+                    "is_genesis": event.get("is_genesis", False),
                 },
             )
         elif ev == "MINT":
-            self.storage.set_coin(
-                event["coin_id"],
-                {"owner": event["user"], "value": event.get("value", "0")},
-            )
+            user = self.storage.get_user(event["user"])
+            karma = float(user.get("karma", "0")) if user else 0.0
+            if user and (
+                user.get("is_genesis")
+                or karma >= float(self.config.KARMA_MINT_THRESHOLD)
+            ):
+                self.storage.set_coin(
+                    event["coin_id"],
+                    {"owner": event["user"], "value": event.get("value", "0")},
+                )
         elif ev == "REVOKE_CONSENT":
             u = self.storage.get_user(event["user"])
             if u:


### PR DESCRIPTION
## Summary
- avoid minting coins for low karma users when using the simplified agent

## Testing
- `pytest tests/test_app.py::test_mint_fails_for_low_karma -q`
- `pytest -q` *(fails: 31, passes: 113)*

------
https://chatgpt.com/codex/tasks/task_e_6886d96604b8832096fe26f31695ab70