### PR TITLE
Add rerun diff feature

### DIFF
--- a/tests/test_dashboard_memory.py
+++ b/tests/test_dashboard_memory.py
@@ -45,3 +45,12 @@ def test_export_latest_result(monkeypatch):
     blob = ui.export_latest_result(state)
     data = json.loads(blob)
     assert data == {"foo": "bar"}
+
+
+def test_diff_results(monkeypatch):
+    ui = load_ui(monkeypatch)
+    old = {"a": 1}
+    new = {"a": 2}
+    diff = ui.diff_results(old, new)
+    assert "-  \"a\": 1" in diff
+    assert "+  \"a\": 2" in diff


### PR DESCRIPTION
## Summary
- add `diff_results` helper to compute diffs
- show a rerun button when a previous result exists
- rerun analysis with stored validations and show diff
- test new diff helper

## Testing
- `pytest tests/test_dashboard_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68871e130be083209e1b9eea0745f252