### PR TITLE
Add numpy scalar aliases to test stub

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -599,8 +599,12 @@ for mod_name in [
             # bool_ is used as an alias for Python's ``bool`` within the test
             # suite.  Define it here so that the NumPy stub mirrors the real
             # module interface and avoid ``AttributeError`` when ``numpy.bool_``
-            # is accessed.
+            # is accessed.  Provide float_ and int_ aliases as well so code that
+            # expects these numpy scalar types continues to operate when running
+            # against the lightweight stub.
             stub.bool_ = bool
+            stub.float_ = float
+            stub.int_ = int
         if mod_name == "dateutil":
             parser_mod = types.ModuleType("dateutil.parser")
             def _parse(val):


### PR DESCRIPTION
## Summary
- extend the numpy stub in `tests/conftest.py` with scalar type aliases

## Testing
- `pytest -q` *(fails: TypeError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887072b40308320b4e2a113877d7ff1