### PR TITLE
Add HarmonySynthesizerAgent

### DIFF
--- a/protocols/README.md
+++ b/protocols/README.md
@@ -7,6 +7,7 @@ This package contains modular agents and supporting utilities used for automated
 - **GuardianInterceptorAgent** – inspects LLM suggestions for risky content.
 - **MetaValidatorAgent** – audits patches and adjusts trust scores.
 - **ObserverAgent** – monitors agent outputs and suggests forks when needed.
+- **HarmonySynthesizerAgent** – converts aggregated metrics into short MIDI snippets.
 
 Utilities, core interfaces, and prebuilt profiles are organized under corresponding subfolders for easy extension.
 

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -4,6 +4,7 @@ from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
 from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
 from .agents.meta_validator_agent import MetaValidatorAgent
 from .agents.observer_agent import ObserverAgent
+from .agents.harmony_synthesizer_agent import HarmonySynthesizerAgent
 
 # Mapping of agent names to metadata dictionaries
 AGENT_REGISTRY = {
@@ -25,6 +26,11 @@ AGENT_REGISTRY = {
     "ObserverAgent": {
         "cls": ObserverAgent,
         "description": "Monitors agent outputs and suggests forks when needed.",
+        "llm_capable": False,
+    },
+    "HarmonySynthesizerAgent": {
+        "cls": HarmonySynthesizerAgent,
+        "description": "Creates MIDI snippets summarizing system metrics.",
         "llm_capable": False,
     },
 }

--- a/protocols/agents/harmony_synthesizer_agent.py
+++ b/protocols/agents/harmony_synthesizer_agent.py
@@ -1,0 +1,38 @@
+"""HarmonySynthesizerAgent
+==========================
+
+Converts aggregated system metrics into short MIDI snippets using
+``resonance_music.generate_midi_from_metrics``.
+
+This agent can subscribe to a metrics feed or accept metrics directly
+through events. The resulting MIDI bytes are emitted on the
+``MIDI_CREATED`` topic for downstream consumers.
+"""
+
+from typing import Callable, Dict, Any
+
+from protocols.core.internal_protocol import InternalAgentProtocol
+from resonance_music import generate_midi_from_metrics
+
+
+class HarmonySynthesizerAgent(InternalAgentProtocol):
+    """Translate metrics into MIDI using a provided aggregator."""
+
+    def __init__(self, metrics_provider: Callable[[], Dict[str, float]] | None = None) -> None:
+        super().__init__()
+        self.name = "HarmonySynthesizer"
+        self.metrics_provider = metrics_provider
+        self.receive("GENERATE_MIDI", self.handle_generate)
+
+    def handle_generate(self, payload: Dict[str, Any] | None = None) -> bytes:
+        """Return MIDI bytes for provided or aggregated metrics."""
+
+        payload = payload or {}
+        metrics = payload.get("metrics")
+        if metrics is None and self.metrics_provider:
+            metrics = self.metrics_provider()
+        if not isinstance(metrics, dict):
+            metrics = {}
+        midi = generate_midi_from_metrics(metrics)
+        self.send("MIDI_CREATED", {"midi": midi, "metrics": metrics})
+        return midi

--- a/tests/test_harmony_synthesizer_agent.py
+++ b/tests/test_harmony_synthesizer_agent.py
@@ -1,0 +1,31 @@
+from protocols.agents.harmony_synthesizer_agent import HarmonySynthesizerAgent
+
+
+def test_generate_uses_provider_when_no_metrics():
+    calls = []
+
+    def provider():
+        calls.append(True)
+        return {"h": 1.0}
+
+    agent = HarmonySynthesizerAgent(metrics_provider=provider)
+    midi = agent.handle_generate({})
+
+    assert calls and isinstance(midi, bytes)
+    assert agent.inbox[-1]["topic"] == "MIDI_CREATED"
+    assert agent.inbox[-1]["payload"]["metrics"] == {"h": 1.0}
+
+
+def test_generate_prefers_payload_metrics():
+    calls = []
+
+    def provider():
+        calls.append(True)
+        return {"x": 0}
+
+    agent = HarmonySynthesizerAgent(metrics_provider=provider)
+    midi = agent.handle_generate({"metrics": {"a": 2}})
+
+    assert not calls
+    assert isinstance(midi, bytes)
+    assert agent.inbox[-1]["payload"]["metrics"] == {"a": 2}


### PR DESCRIPTION
## Summary
- create `HarmonySynthesizerAgent` for turning metrics into MIDI
- register new agent in protocol registry
- document the new agent in `protocols/README.md`
- test agent behaviour

## Testing
- `pytest tests/test_harmony_synthesizer_agent.py -q`
- `pytest -q` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_68872261b7888320b5c1b389f177c01f