### PR TITLE
Fix Streamlit UI launch instructions and debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ docker-compose up
 
 The application will be available at [http://localhost:8000](http://localhost:8000).
 
+## 🎛️ Local Streamlit UI
+
+To experiment with the validation analyzer locally, launch the Streamlit frontend:
+
+```bash
+streamlit run ui.py
+```
+
+Open [http://localhost:8501](http://localhost:8501) in your browser to interact with the demo.
+
 ## 🌩️ Streamlit Cloud
 
 Deploy the demo UI online with Streamlit Cloud:

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -3540,16 +3540,6 @@ class TranscendentalCLI(cmd.Cmd):
 # and ALLOWED_ORIGINS before running the containers. Ensure these values match
 # your production infrastructure.
 
-if __name__ == "__main__":
-    if '_is_streamlit_context' in globals() and _is_streamlit_context():
-        _run_boot_debug()
-        sys.exit(0)
-
-    import uvicorn
-
-    create_app()
-    run_validation_cycle()
-    uvicorn.run(app, host="0.0.0.0", port=8000)
 
 
 # --- MODULE: storage.py ---
@@ -3924,8 +3914,7 @@ if __name__ == "__main__":
     import os
 
     debug_boot = os.getenv("DEBUG_BOOT_UI")
-    running_with_streamlit = _is_streamlit_context()
-    if debug_boot or running_with_streamlit:
+    if debug_boot:
         _run_boot_debug()
         sys.exit(0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ except Exception:  # pragma: no cover - handle optional dependency
 # not require optional scientific dependencies.
 if "superNova_2177" not in sys.modules:
     import types
+    import importlib
+    import importlib.machinery
     from decimal import Decimal
 
     stub_sn = types.ModuleType("superNova_2177")
@@ -205,6 +207,7 @@ if "superNova_2177" not in sys.modules:
         import types
 
         fastapi_stub = types.ModuleType("fastapi")
+        fastapi_stub.__spec__ = importlib.machinery.ModuleSpec("fastapi", loader=None)
 
         class FastAPI:
             def __init__(self, *a, **kw):
@@ -461,11 +464,17 @@ for mod_name in [
             stub.evaluate_governance_risks = _noop
             stub.apply_governance_actions = _noop
         if mod_name == "structlog":
-            stub.get_logger = lambda *_a, **_kw: types.SimpleNamespace(
-                info=lambda *a, **k: None,
-                warning=lambda *a, **k: None,
-                error=lambda *a, **k: None,
-            )
+            def _logger(*_a, **_kw):
+                ns = types.SimpleNamespace()
+                def _noop(*a, **k):
+                    return None
+                ns.info = _noop
+                ns.warning = _noop
+                ns.error = _noop
+                ns.bind = lambda *a, **k: ns
+                return ns
+
+            stub.get_logger = _logger
             stub.configure = lambda *a, **k: None
             stub.stdlib = types.SimpleNamespace(
                 filter_by_level=None,


### PR DESCRIPTION
## Summary
- document how to launch the Streamlit interface
- skip debug UI unless explicitly enabled
- make FastAPI stub discoverable and add a `bind` method to the structlog stub

## Testing
- `pytest tests/test_app.py::test_status_endpoint -q`
- `pytest -k "dummy" -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e670924083208946d3ec4ffc893a