### PR TITLE
Handle SentenceTransformer download failures

### DIFF
--- a/tests/test_network_coordination_detector.py
+++ b/tests/test_network_coordination_detector.py
@@ -133,3 +133,35 @@ def test_detect_semantic_coordination_no_numpy_sklearn(monkeypatch):
     assert result["semantic_clusters"]
     assert result["semantic_clusters"][0]["similarity_score"] >= 0.8
 
+
+def test_detect_semantic_coordination_sentence_transformer_failure(monkeypatch):
+    validations = [
+        {
+            "validator_id": "v1",
+            "hypothesis_id": "h1",
+            "score": 0.8,
+            "timestamp": "2025-01-01T00:00:00Z",
+            "note": "the quick brown fox jumps over the lazy dog",
+        },
+        {
+            "validator_id": "v2",
+            "hypothesis_id": "h2",
+            "score": 0.8,
+            "timestamp": "2025-01-01T00:01:00Z",
+            "note": "the quick brown fox leaps over the lazy dog",
+        },
+    ]
+
+    import types, sys
+
+    class FailingST:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("no model")
+
+    fake_module = types.SimpleNamespace(SentenceTransformer=FailingST)
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
+
+    result = detect_semantic_coordination(validations)
+    assert result["semantic_clusters"]
+    assert result["semantic_clusters"][0]["similarity_score"] >= 0.8
+


### PR DESCRIPTION
## Summary
- avoid network downloads when initializing `SentenceTransformer`
- add fallback test for when `SentenceTransformer` instantiation fails

## Testing
- `pytest tests/test_network_coordination_detector.py -q`
- `pytest -q` *(fails: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6886f10056848320805c5826f3443359