### PR TITLE
Fix stub find_spec handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
 import sys
 from pathlib import Path
+import importlib.util
+
+_orig_find_spec = importlib.util.find_spec
+
+
+def _safe_find_spec(name, package=None):
+    try:
+        return _orig_find_spec(name, package)
+    except ValueError:
+        return None
+
+importlib.util.find_spec = _safe_find_spec
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:


### PR DESCRIPTION
## Summary
- patch test conftest to safely handle ValueError from `importlib.util.find_spec`

## Testing
- `pytest tests/test_app.py::test_register_success -q`


------
https://chatgpt.com/codex/tasks/task_e_6886e582414083209b53feee39b8d630