### PR TITLE
Implement asyncio fallback for pytest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,7 @@
-# Package marker
+"""Test suite package configuration."""
+
+# Automatically register the async fallback plugin so that async tests run
+# even when ``pytest-asyncio`` is not installed.
+# The plugin module lives inside this package, so use the fully qualified name.
+pytest_plugins = ["tests.async_fallback"]
+

--- a/tests/async_fallback.py
+++ b/tests/async_fallback.py
@@ -1,0 +1,10 @@
+import asyncio
+import inspect
+import pytest
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    testfunc = pyfuncitem.obj
+    if inspect.iscoroutinefunction(testfunc):
+        asyncio.run(testfunc(**pyfuncitem.funcargs))
+        return True


### PR DESCRIPTION
## Summary
- add a plugin to run async tests when `pytest-asyncio` isn't installed
- load the plugin via `tests.__init__`

## Testing
- `pytest tests/test_hook_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f83547b08320843a3a16e0484c5a