### PR TITLE
Fix stub MINT logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,10 +165,12 @@ if "superNova_2177" not in sys.modules:
                     },
                 )
             elif ev == "MINT":
-                self.storage.set_coin(
-                    event["coin_id"],
-                    {"owner": event["user"], "value": event.get("value", "0")},
-                )
+                user = self.storage.get_user(event["user"])
+                if user and float(user.get("karma", "0")) >= float(self.config.KARMA_MINT_THRESHOLD):
+                    self.storage.set_coin(
+                        event["coin_id"],
+                        {"owner": event["user"], "value": event.get("value", "0")},
+                    )
             elif ev == "REVOKE_CONSENT":
                 u = self.storage.get_user(event["user"])
                 if u:


### PR DESCRIPTION
## Summary
- update the RemixAgent stub in tests to only mint when the user meets the karma threshold

## Testing
- `pytest -q` *(fails: TypeError 'NoneType' object has no attribute, AttributeError 'numpy' ... 30 failed, 81 passed, 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886fff5ed0c8320b5fd8682476f6991