### PR TITLE
Refactor AGENT_REGISTRY as dicts

### DIFF
--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -1,10 +1,6 @@
 # protocols/__init__.py
 
 from ._registry import AGENT_REGISTRY
-from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
-from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
-from .agents.meta_validator_agent import MetaValidatorAgent
-from .agents.observer_agent import ObserverAgent
 from .core.contracts import AgentTaskContract
 from .core.profiles import AgentProfile
 from .profiles.dream_weaver import DreamWeaver
@@ -12,6 +8,10 @@ from .profiles.validator_elf import ValidatorElf
 from .utils.forking import fork_agent
 from .utils.reflection import self_reflect
 from .utils.remote import handshake, ping_agent
+
+# Expose agent classes for convenience
+for _name, _info in AGENT_REGISTRY.items():
+    globals()[_name] = _info["cls"]
 
 __all__ = [
     "AgentProfile",
@@ -22,9 +22,4 @@ __all__ = [
     "fork_agent",
     "ValidatorElf",
     "DreamWeaver",
-    "CI_PRProtectorAgent",
-    "GuardianInterceptorAgent",
-    "MetaValidatorAgent",
-    "ObserverAgent",
-    "AGENT_REGISTRY",
-]
+] + list(AGENT_REGISTRY.keys()) + ["AGENT_REGISTRY"]

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -5,22 +5,26 @@ from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from .agents.meta_validator_agent import MetaValidatorAgent
 from .agents.observer_agent import ObserverAgent
 
-# Mapping of agent names to (class, short description)
+# Mapping of agent names to metadata dictionaries
 AGENT_REGISTRY = {
-    "CI_PRProtectorAgent": (
-        CI_PRProtectorAgent,
-        "Repairs CI/PR failures by proposing patches.",
-    ),
-    "GuardianInterceptorAgent": (
-        GuardianInterceptorAgent,
-        "Inspects LLM suggestions for risky content.",
-    ),
-    "MetaValidatorAgent": (
-        MetaValidatorAgent,
-        "Audits patches and adjusts trust scores.",
-    ),
-    "ObserverAgent": (
-        ObserverAgent,
-        "Monitors agent outputs and suggests forks when needed.",
-    ),
+    "CI_PRProtectorAgent": {
+        "cls": CI_PRProtectorAgent,
+        "description": "Repairs CI/PR failures by proposing patches.",
+        "llm_capable": True,
+    },
+    "GuardianInterceptorAgent": {
+        "cls": GuardianInterceptorAgent,
+        "description": "Inspects LLM suggestions for risky content.",
+        "llm_capable": True,
+    },
+    "MetaValidatorAgent": {
+        "cls": MetaValidatorAgent,
+        "description": "Audits patches and adjusts trust scores.",
+        "llm_capable": True,
+    },
+    "ObserverAgent": {
+        "cls": ObserverAgent,
+        "description": "Monitors agent outputs and suggests forks when needed.",
+        "llm_capable": False,
+    },
 }


### PR DESCRIPTION
## Summary
- store additional metadata per agent in `protocols/_registry.py`
- update `protocols/__init__.py` to expose agent classes dynamically

## Testing
- `pytest -q` *(fails: 18 failed, 113 passed, 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68871fd4a7848320a6a14b224bc432d9