### PR TITLE
Replace deprecated session.query calls

### DIFF
--- a/prediction_manager.py
+++ b/prediction_manager.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Callable
 
 from quantum_sim import QuantumContext
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 try:  # Prefer SystemState from db_models if available
@@ -62,7 +63,13 @@ class PredictionManager:
             return
         session = self.session_factory()
         try:
-            state = session.query(SystemState).filter(SystemState.key == key).first()
+            state = (
+                session.execute(
+                    select(SystemState).filter(SystemState.key == key)
+                )
+                .scalars()
+                .first()
+            )
             if state:
                 state.value = value
             else:
@@ -77,7 +84,13 @@ class PredictionManager:
             return self.state_service.get_state(key, None)
         session = self.session_factory()
         try:
-            state = session.query(SystemState).filter(SystemState.key == key).first()
+            state = (
+                session.execute(
+                    select(SystemState).filter(SystemState.key == key)
+                )
+                .scalars()
+                .first()
+            )
             return state.value if state else None
         finally:
             session.close()

--- a/tests/test_hypothesis_tracker.py
+++ b/tests/test_hypothesis_tracker.py
@@ -2,6 +2,7 @@ import re
 
 from hypothesis_tracker import register_hypothesis
 from db_models import HypothesisRecord
+from sqlalchemy import select
 
 
 def test_register_hypothesis_generates_unique_id(test_db):
@@ -26,7 +27,11 @@ def test_metadata_json_persistence_new_session(test_db):
 
     new_session = SessionLocal()
     try:
-        record = new_session.query(HypothesisRecord).filter_by(id=hid).first()
+        record = (
+            new_session.execute(select(HypothesisRecord).filter_by(id=hid))
+            .scalars()
+            .first()
+        )
         assert record is not None
         assert record.metadata_json == metadata
     finally:

--- a/tests/test_orm_consistency.py
+++ b/tests/test_orm_consistency.py
@@ -3,7 +3,7 @@ import importlib.util
 import sys
 
 import superNova_2177 as sn
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 
 # Reload the real module if a lightweight stub is installed
 if (
@@ -24,6 +24,6 @@ def test_orm_consistency():
     sn.Base.metadata.create_all(engine)
     session = sn.SessionLocal(bind=engine)
     try:
-        session.query(sn.Harmonizer).all()
+        session.execute(select(sn.Harmonizer)).scalars().all()
     finally:
         session.close()

--- a/validate_hypothesis.py
+++ b/validate_hypothesis.py
@@ -19,7 +19,7 @@ from typing import Dict, Any, List
 from datetime import datetime, timedelta
 import random
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 from db_models import HypothesisRecord, LogEntry
 
@@ -271,7 +271,13 @@ For more information: https://github.com/yourusername/superNova_2177
         Session = sessionmaker(bind=engine)
         session = Session()
         try:
-            record = session.query(HypothesisRecord).filter_by(id=args.hypothesis).first()
+            record = (
+                session.execute(
+                    select(HypothesisRecord).filter_by(id=args.hypothesis)
+                )
+                .scalars()
+                .first()
+            )
             if not record:
                 print(f"❌ Hypothesis {args.hypothesis} not found in database")
                 return 1
@@ -281,7 +287,13 @@ For more information: https://github.com/yourusername/superNova_2177
                 print(f"❌ No validations found for hypothesis {args.hypothesis}")
                 return 1
 
-            log_entries = session.query(LogEntry).filter(LogEntry.id.in_(log_ids)).all()
+            log_entries = (
+                session.execute(
+                    select(LogEntry).filter(LogEntry.id.in_(log_ids))
+                )
+                .scalars()
+                .all()
+            )
             for entry in log_entries:
                 try:
                     payload = json.loads(entry.payload) if entry.payload else {}


### PR DESCRIPTION
## Summary
- swap `session.query` for modern `session.execute(select(...))` pattern
- adjust result retrieval via `.scalars()`
- import `select` where required

## Testing
- `pytest -q` *(fails: Engine object KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_6886f0fab8f083208061a0d9f7e8f118