### PR TITLE
Fix path in Streamlit RFC

### DIFF
--- a/rfcs/001-gui-integration/README.md
+++ b/rfcs/001-gui-integration/README.md
@@ -4,11 +4,11 @@
 The validation toolkit currently requires command-line interaction, which can be a barrier for non-technical users who want to run or review validations.
 
 ## Proposed Solution
-Introduce a `app.py` module built with Streamlit that exposes the existing `validate_hypothesis` logic through a simple web interface. Users can select a hypothesis file, trigger validation, and view the resulting reports directly in the browser.
+Introduce a `ui.py` module built with Streamlit that exposes the existing `validate_hypothesis` logic through a simple web interface. Users can select a hypothesis file, trigger validation, and view the resulting reports directly in the browser.
 
 ## Alternatives
 - Continue relying solely on the command-line interface.
 - Build a custom React or Django front‑end instead of Streamlit.
 
 ## Impact
-A lightweight GUI makes the validation pipeline more accessible and provides a starting point for future web-based features. Deployment can be as easy as running `streamlit run app.py` on a server or container.
+A lightweight GUI makes the validation pipeline more accessible and provides a starting point for future web-based features. Deployment can be as easy as running `streamlit run ui.py` on a server or container.


### PR DESCRIPTION
## Summary
- update references to `ui.py` in the GUI integration RFC

## Testing
- `pytest -q` *(fails: test_mint_success, test_buy_coin_success, test_creator_karma_gain_on_react, test_export_causal_path_handles_malformed_entries, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68870722b2548320bba4eeb6acb4cbe1