### PR TITLE
Document Streamlit secrets fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ directly as that bypasses Streamlit's runtime.
 
 Open [http://localhost:8501](http://localhost:8501) in your browser to interact with the demo.
 
+`ui.py` reads configuration from `st.secrets` when running under Streamlit. If
+the secrets dictionary is unavailable (such as during local development), the
+module falls back to a development setup equivalent to:
+
+```python
+{"SECRET_KEY": "dev", "DATABASE_URL": "sqlite:///:memory:"}
+```
+
 ## 🌩️ Streamlit Cloud
 
 Deploy the demo UI online with Streamlit Cloud:

--- a/tests/test_ui_fallback.py
+++ b/tests/test_ui_fallback.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+import types
+
+
+def test_ui_defaults_to_dev_secrets(monkeypatch):
+    """Importing ui without ``st.secrets`` should use dev configuration."""
+    # Stub the streamlit module so accessing ``st.secrets`` raises an error
+    stub = types.ModuleType("streamlit")
+
+    def __getattr__(name):
+        if name == "secrets":
+            raise RuntimeError("no secrets")
+        return lambda *a, **k: None
+
+    stub.__getattr__ = __getattr__
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+
+    # Provide a minimal matplotlib stub for the import in ui
+    mpl = types.ModuleType("matplotlib")
+    plt = types.ModuleType("matplotlib.pyplot")
+    mpl.pyplot = plt
+    monkeypatch.setitem(sys.modules, "matplotlib", mpl)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", plt)
+
+    ui = importlib.import_module("ui")
+    importlib.reload(ui)
+    assert ui.st_secrets == {
+        "SECRET_KEY": "dev",
+        "DATABASE_URL": "sqlite:///:memory:",
+    }
+


### PR DESCRIPTION
## Summary
- document dev config fallback for `ui.py` when `st.secrets` is missing
- add a minimal test verifying the fallback dictionary

## Testing
- `pytest -q tests/test_ui_fallback.py`

------
https://chatgpt.com/codex/tasks/task_e_6887071cb1b88320b2c5ade59ee0c9c8