### PR TITLE
Add pip mirror fallback for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: |
-          pip install -r requirements-minimal.txt -r requirements-dev.txt
+      - name: Install dependencies with fallback mirror
+        run: |
+          python -m pip install --upgrade pip
+          if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://pypi.org/simple; then
+            echo "[INFO] Pip install succeeded using https://pypi.org/simple"
+          else
+            echo "[WARNING] Falling back to mirror: https://mirrors.aliyun.com/pypi/simple/"
+            if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://mirrors.aliyun.com/pypi/simple/; then
+              echo "[INFO] Pip install succeeded using https://mirrors.aliyun.com/pypi/simple/"
+            else
+              echo "[ERROR] All pip index sources failed. Aborting."
+              exit 1
+            fi
+          fi
           pip install -e .
       - run: mypy
       - run: pytest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,6 +14,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements-minimal.txt mypy
+      - name: Install dependencies with fallback mirror
+        run: |
+          python -m pip install --upgrade pip
+          if pip install -r requirements-minimal.txt mypy --index-url=https://pypi.org/simple; then
+            echo "[INFO] Pip install succeeded using https://pypi.org/simple"
+          else
+            echo "[WARNING] Falling back to mirror: https://mirrors.aliyun.com/pypi/simple/"
+            if pip install -r requirements-minimal.txt mypy --index-url=https://mirrors.aliyun.com/pypi/simple/; then
+              echo "[INFO] Pip install succeeded using https://mirrors.aliyun.com/pypi/simple/"
+            else
+              echo "[ERROR] All pip index sources failed. Aborting."
+              exit 1
+            fi
+          fi
       - run: mypy
       - run: pytest


### PR DESCRIPTION
## Summary
- add fallback mirror when installing dependencies in CI workflows

## Testing
- `pytest -q` *(fails: sqlalchemy operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886dda1ff1083208096330723b23a48