### PR TITLE
Add streamlit_json dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
   If you prefer to manage the environment manually, install the required
   packages yourself using `requirements.txt`:
   ```bash
-  pip install -r requirements.txt  # installs numpy, python-dateutil, email-validator, etc.
+  pip install -r requirements.txt  # installs numpy, python-dateutil, email-validator, streamlit_json, streamlit-ace, etc.
   ```
    A PyPI wheel is currently unavailable. Run `python setup_env.py` or use the online installer scripts:
    ```bash
@@ -177,7 +177,7 @@ Set up a Python environment and install the package and its dependencies:
 ```bash
 pip install .
 # install optional libraries used by the tests
-pip install -r requirements.txt
+pip install -r requirements.txt  # includes streamlit_json and streamlit-ace
 # To install the exact versions used during development,
 # use the generated `requirements.lock` file instead:
 # pip install -r requirements.lock
@@ -283,7 +283,7 @@ Before running the tests, install the packages from `requirements.txt` (or the e
 
 ```bash
 python setup_env.py --locked  # install from requirements.lock
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs streamlit_json and streamlit-ace
 ```
 
 ### Test Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
     "scikit-learn",
     "streamlit",
     "asyncpg",
-    "email-validator"
+    "email-validator",
+    "streamlit_json",
+    "streamlit-ace"
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,6 @@ flake8
 mypy
 bandit
 httpx==0.27.0
+
+streamlit_json
+streamlit-ace

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,6 @@ qrcode
 asyncpg
 email-validator
 httpx==0.27.0
+
+streamlit_json
+streamlit-ace


### PR DESCRIPTION
## Summary
- add `streamlit_json` and `streamlit-ace` to requirements files and `pyproject.toml`
- update README installation instructions with the new packages

## Testing
- `pytest -q` *(fails: 17 failed, 95 passed, 35 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68870bb4c38c832081381edd9732e599