### PR TITLE
Update CI streamlit smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 10
-          curl -f http://localhost:8501
+          sleep 15
+          curl -f http://localhost:8501 || (echo "Streamlit UI not ready" && exit 1)
           pkill streamlit


### PR DESCRIPTION
## Summary
- extend the Streamlit smoke test wait time to 15 seconds
- explicitly fail if the UI is not ready

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object cannot be interpreted as an integer)*

------
https://chatgpt.com/codex/tasks/task_e_6886f8171cac832088e33662ea1c41d0