### PR TITLE
Fix fastapi find_spec result

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,10 @@ if "superNova_2177" not in sys.modules:
         import types
 
         fastapi_stub = types.ModuleType("fastapi")
-        fastapi_stub.__spec__ = importlib.machinery.ModuleSpec("fastapi", loader=None)
+        # Avoid providing a ModuleSpec so ``importlib.util.find_spec('fastapi')``
+        # returns ``None`` when FastAPI isn't installed. This ensures the tests
+        # don't try to import the real package in minimal environments.
+        fastapi_stub.__spec__ = None
 
         class FastAPI:
             def __init__(self, *a, **kw):


### PR DESCRIPTION
## Summary
- fix fastapi stub `__spec__` to return `None` with `find_spec`

## Testing
- `pytest -q` *(fails: 30 failed, 80 passed, 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886edb0c13c83209ae3a6c88b465387