### PR TITLE
Fix Makefile commands indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	pytest -q
 
 lint:
-        mypy
+	mypy
 
 ui:
-        streamlit run ui.py
+	streamlit run ui.py


### PR DESCRIPTION
## Summary
- ensure `lint` and `ui` commands in Makefile use tab indentation

## Testing
- `make --dry-run lint`
- `make --dry-run ui`


------
https://chatgpt.com/codex/tasks/task_e_68870736f5f8832082cdb4a04a766d01