### PR TITLE
Update workflow sleep duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 10
+          sleep 15
           curl -f http://localhost:8501
           pkill streamlit

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 10
+          sleep 15
           curl -f http://localhost:8501
           pkill streamlit


### PR DESCRIPTION
## Summary
- increase wait time for Streamlit startup in CI workflows

## Testing
- `mypy`
- `pytest -q` *(fails: TypeError 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6886f7fa2f2483209ed293a7ea457218