### PR TITLE
Add disclaimer tooltip in Streamlit UI

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -151,6 +151,15 @@ def main() -> None:
         "Upload a JSON file with a `validations` array, paste JSON below, "
         "or enable demo mode to see the pipeline in action."
     )
+    disclaimer = (
+        "\u26a0\ufe0f Metrics like Harmony Score and Resonance are purely symbolic "
+        "and carry no monetary value. See README.md lines 12–13 for the full "
+        "disclaimer."
+    )
+    st.markdown(
+        f"<span title='{disclaimer}'><em>{disclaimer}</em></span>",
+        unsafe_allow_html=True,
+    )
 
     if "validations_json" not in st.session_state:
         st.session_state["validations_json"] = ""


### PR DESCRIPTION
## Summary
- show disclaimer notice in Streamlit dashboard

## Testing
- `pytest -q` *(fails: TypeError, AssertionError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68870e576f1c8320b24b49f308002a45