### PR TITLE
Add result download button to Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ directly as that bypasses Streamlit's runtime.
 
 Open [http://localhost:8501](http://localhost:8501) in your browser to interact with the demo.
 
+After running an analysis, use the **Download Result** button to save the JSON output for offline inspection.
+
 `ui.py` reads configuration from `st.secrets` when running under Streamlit. If
 the secrets dictionary is unavailable (such as during local development), the
 module falls back to a development setup equivalent to:


### PR DESCRIPTION
## Summary
- retain analysis results within the UI
- provide a Streamlit download button so users can save the JSON
- document the new feature in the README

## Testing
- `pre-commit run --files ui.py README.md`
- `pytest -q` *(fails: TypeError and sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68870bb6ac7c8320a8feb1e263f4963e