### PR TITLE
Add governance patch compliance monitor

### DIFF
--- a/governance/patch_monitor.py
+++ b/governance/patch_monitor.py
@@ -1,0 +1,56 @@
+"""Patch compliance monitoring utilities.
+
+These helpers evaluate incoming code additions
+for required governance disclaimers or other
+policy markers defined in ``DEFAULT_DISCLAIMER_PHRASES``.
+
+The functions can be integrated into commit hooks
+or CI jobs to automatically flag patches that
+lack mandatory legal language.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+DEFAULT_DISCLAIMER_PHRASES = [
+    "STRICTLY A SOCIAL MEDIA PLATFORM",
+    "Intellectual Property & Artistic Inspiration",
+    "Legal & Ethical Safeguards",
+]
+
+
+def _contains_disclaimers(
+    text: str, phrases: Iterable[str] = DEFAULT_DISCLAIMER_PHRASES
+) -> bool:
+    lower = text.lower()
+    return all(p.lower() in lower for p in phrases)
+
+
+def check_file_compliance(
+    path: str, phrases: Iterable[str] = DEFAULT_DISCLAIMER_PHRASES
+) -> List[str]:
+    """Return a list of issues for ``path`` if disclaimers are missing."""
+    p = Path(path)
+    if not p.is_file():
+        return [f"File {path} does not exist"]
+    text = p.read_text(errors="ignore")
+    if not _contains_disclaimers(text, phrases):
+        return [f"Missing required disclaimers in {p.name}"]
+    return []
+
+
+def check_patch_compliance(
+    patch: str, phrases: Iterable[str] = DEFAULT_DISCLAIMER_PHRASES
+) -> List[str]:
+    """Inspect added lines in a diff patch for required disclaimers."""
+    additions = [
+        line[1:]
+        for line in patch.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+    text = "\n".join(additions)
+    if additions and not _contains_disclaimers(text, phrases):
+        return ["New additions missing required disclaimers"]
+    return []

--- a/tests/test_patch_monitor.py
+++ b/tests/test_patch_monitor.py
@@ -1,0 +1,41 @@
+import textwrap
+
+from governance.patch_monitor import (check_file_compliance,
+                                      check_patch_compliance)
+
+
+def test_check_file_compliance(tmp_path):
+    f = tmp_path / "module.py"
+    f.write_text(
+        (
+            "# STRICTLY A SOCIAL MEDIA PLATFORM\n"
+            "# Intellectual Property & Artistic Inspiration\n"
+            "# Legal & Ethical Safeguards\n"
+            "print('hello')\n"
+        )
+    )
+    assert check_file_compliance(str(f)) == []  # nosec B101
+
+
+def test_check_file_compliance_missing(tmp_path):
+    f = tmp_path / "module.py"
+    f.write_text("print('hi')\n")
+    issues = check_file_compliance(str(f))
+    assert issues and "Missing required disclaimers" in issues[0]  # nosec B101
+
+
+def test_check_patch_compliance():
+    patch = textwrap.dedent(
+        """@@\n"
+        "+ # STRICTLY A SOCIAL MEDIA PLATFORM\n"
+        "+ # Intellectual Property & Artistic Inspiration\n"
+        "+ # Legal & Ethical Safeguards\n"
+        "+ pass\n"""
+    )
+    assert check_patch_compliance(patch) == []  # nosec B101
+
+
+def test_check_patch_compliance_missing():
+    patch = "@@\n+print('hi')\n"
+    issues = check_patch_compliance(patch)
+    assert issues and "missing required disclaimers" in issues[0].lower()  # nosec B101


### PR DESCRIPTION
## Summary
- add `patch_monitor` module for governance compliance checks
- include tests verifying patch and file compliance logic

## Testing
- `pre-commit run --files governance/patch_monitor.py tests/test_patch_monitor.py`
- `pytest tests/test_patch_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688721ca08fc8320a7dedae6b2f51b33