### PR TITLE
Add AnomalySpotterAgent

### DIFF
--- a/protocols/README.md
+++ b/protocols/README.md
@@ -7,6 +7,7 @@ This package contains modular agents and supporting utilities used for automated
 - **GuardianInterceptorAgent** – inspects LLM suggestions for risky content.
 - **MetaValidatorAgent** – audits patches and adjusts trust scores.
 - **ObserverAgent** – monitors agent outputs and suggests forks when needed.
+- **AnomalySpotterAgent** – detects unusual metrics to catch risks early.
 
 Utilities, core interfaces, and prebuilt profiles are organized under corresponding subfolders for easy extension.
 

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -4,6 +4,7 @@ from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
 from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from .agents.meta_validator_agent import MetaValidatorAgent
 from .agents.observer_agent import ObserverAgent
+from .agents.anomaly_spotter_agent import AnomalySpotterAgent
 
 # Mapping of agent names to metadata dictionaries
 AGENT_REGISTRY = {
@@ -25,6 +26,11 @@ AGENT_REGISTRY = {
     "ObserverAgent": {
         "cls": ObserverAgent,
         "description": "Monitors agent outputs and suggests forks when needed.",
+        "llm_capable": False,
+    },
+    "AnomalySpotterAgent": {
+        "cls": AnomalySpotterAgent,
+        "description": "Flags unusual metrics for early risk detection.",
         "llm_capable": False,
     },
 }

--- a/protocols/agents/anomaly_spotter_agent.py
+++ b/protocols/agents/anomaly_spotter_agent.py
@@ -1,0 +1,64 @@
+# protocols/anomaly_spotter_agent.py
+
+"""AnomalySpotterAgent detects suspicious patterns in metrics.
+
+The agent consumes streams of numerical data or network notes and
+flags anomalies before they propagate into the validation pipeline.
+It can optionally leverage an ``llm_backend`` callable for additional
+analysis of metric context or textual notes.
+"""
+
+import logging
+from statistics import mean, stdev
+from typing import List
+
+from protocols.core.internal_protocol import InternalAgentProtocol
+
+logger = logging.getLogger("AnomalySpotterAgent")
+
+
+class AnomalySpotterAgent(InternalAgentProtocol):
+    """Analyze metrics to preemptively surface unusual activity.
+
+    Parameters
+    ----------
+    llm_backend : callable, optional
+        Optional function used for deeper metric inspection.
+    """
+
+    def __init__(self, llm_backend=None) -> None:
+        super().__init__()
+        self.name = "AnomalySpotter"
+        self.llm_backend = llm_backend
+        self.threshold = 2.0
+        self.receive("DATA_METRICS", self.inspect_data)
+
+    def inspect_data(self, payload: dict) -> dict:
+        """Return anomaly information for provided metrics."""
+
+        values: List[float] = payload.get("metrics", [])
+        notes = payload.get("notes", "")
+
+        if self.llm_backend:
+            notes = self.llm_backend(notes or str(values))
+
+        if len(values) < 2:
+            return {"flagged": False, "details": "insufficient data"}
+
+        avg = mean(values)
+        dev = stdev(values)
+        outliers = [v for v in values if dev and abs(v - avg) / dev > self.threshold]
+
+        flagged = bool(outliers)
+        suspicious_keywords = ["attack", "breach", "malware"]
+        if any(word in notes.lower() for word in suspicious_keywords):
+            flagged = True
+
+        result = {
+            "mean": avg,
+            "stdev": dev,
+            "outliers": outliers,
+            "flagged": flagged,
+        }
+        logger.info(f"[AnomalySpotter] result: {result}")
+        return result

--- a/tests/test_agents_llm_backend.py
+++ b/tests/test_agents_llm_backend.py
@@ -5,6 +5,7 @@ from protocols.agents.ci_pr_protector_agent import CI_PRProtectorAgent
 from protocols.agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from protocols.agents.meta_validator_agent import MetaValidatorAgent
 from protocols.agents.observer_agent import ObserverAgent
+from protocols.agents.anomaly_spotter_agent import AnomalySpotterAgent
 
 
 def test_ci_pr_protector_uses_llm_backend():
@@ -74,4 +75,17 @@ def test_observer_agent_llm_backend_called():
     agent.observe(msg)
 
     assert calls and "agent a" in calls[0]
+
+
+def test_anomaly_spotter_llm_backend_usage():
+    calls = []
+
+    def backend(text):
+        calls.append(text)
+        return text
+
+    agent = AnomalySpotterAgent(llm_backend=backend)
+    agent.process_event({"event": "DATA_METRICS", "payload": {"metrics": [1, 2, 3]}})
+
+    assert calls and calls[0] == "[1, 2, 3]"
 


### PR DESCRIPTION
## Summary
- implement `AnomalySpotterAgent` for metric anomaly detection
- register it in the protocols registry
- document the new agent in README
- test that the agent uses the LLM backend when provided

## Testing
- `pytest tests/test_agents_llm_backend.py::test_anomaly_spotter_llm_backend_usage -q`
- `pytest -q` *(fails: TypeError and AttributeError in many tests)*

------
https://chatgpt.com/codex/tasks/task_e_688721ef8018832081cae8e1ae577606