### PR TITLE
Pin httpx version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ isort
 flake8
 mypy
 bandit
-httpx
+httpx==0.27.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -3,7 +3,7 @@ python-dateutil
 networkx
 sqlalchemy>=2.0
 pytest-asyncio
-httpx
+httpx==0.27.0
 email-validator
 fastapi
 python-multipart

--- a/requirements.lock
+++ b/requirements.lock
@@ -28,6 +28,7 @@ greenlet==3.2.3
 h11==0.16.0
 hf-xet==1.1.5
 huggingface-hub==0.34.1
+httpx==0.27.0
 idna==3.10
 iniconfig==2.1.0
 isort==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ streamlit>=1.28
 qrcode
 asyncpg
 email-validator
-httpx
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- pin `httpx==0.27.0` in dependency lists to ensure the real client is available during tests

## Testing
- `pytest -q` *(fails: 33 failed, 112 passed, 196 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea57b608832088c71ab3d153ffb6