### PR TITLE
Handle missing demo file in UI

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -104,8 +104,16 @@ def main() -> None:
 
     if run_clicked:
         if demo_mode:
-            with open("sample_validations.json") as f:
-                data = json.load(f)
+            try:
+                with open("sample_validations.json") as f:
+                    data = json.load(f)
+            except FileNotFoundError:
+                st.warning("Demo file not found, using default dataset.")
+                data = {
+                    "validations": [
+                        {"validator": "A", "target": "B", "score": 0.9}
+                    ]
+                }
         elif uploaded_file is not None:
             data = json.load(uploaded_file)
         else:


### PR DESCRIPTION
## Summary
- avoid crashing when demo data is missing by showing a warning and using a fallback dataset

## Testing
- `pytest -q` *(fails: sqlalchemy module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886f8147fd0832083fd7dd9985e0d75