### PR TITLE
Quiet startup logs and disable propagation

### DIFF
--- a/annual_audit.py
+++ b/annual_audit.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 class Config:
     """Default configuration for the audit task."""

--- a/audit_bridge.py
+++ b/audit_bridge.py
@@ -12,6 +12,7 @@ from causal_graph import InfluenceGraph
 from db_models import SystemState, LogEntry
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 from exceptions import DataParseError

--- a/audit_explainer.py
+++ b/audit_explainer.py
@@ -21,6 +21,7 @@ from db_models import SystemState, LogEntry # For accessing logs and hypothesis 
 import hypothesis_tracker as ht # For getting hypothesis records
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 from exceptions import DataParseError

--- a/causal_trigger.py
+++ b/causal_trigger.py
@@ -10,6 +10,7 @@ from audit_explainer import trace_causal_chain
 from governance_reviewer import evaluate_governance_risks, apply_governance_actions
 
 logger = logging.getLogger("superNova_2177.trigger")
+logger.propagate = False
 
 
 from exceptions import DataParseError

--- a/diversity_analyzer.py
+++ b/diversity_analyzer.py
@@ -26,6 +26,7 @@ from temporal_consistency_checker import analyze_temporal_consistency
 from network.network_coordination_detector import detect_score_coordination
 
 logger = logging.getLogger("superNova_2177.certifier")
+logger.propagate = False
 
 
 # --- Configuration ---

--- a/governance/governance_reviewer.py
+++ b/governance/governance_reviewer.py
@@ -12,6 +12,7 @@ import logging
 import networkx as nx  # Required for cycle detection
 
 logger = logging.getLogger("superNova_2177.governance")
+logger.propagate = False
 
 # Configurable thresholds and rule toggles
 class Config:

--- a/hypothesis_reasoner.py
+++ b/hypothesis_reasoner.py
@@ -15,6 +15,7 @@ import textwrap # Added for text summarization
 import logging
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 from sqlalchemy.orm import Session
 from sqlalchemy import func, select
 

--- a/hypothesis_tracker.py
+++ b/hypothesis_tracker.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 from exceptions import DataParseError

--- a/immutable_tri_species_adjust.py
+++ b/immutable_tri_species_adjust.py
@@ -50,6 +50,7 @@ class InvalidEventError(Exception):
     pass
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 class ImmutableTriSpeciesAgent(RemixAgent):
     """

--- a/introspection/introspection_pipeline.py
+++ b/introspection/introspection_pipeline.py
@@ -17,6 +17,7 @@ from db_models import LogEntry # LogEntry is still needed here for querying vali
 import hypothesis_tracker as ht # hypothesis_tracker is now ORM-based internally, but its public methods return dicts
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 from exceptions import DataParseError

--- a/network/network_coordination_detector.py
+++ b/network/network_coordination_detector.py
@@ -25,6 +25,7 @@ import os
 import math
 
 logger = logging.getLogger("superNova_2177.coordination")
+logger.propagate = False
 
 
 class Config:

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -3507,7 +3507,7 @@ class TranscendentalCLI(cmd.Cmd):
     def do_add_user(self, arg):
         args = arg.split()
         if len(args) < 3:
-            print("Usage: add_user <name> <species> <is_genesis>")
+            logger.info("Usage: add_user <name> <species> <is_genesis>")
             return
         name, species, is_genesis = args[0], args[1], args[2] == "True"
         event = AddUserPayload(
@@ -3527,7 +3527,7 @@ class TranscendentalCLI(cmd.Cmd):
             nonce=uuid.uuid4().hex,
         )
         self.agent.process_event(event)
-        print(f"User {name} added.")
+        logger.info("User %s added.", name)
 
     # Add all other do_ methods, making it comprehensive with 50+ commands.
 
@@ -3948,7 +3948,7 @@ def _run_boot_debug() -> None:
             except Exception as exc:  # pragma: no cover - debug only
                 st.error(f"Dummy scan error: {exc}")
     except Exception as exc:  # pragma: no cover - debug only
-        print(f"Streamlit debug view failed: {exc}")
+        logger.error("Streamlit debug view failed: %s", exc)
 
 
 if __name__ == "__main__":
@@ -3975,7 +3975,7 @@ if __name__ == "__main__":
         try:
             import pytest  # type: ignore
         except ImportError:
-            print("pytest not installed.")
+            logger.error("pytest not installed.")
             sys.exit(1)
 
         pytest.main(["-vv"])
@@ -3985,10 +3985,11 @@ if __name__ == "__main__":
         try:
             import uvicorn
         except ImportError:
-            print("uvicorn not installed.")
+            logger.error("uvicorn not installed.")
             sys.exit(1)
 
-        run_validation_cycle()
+        if os.getenv("RUN_STARTUP_VALIDATIONS", "1") != "0":
+            run_validation_cycle()
         uvicorn.run(app, host="0.0.0.0", port=8000)
 
 # COMMUNITY_GUIDELINES_V40 GENERATED SUCCESSFULLY — ZERO DELETION CONFIRMED

--- a/temporal_consistency_checker.py
+++ b/temporal_consistency_checker.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     parser = None  # type: ignore[assignment]
 
 logger = logging.getLogger("superNova_2177.temporal")
+logger.propagate = False
 
 class Config:
     MAX_VALIDATION_GAP_HOURS = 96       # Warn if large time gaps appear

--- a/transcendental-resonance-frontend/src/utils/api.py
+++ b/transcendental-resonance-frontend/src/utils/api.py
@@ -11,6 +11,7 @@ from nicegui import ui
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 TOKEN: Optional[str] = None
 

--- a/ui.py
+++ b/ui.py
@@ -1,8 +1,12 @@
 import json
+import logging
 
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
 
 try:
     st_secrets = st.secrets
@@ -144,5 +148,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    print("✅ Streamlit UI started. Launching main()...")
+    logger.info("\u2705 Streamlit UI started. Launching main()...")
     main()

--- a/validation_certifier.py
+++ b/validation_certifier.py
@@ -20,6 +20,7 @@ from network.network_coordination_detector import analyze_coordination_patterns
 from temporal_consistency_checker import analyze_temporal_consistency, assess_temporal_trust_factor
 
 logger = logging.getLogger("superNova_2177.certifier")
+logger.propagate = False
 
 class Config:
     """Unified configuration for all validation analysis components."""

--- a/validator_reputation_tracker.py
+++ b/validator_reputation_tracker.py
@@ -18,6 +18,7 @@ from semantic_contradiction_resolver import semantic_contradiction_resolver
 
 
 logger = logging.getLogger("superNova_2177.reputation")
+logger.propagate = False
 
 # --- Configuration ---
 class Config:

--- a/validators/daily_participation_validator.py
+++ b/validators/daily_participation_validator.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("superNova_2177.participation")
+logger.propagate = False
 
 
 class Config:

--- a/validators/reputation_influence_tracker.py
+++ b/validators/reputation_influence_tracker.py
@@ -15,6 +15,7 @@ from statistics import mean, stdev
 from datetime import datetime
 
 logger = logging.getLogger("superNova_2177.reputation")
+logger.propagate = False
 
 class Config:
     DEFAULT_REPUTATION = 0.5

--- a/validators/strategies/voting_consensus_engine.py
+++ b/validators/strategies/voting_consensus_engine.py
@@ -17,6 +17,7 @@ from enum import Enum
 from datetime import datetime
 
 logger = logging.getLogger("superNova_2177.voting")
+logger.propagate = False
 
 
 class VotingMethod(Enum):


### PR DESCRIPTION
## Summary
- disable log propagation for module loggers
- gate startup validation cycle on `RUN_STARTUP_VALIDATIONS`
- replace noisy `print` calls in `superNova_2177.py` and `ui.py`

## Testing
- `pytest -q` *(fails: sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887038f6c708320ae81f6ace14e067f