### PR TITLE
Add stub fallback for missing FastAPI/SQLAlchemy

### DIFF
--- a/stubs/fastapi_stub.py
+++ b/stubs/fastapi_stub.py
@@ -1,0 +1,59 @@
+class FastAPI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class Depends:
+    def __init__(self, dependency=None):
+        self.dependency = dependency
+
+class HTTPException(Exception):
+    def __init__(self, status_code: int, detail=None):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+class status:
+    HTTP_200_OK = 200
+    HTTP_201_CREATED = 201
+    HTTP_400_BAD_REQUEST = 400
+    HTTP_401_UNAUTHORIZED = 401
+    HTTP_500_INTERNAL_SERVER_ERROR = 500
+
+class Query:
+    def __init__(self, default=None, **kwargs):
+        self.default = default
+
+class Body:
+    def __init__(self, default=None, **kwargs):
+        self.default = default
+
+class UploadFile:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class File:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class BackgroundTasks:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class HTMLResponse:
+    def __init__(self, content=None, **kwargs):
+        self.content = content
+
+class JSONResponse:
+    def __init__(self, content=None, **kwargs):
+        self.content = content
+
+class OAuth2PasswordBearer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class OAuth2PasswordRequestForm:
+    pass
+
+class CORSMiddleware:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/stubs/sqlalchemy_stub.py
+++ b/stubs/sqlalchemy_stub.py
@@ -1,0 +1,57 @@
+class Column:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class Integer:
+    pass
+
+class String:
+    pass
+
+class Text:
+    pass
+
+class Boolean:
+    pass
+
+class DateTime:
+    pass
+
+class ForeignKey:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class Table:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class Float:
+    pass
+
+class JSON:
+    pass
+
+class Session:
+    pass
+
+class IntegrityError(Exception):
+    pass
+
+def create_engine(*args, **kwargs):
+    return None
+
+def sessionmaker(*args, **kwargs):
+    def maker(*margs, **mkwargs):
+        return Session()
+    return maker
+
+def relationship(*args, **kwargs):
+    return None
+
+def declarative_base():
+    class Base:
+        pass
+    return Base
+
+class func:
+    pass

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -278,38 +278,78 @@ import weakref
 from datetime import timedelta
 
 # Web and DB Imports from FastAPI files
-from fastapi import (
-    FastAPI,
-    Depends,
-    HTTPException,
-    status,
-    Query,
-    Body,
-    UploadFile,
-    File,
-    BackgroundTasks,
-)
-from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from fastapi.middleware.cors import CORSMiddleware
+USING_STUBS = False
+try:
+    from fastapi import (
+        FastAPI,
+        Depends,
+        HTTPException,
+        status,
+        Query,
+        Body,
+        UploadFile,
+        File,
+        BackgroundTasks,
+    )
+    from fastapi.responses import HTMLResponse, JSONResponse
+    from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+    from fastapi.middleware.cors import CORSMiddleware
+    from sqlalchemy import (
+        create_engine,
+        Column,
+        Integer,
+        String,
+        Text,
+        Boolean,
+        DateTime,
+        ForeignKey,
+        Table,
+        Float,
+        JSON,
+        func,
+    )
+    from sqlalchemy.orm import sessionmaker, relationship, Session, declarative_base
+    from sqlalchemy.exc import IntegrityError
+except ImportError:  # pragma: no cover - fallback when deps are missing
+    USING_STUBS = True
+    from stubs.fastapi_stub import (
+        FastAPI,
+        Depends,
+        HTTPException,
+        status,
+        Query,
+        Body,
+        UploadFile,
+        File,
+        BackgroundTasks,
+        HTMLResponse,
+        JSONResponse,
+        OAuth2PasswordBearer,
+        OAuth2PasswordRequestForm,
+        CORSMiddleware,
+    )
+    from stubs.sqlalchemy_stub import (
+        create_engine,
+        Column,
+        Integer,
+        String,
+        Text,
+        Boolean,
+        DateTime,
+        ForeignKey,
+        Table,
+        Float,
+        JSON,
+        func,
+        sessionmaker,
+        relationship,
+        Session,
+        declarative_base,
+        IntegrityError,
+    )
 from pydantic import BaseModel, Field, EmailStr, ValidationError
 from pydantic_settings import BaseSettings
 import redis
-from sqlalchemy import (
-    create_engine,
-    Column,
-    Integer,
-    String,
-    Text,
-    Boolean,
-    DateTime,
-    ForeignKey,
-    Table,
-    Float,
-    JSON,
-)
-from sqlalchemy.orm import sessionmaker, relationship, Session, declarative_base
-from sqlalchemy.exc import IntegrityError
 from passlib.context import CryptContext
 from jose import JWTError, jwt
 
@@ -459,7 +499,6 @@ import structlog
 import prometheus_client as prom
 from prometheus_client import REGISTRY
 from config import Config
-from sqlalchemy import func
 from scientific_metrics import (
     calculate_influence_score,
     calculate_interaction_entropy,


### PR DESCRIPTION
## Summary
- handle optional FastAPI/SQLAlchemy by falling back to stubs
- provide simple fastapi and sqlalchemy stub modules

## Testing
- `pytest -q` *(fails: test_hook_manager_basic_async_and_sync and others)*

------
https://chatgpt.com/codex/tasks/task_e_6886dee89bbc8320a9b3fcc89f20be13