### PR TITLE
Fix Streamlit UI launch instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
           pip install -e .
       - run: mypy
       - run: pytest
+      - name: Streamlit smoke test
+        run: |
+          streamlit run ui.py --server.headless true &
+          sleep 10
+          curl -f http://localhost:8501
+          pkill streamlit

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -30,3 +30,9 @@ jobs:
           fi
       - run: mypy
       - run: pytest
+      - name: Streamlit smoke test
+        run: |
+          streamlit run ui.py --server.headless true &
+          sleep 10
+          curl -f http://localhost:8501
+          pkill streamlit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: install test lint
+.PHONY: ui
 
 install:
 	python setup_env.py
@@ -7,4 +8,7 @@ test:
 	pytest -q
 
 lint:
-	mypy
+        mypy
+
+ui:
+        streamlit run ui.py

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ To experiment with the validation analyzer locally, launch the Streamlit fronten
 ```bash
 streamlit run ui.py
 ```
+Run this command from the repository root. **Do not** execute `python ui.py`
+directly as that bypasses Streamlit's runtime.
 
 Open [http://localhost:8501](http://localhost:8501) in your browser to interact with the demo.
 

--- a/launch_ui.sh
+++ b/launch_ui.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+streamlit run ui.py


### PR DESCRIPTION
## Summary
- add warning in README about launching `ui.py`
- provide `launch_ui.sh`
- expose `ui` target in Makefile
- add basic Streamlit smoke tests to CI

## Testing
- `pytest -q` *(fails: AttributeError in tests/test_app.py)*

------
https://chatgpt.com/codex/tasks/task_e_6886ed4511a88320a045f4dc88571191