### PR TITLE
Fix Streamlit smoke test timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 10
-          curl -f http://localhost:8501
+          sleep 15
+          if ! curl -f http://localhost:8501; then
+            echo "[ERROR] Curl failed to reach Streamlit server"
+            pkill streamlit
+            exit 1
+          fi
           pkill streamlit

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 10
-          curl -f http://localhost:8501
+          sleep 15
+          if ! curl -f http://localhost:8501; then
+            echo "[ERROR] Curl failed to reach Streamlit server"
+            pkill streamlit
+            exit 1
+          fi
           pkill streamlit


### PR DESCRIPTION
## Summary
- bump Streamlit smoke test startup time from 10s to 15s
- echo a helpful error if curl fails

## Testing
- `pytest -q` *(fails: sqlalchemy.exc.AmbiguousForeignKeysError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6886f80faf4c832086d6ce5af7623f80