### PR TITLE
Add CoordinationSentinelAgent

### DIFF
--- a/protocols/README.md
+++ b/protocols/README.md
@@ -7,6 +7,7 @@ This package contains modular agents and supporting utilities used for automated
 - **GuardianInterceptorAgent** – inspects LLM suggestions for risky content.
 - **MetaValidatorAgent** – audits patches and adjusts trust scores.
 - **ObserverAgent** – monitors agent outputs and suggests forks when needed.
+- **CoordinationSentinelAgent** – flags suspicious validator coordination.
 
 Utilities, core interfaces, and prebuilt profiles are organized under corresponding subfolders for easy extension.
 

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -4,6 +4,7 @@ from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
 from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from .agents.meta_validator_agent import MetaValidatorAgent
 from .agents.observer_agent import ObserverAgent
+from .agents.coordination_sentinel_agent import CoordinationSentinelAgent
 
 # Mapping of agent names to metadata dictionaries
 AGENT_REGISTRY = {
@@ -25,6 +26,11 @@ AGENT_REGISTRY = {
     "ObserverAgent": {
         "cls": ObserverAgent,
         "description": "Monitors agent outputs and suggests forks when needed.",
+        "llm_capable": False,
+    },
+    "CoordinationSentinelAgent": {
+        "cls": CoordinationSentinelAgent,
+        "description": "Runs network coordination analysis and flags collusion.",
         "llm_capable": False,
     },
 }

--- a/protocols/agents/coordination_sentinel_agent.py
+++ b/protocols/agents/coordination_sentinel_agent.py
@@ -1,0 +1,30 @@
+"""CoordinationSentinelAgent - monitors validator submissions for suspicious coordination."""
+
+from typing import List, Dict, Any
+
+from protocols.core.internal_protocol import InternalAgentProtocol
+from network.network_coordination_detector import analyze_coordination_patterns
+
+
+class CoordinationSentinelAgent(InternalAgentProtocol):
+    """Automates network coordination analysis and emits flags."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "CoordinationSentinel"
+        self.receive("VALIDATIONS", self.inspect_validations)
+
+    def inspect_validations(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Run coordination analysis on provided validations."""
+        validations: List[Dict[str, Any]] = payload.get("validations", [])
+        result = analyze_coordination_patterns(validations)
+        self.send(
+            "COORDINATION_RESULT",
+            {
+                "flags": result.get("flags", []),
+                "clusters": result.get("coordination_clusters", {}),
+                "risk": result.get("overall_risk_score", 0.0),
+            },
+        )
+        return result
+

--- a/tests/test_coordination_sentinel_agent.py
+++ b/tests/test_coordination_sentinel_agent.py
@@ -1,0 +1,32 @@
+import pytest
+from protocols.agents.coordination_sentinel_agent import CoordinationSentinelAgent
+
+
+def build_validations():
+    vals = []
+    for i in range(3):
+        ts = f"2025-01-01T00:0{i}:00Z"
+        note = "the quick brown fox jumps over the lazy dog"
+        vals.append({
+            "validator_id": "v1",
+            "hypothesis_id": f"h{i}",
+            "score": 0.8,
+            "timestamp": ts,
+            "note": note,
+        })
+        vals.append({
+            "validator_id": "v2",
+            "hypothesis_id": f"h{i}",
+            "score": 0.8,
+            "timestamp": ts,
+            "note": note,
+        })
+    return vals
+
+
+def test_coordination_sentinel_detects_risk():
+    agent = CoordinationSentinelAgent()
+    result = agent.inspect_validations({"validations": build_validations()})
+    assert result["risk_breakdown"]["temporal"] >= 1
+    assert agent.inbox and agent.inbox[-1]["topic"] == "COORDINATION_RESULT"
+


### PR DESCRIPTION
## Summary
- add CoordinationSentinelAgent for detecting validator collusion
- register the new agent
- document the agent in protocols README
- test coordination detection logic

## Testing
- `pytest -k coordination_sentinel_agent -q`

------
https://chatgpt.com/codex/tasks/task_e_68872230fe8c8320b1f029450c485bd2