### PR TITLE
Add agent registry and exports

### DIFF
--- a/protocols/README.md
+++ b/protocols/README.md
@@ -9,3 +9,9 @@ This package contains modular agents and supporting utilities used for automated
 - **ObserverAgent** – monitors agent outputs and suggests forks when needed.
 
 Utilities, core interfaces, and prebuilt profiles are organized under corresponding subfolders for easy extension.
+
+```python
+from protocols import GuardianInterceptorAgent, CI_PRProtectorAgent
+```
+
+See `protocols/_registry.py` for a programmatic listing of available agents.

--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -1,17 +1,17 @@
 # protocols/__init__.py
 
-from .core.profiles import AgentProfile
-from .core.contracts import AgentTaskContract
-from .utils.reflection import self_reflect
-from .utils.remote import ping_agent, handshake
-from .utils.forking import fork_agent
-from .profiles.validator_elf import ValidatorElf
-from .profiles.dream_weaver import DreamWeaver
-
+from ._registry import AGENT_REGISTRY
 from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
 from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from .agents.meta_validator_agent import MetaValidatorAgent
 from .agents.observer_agent import ObserverAgent
+from .core.contracts import AgentTaskContract
+from .core.profiles import AgentProfile
+from .profiles.dream_weaver import DreamWeaver
+from .profiles.validator_elf import ValidatorElf
+from .utils.forking import fork_agent
+from .utils.reflection import self_reflect
+from .utils.remote import handshake, ping_agent
 
 __all__ = [
     "AgentProfile",
@@ -26,4 +26,5 @@ __all__ = [
     "GuardianInterceptorAgent",
     "MetaValidatorAgent",
     "ObserverAgent",
+    "AGENT_REGISTRY",
 ]

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -1,0 +1,26 @@
+"""Registry of core protocol agents and their purposes."""
+
+from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
+from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
+from .agents.meta_validator_agent import MetaValidatorAgent
+from .agents.observer_agent import ObserverAgent
+
+# Mapping of agent names to (class, short description)
+AGENT_REGISTRY = {
+    "CI_PRProtectorAgent": (
+        CI_PRProtectorAgent,
+        "Repairs CI/PR failures by proposing patches.",
+    ),
+    "GuardianInterceptorAgent": (
+        GuardianInterceptorAgent,
+        "Inspects LLM suggestions for risky content.",
+    ),
+    "MetaValidatorAgent": (
+        MetaValidatorAgent,
+        "Audits patches and adjusts trust scores.",
+    ),
+    "ObserverAgent": (
+        ObserverAgent,
+        "Monitors agent outputs and suggests forks when needed.",
+    ),
+}

--- a/protocols/agents/ci_pr_protector_agent.py
+++ b/protocols/agents/ci_pr_protector_agent.py
@@ -11,16 +11,20 @@ Components:
 - writes safe response directly into PR comment or diff patch
 """
 
+import json
+import logging
+import subprocess
+import uuid
+
 from protocols.core.internal_protocol import InternalAgentProtocol
 from protocols.utils.skills import Skill
-import subprocess
-import json
-import uuid
-import logging
 
 logger = logging.getLogger("CI_PR_PROTECTOR")
 
+
 class CI_PRProtectorAgent(InternalAgentProtocol):
+    """Suggests fixes for failing CI runs or PR diffs."""
+
     def __init__(self, talk_to_llm_fn):
         super().__init__()
         self.name = "CI_PRProtector"
@@ -33,7 +37,7 @@ class CI_PRProtectorAgent(InternalAgentProtocol):
         branch = payload.get("branch")
         logs = payload.get("logs")
         logger.info(f"CI failure detected on {repo}:{branch}")
-        
+
         prompt = self.construct_prompt(logs, context_type="CI")
         llm_response = self.talk_to_llm(prompt)
         patch = self.extract_code_block(llm_response)
@@ -69,12 +73,13 @@ Explanation:
 
     def extract_code_block(self, llm_response: str) -> str:
         if "```" in llm_response:
-            code = llm_response.split("```python")[-1].split("```") [0]
+            code = llm_response.split("```python")[-1].split("```")[0]
             return code.strip()
         return "# No valid patch found"
 
 
 # --- Hook to LLM (example) ---
+
 
 def dummy_llm_talker(prompt):
     # Replace with real API call to GPT/Claude etc.
@@ -86,6 +91,7 @@ print(\"Fix applied\")
 Explanation:
 This is a dummy patch. Replace me.
 """
+
 
 # Usage:
 # agent = CI_PRProtectorAgent(dummy_llm_talker)

--- a/protocols/agents/observer_agent.py
+++ b/protocols/agents/observer_agent.py
@@ -5,14 +5,18 @@ ObserverAgent watches agent activity via MessageHub and suggests evolutionary fo
 skill swaps, or role specialization based on performance trends and behavioral anomalies.
 """
 
-from protocols.utils.forking import fork_agent
-from collections import defaultdict, deque
-import time
 import logging
+import time
+from collections import defaultdict, deque
+
+from protocols.utils.forking import fork_agent
 
 logger = logging.getLogger("ObserverAgent")
 
+
 class ObserverAgent:
+    """Watches tasks and recommends agent forks or upgrades."""
+
     def __init__(self, hub, agent_registry, fatigue_tracker):
         self.hub = hub
         self.registry = agent_registry
@@ -43,7 +47,9 @@ class ObserverAgent:
         if self.should_fork(agent_id, task, fatigue, belief_score):
             mutation = {"name": f"{agent_id}_forked_{int(time.time())}"}
             new_agent = fork_agent(self.registry[agent_id], mutation)
-            logger.info(f"Forked agent {agent_id} -> {new_agent.name} due to fatigue={fatigue}, belief={belief_score:.2f}")
+            logger.info(
+                f"Forked agent {agent_id} -> {new_agent.name} due to fatigue={fatigue}, belief={belief_score:.2f}"
+            )
             # Optionally auto-register
             self.registry[new_agent.name] = new_agent
 


### PR DESCRIPTION
## Summary
- document each agent with one-line docstrings
- export AGENT_REGISTRY via protocols package
- provide a simple agent registry listing
- show import example in `protocols/README.md`

## Testing
- `pip install -r requirements-minimal.txt`
- `pip install pre-commit`
- `pre-commit run --files protocols/__init__.py protocols/_registry.py protocols/agents/ci_pr_protector_agent.py protocols/agents/meta_validator_agent.py protocols/agents/observer_agent.py protocols/README.md`
- `pytest -q` *(fails: sqlalchemy operational errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_68871ced26288320afa6fcea63df6cee