### PR TITLE
Simplify coin minting in simple mode

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -268,12 +268,7 @@ class RemixAgent:
                 },
             )
         elif ev == "MINT":
-            user = self.storage.get_user(event["user"])
-            karma = float(user.get("karma", "0")) if user else 0.0
-            if user and (
-                user.get("is_genesis")
-                or karma >= float(self.config.KARMA_MINT_THRESHOLD)
-            ):
+            if self.storage.get_user(event["user"]):
                 self.storage.set_coin(
                     event["coin_id"],
                     {"owner": event["user"], "value": event.get("value", "0")},


### PR DESCRIPTION
## Summary
- remove karma threshold check when minting in simple mode

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea5bccec83209cb21840cd06a576