### PR TITLE
Patch SQLite fixture to update metadata binds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -715,12 +715,19 @@ def _setup_sqlite(monkeypatch, db_path):
 
     monkeypatch.setattr(db_models, "engine", engine, raising=False)
     monkeypatch.setattr(db_models, "SessionLocal", Session, raising=False)
+    if getattr(db_models.Base.metadata, "bind", None) is not engine:
+        monkeypatch.setattr(db_models.Base.metadata, "bind", engine, raising=False)
 
     for mod in list(sys.modules.values()):
         if getattr(mod, "engine", None) is old_engine:
             monkeypatch.setattr(mod, "engine", engine, raising=False)
         if getattr(mod, "SessionLocal", None) is old_session:
             monkeypatch.setattr(mod, "SessionLocal", Session, raising=False)
+        base = getattr(mod, "Base", None)
+        if base is not None:
+            metadata = getattr(base, "metadata", None)
+            if getattr(metadata, "bind", None) is old_engine:
+                monkeypatch.setattr(metadata, "bind", engine, raising=False)
 
     db_models.Base.metadata.create_all(bind=engine)
     return engine, Session, db_models


### PR DESCRIPTION
## Summary
- ensure `_setup_sqlite` patches any modules that still reference the old SQLAlchemy engine/sessionmaker
- update `Base.metadata.bind` for db_models and any loaded modules to avoid stale binds

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6886f0f3d0a083209b20a00f1ca7fb40