### PR TITLE
Fix stub detection

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,12 +8,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import importlib
+import importlib.util
 import sys
 
 import superNova_2177 as sn
 
 # Reload the real module if a lightweight stub was installed by conftest
-if getattr(sn, "__file__", "") in (None, "superNova_2177_stub") or str(getattr(sn, "__file__", "")).endswith("_stub"):
+if (
+    getattr(sn, "__file__", "") in (None, "superNova_2177_stub")
+    or str(getattr(sn, "__file__", "")).endswith("_stub")
+) and importlib.util.find_spec("fastapi") is not None:
     for mod in list(sys.modules):
         if mod.startswith("fastapi") or mod.startswith("pydantic") or mod.startswith("sqlalchemy"):
             sys.modules.pop(mod, None)

--- a/tests/test_orm_consistency.py
+++ b/tests/test_orm_consistency.py
@@ -1,11 +1,15 @@
 import importlib
+import importlib.util
 import sys
 
 import superNova_2177 as sn
 from sqlalchemy import create_engine
 
 # Reload the real module if a lightweight stub is installed
-if getattr(sn, "__file__", "") in (None, "superNova_2177_stub") or str(getattr(sn, "__file__", "")).endswith("_stub"):
+if (
+    getattr(sn, "__file__", "") in (None, "superNova_2177_stub")
+    or str(getattr(sn, "__file__", "")).endswith("_stub")
+) and importlib.util.find_spec("fastapi") is not None:
     for mod in list(sys.modules):
         if mod.startswith("fastapi") or mod.startswith("pydantic") or mod.startswith("sqlalchemy"):
             sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- avoid heavy module reload when FastAPI isn't installed by checking for it in tests

## Testing
- `pytest tests/test_app.py::test_register_success -q`


------
https://chatgpt.com/codex/tasks/task_e_6886e1d9d3dc8320b401cd57219e8f68