### PR TITLE
Fix Streamlit secrets fallback

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -3,6 +3,11 @@ import streamlit as st
 import networkx as nx
 import matplotlib.pyplot as plt
 
+try:
+    SECRETS = st.secrets
+except Exception:  # pragma: no cover - environment may lack st.secrets
+    SECRETS = {"SECRET_KEY": "dev", "DATABASE_URL": "sqlite:///:memory:"}
+
 from validation_integrity_pipeline import analyze_validation_integrity
 from network.network_coordination_detector import build_validation_graph
 
@@ -88,8 +93,8 @@ def main() -> None:
         "mode to see the pipeline in action."
     )
 
-    secret_key = st.secrets.get("SECRET_KEY", "not set")
-    database_url = st.secrets.get("DATABASE_URL", "not set")
+    secret_key = SECRETS.get("SECRET_KEY", "not set")
+    database_url = SECRETS.get("DATABASE_URL", "not set")
 
     with st.sidebar:
         st.header("Environment")


### PR DESCRIPTION
## Summary
- ensure `ui.py` has a fallback when `st.secrets` is unavailable
- update use of Streamlit secrets to use the fallback mapping

## Testing
- `pytest -q` *(fails: TypeError: 'FastAPI' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6886f7eb01c48320b1a46cbf191a536f