### PR TITLE
Fix Makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	pytest -q
 
 lint:
-        mypy
+	mypy
 
 ui:
-        streamlit run ui.py
+	streamlit run ui.py


### PR DESCRIPTION
## Summary
- use real tabs for `lint` and `ui` commands

## Testing
- `pytest -q` *(fails: 18 failed, 93 passed, 35 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887071664e083209a0e22f99b080b4a