### PR TITLE
Add Streamlit configuration

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+headless = true
+enableCORS = false
+port = 8501


### PR DESCRIPTION
## Summary
- create `.streamlit` directory
- configure Streamlit to run headless without CORS on port 8501

## Testing
- `pytest -q` *(fails: 34 failed, 112 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6886f81616b8832082ba4d989198fe18