### PR TITLE
Add session state dashboard and export features

### DIFF
--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+import types
+
+import json
+
+
+def make_stub():
+    stub = types.ModuleType("streamlit")
+    stub.session_state = {}
+    stub.secrets = {}
+    def no_op(*a, **k):
+        return None
+    stub.experimental_rerun = no_op
+    return stub
+
+
+def stub_dependencies(monkeypatch):
+    mpl = types.ModuleType("matplotlib")
+    plt = types.ModuleType("matplotlib.pyplot")
+    mpl.pyplot = plt
+    monkeypatch.setitem(sys.modules, "matplotlib", mpl)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", plt)
+    monkeypatch.setitem(sys.modules, "networkx", types.ModuleType("networkx"))
+
+
+def test_clear_memory_resets_state(monkeypatch):
+    stub = make_stub()
+    stub_dependencies(monkeypatch)
+    stub.session_state.update({
+        "analysis_diary": [1],
+        "run_count": 3,
+        "last_run": "time",
+        "last_result": {"foo": "bar"},
+        "show_explanation": True,
+    })
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    import ui
+    importlib.reload(ui)
+    ui.clear_memory()
+    assert stub.session_state["analysis_diary"] == []
+    assert stub.session_state["run_count"] == 0
+    assert stub.session_state["last_result"] is None
+    assert not stub.session_state["show_explanation"]
+
+
+def test_export_latest_result(monkeypatch):
+    stub = make_stub()
+    stub_dependencies(monkeypatch)
+    stub.session_state["last_result"] = {"a": 1}
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    import ui
+    importlib.reload(ui)
+    data = ui.export_latest_result()
+    assert json.loads(data) == {"a": 1}


### PR DESCRIPTION
## Summary
- track `run_count` and `last_run` in the Streamlit session
- provide helpers for clearing memory, exporting results and generating explanations
- show run dashboard and new buttons in the sidebar
- display explanation in an expander after running
- test memory clearing and export helpers

## Testing
- `pytest tests/test_ui_state.py -q`
- `pytest -q` *(fails: test_buy_coin_success, test_creator_karma_gain_on_react, test_export_causal_path_handles_malformed_entries, test_export_causal_path_handles_non_dict_entries, test_list_forks_serializes_decimal_config, test_fork_info_serializes_decimal_config, test_create_fork_success, test_create_fork_invalid_creator, test_create_fork_invalid_config, test_create_fork_cooldown, test_list_forks_and_info, test_fork_info_not_found, test_vote_fork_success_and_duplicate, test_vote_fork_missing_records, test_orm_consistency, test_prediction_lifecycle, test_annual_audit_scheduler)*

------
https://chatgpt.com/codex/tasks/task_e_68870e6a5d5883208e51ea4a5434ded9