### PR TITLE
Fix mint karma check in stub agent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,11 +166,13 @@ if "superNova_2177" not in sys.modules:
                 )
             elif ev == "MINT":
                 user = self.storage.get_user(event["user"])
-                if user and float(user.get("karma", "0")) >= float(self.config.KARMA_MINT_THRESHOLD):
-                    self.storage.set_coin(
-                        event["coin_id"],
-                        {"owner": event["user"], "value": event.get("value", "0")},
-                    )
+                if user:
+                    karma = Decimal(user.get("karma", "0"))
+                    if karma >= self.config.KARMA_MINT_THRESHOLD:
+                        self.storage.set_coin(
+                            event["coin_id"],
+                            {"owner": event["user"], "value": event.get("value", "0")},
+                        )
             elif ev == "REVOKE_CONSENT":
                 u = self.storage.get_user(event["user"])
                 if u:


### PR DESCRIPTION
## Summary
- align RemixAgent stub mint logic with main agent

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q` *(fails: sqlalchemy.exc.ArgumentError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688702f3da288320aa2165de0f98bb69