### PR TITLE
Add ping check for Redis during app setup

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2314,6 +2314,10 @@ def create_app() -> FastAPI:
     s = get_settings()
     try:
         redis_client = redis.from_url(s.REDIS_URL, decode_responses=True)
+        try:
+            redis_client.ping()
+        except Exception:
+            raise
         if not hasattr(redis_client, "get"):
             raise AttributeError
     except Exception:  # pragma: no cover - fallback for test stubs


### PR DESCRIPTION
## Summary
- perform a simple `ping()` after connecting to Redis in `create_app`
- fall back to `DummyRedis` if the ping or connection fails

## Testing
- `python -m py_compile superNova_2177.py`


------
https://chatgpt.com/codex/tasks/task_e_6886ea5d4f9883209d13f4793b3fcb4b