### PR TITLE
Fix workflows to install streamlit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Install dependencies with fallback mirror
         run: |
           python -m pip install --upgrade pip
+          # Ensure Streamlit is present for smoke tests
+          pip install streamlit
           if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://pypi.org/simple; then
             echo "[INFO] Pip install succeeded using https://pypi.org/simple"
           else

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Install dependencies with fallback mirror
         run: |
           python -m pip install --upgrade pip
+          # Ensure Streamlit is present for smoke tests
+          pip install streamlit
           if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://pypi.org/simple; then
             echo "[INFO] Pip install succeeded using https://pypi.org/simple"
           else


### PR DESCRIPTION
## Summary
- ensure streamlit is installed before running smoke tests in CI
- apply same change in PR tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/pr-tests.yml`
- `pytest -q` *(fails: TypeError and AssertionError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68870b3fc8d08320840c876c50a123c8