### PR TITLE
Ensure db_models import cleanup

### DIFF
--- a/validator_reputation_tracker.py
+++ b/validator_reputation_tracker.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Any
 from datetime import datetime, timedelta
 from statistics import mean
 from exceptions import DataAccessError
+import sys
 
 from diversity_analyzer import compute_diversity_score
 from semantic_contradiction_resolver import semantic_contradiction_resolver
@@ -141,6 +142,7 @@ def save_reputations(reputations: Dict[str, float], db) -> None:
         from db_models import ValidatorReputation
     except Exception as e:  # pragma: no cover - fallback handling
         logger.error(f"DB models unavailable: {e}")
+        sys.modules.pop("db_models", None)  # allow later imports
         return
 
     for vid, rep in reputations.items():
@@ -163,6 +165,7 @@ def load_reputations(db) -> Dict[str, float]:
         from db_models import ValidatorReputation
     except Exception as e:  # pragma: no cover - fallback handling
         logger.error(f"DB models unavailable: {e}")
+        sys.modules.pop("db_models", None)  # allow later imports
         raise DataAccessError("ValidatorReputation model unavailable") from e
 
     rows = db.query(ValidatorReputation).all()


### PR DESCRIPTION
## Summary
- import `sys` to manage `sys.modules`
- remove `db_models` from `sys.modules` after failed import in reputation helpers

## Testing
- `pytest -q` *(fails: module 'numpy' has no attribute 'isscalar' and TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea5a26a08320a3a1861ff36d96fb