### PR TITLE
Add agent docstrings and typing cleanup

### DIFF
--- a/immutable_tri_species_adjust.py
+++ b/immutable_tri_species_adjust.py
@@ -1,3 +1,5 @@
+"""Immutable tri-species governance enforcement for Remix agents."""
+
 from typing import Dict, Any, List
 from collections import defaultdict
 from decimal import Decimal


### PR DESCRIPTION
## Summary
- document responsibilities of core agent modules
- expand type hints on the RemixAgent base class and example simulation
- clean up examples with forward annotations

## Testing
- `pytest -q` *(fails: TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68871cf24314832099b3ca22064b4eb8