### PR TITLE
Update sqlite setup skip logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -736,7 +736,7 @@ def _setup_sqlite(monkeypatch, db_path):
     from sqlalchemy.orm import sessionmaker
     import db_models, sys, pytest
 
-    if getattr(create_engine, "__module__", "") == "stubs.sqlalchemy_stub":
+    if "stubs" in getattr(create_engine, "__module__", ""):
         pytest.skip("SQLAlchemy not available")
 
     engine = create_engine(
@@ -763,7 +763,7 @@ def _setup_sqlite(monkeypatch, db_path):
             base = getattr(mod, "Base", None)
             if base is not None:
                 metadata = getattr(base, "metadata", None)
-                if getattr(metadata, "bind", None) is old_engine:
+                if metadata and getattr(metadata, "bind", None) is old_engine:
                     monkeypatch.setattr(metadata, "bind", engine, raising=False)
         except AttributeError:
             continue


### PR DESCRIPTION
## Summary
- skip database tests when only stub SQLAlchemy is present
- avoid AttributeError when patching bound metadata

## Testing
- `pre-commit run --files tests/conftest.py` *(fails: black, isort, flake8)*
- `pytest -q` *(fails: 18 failed, 93 passed, 35 skipped, 65 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688702eb81588320a1db3d19925a874a