### PR TITLE
Add simple D3 viewer

### DIFF
--- a/docs/3d_viewer/README.md
+++ b/docs/3d_viewer/README.md
@@ -1,0 +1,22 @@
+# 3D Viewer
+
+This folder provides a very small demo that renders a network graph using D3.js.
+It loads `network.json` and displays the nodes and edges with a force directed
+layout.
+
+## Quick start
+
+1. Serve the contents of this directory with any static HTTP server. A quick
+   approach is:
+
+   ```bash
+   cd docs/3d_viewer
+   python -m http.server 8000
+   ```
+
+2. Open `http://localhost:8000` in your browser. The included `render.js`
+   automatically fetches `network.json` and visualises it.
+
+Edit `network.json` to experiment with your own nodes and edges. Each node should
+have a unique `id` and each edge should reference the node ids with `source` and
+`target` fields.

--- a/docs/3d_viewer/render.js
+++ b/docs/3d_viewer/render.js
@@ -1,5 +1,80 @@
 // RFC_V5_1_INIT
+// Basic D3 force‑directed layout
 function renderNetwork(graph) {
-  // Placeholder 3D render stub
-  console.log('3D viewer stub', graph);
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+
+  const svg = d3
+    .select('body')
+    .append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+  const simulation = d3
+    .forceSimulation(graph.nodes)
+    .force('link', d3.forceLink(graph.edges).id(d => d.id).distance(50))
+    .force('charge', d3.forceManyBody().strength(-200))
+    .force('center', d3.forceCenter(width / 2, height / 2));
+
+  const link = svg
+    .append('g')
+    .attr('stroke', '#aaa')
+    .selectAll('line')
+    .data(graph.edges)
+    .join('line')
+    .attr('stroke-width', 1.5);
+
+  const node = svg
+    .append('g')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 1.5)
+    .selectAll('circle')
+    .data(graph.nodes)
+    .join('circle')
+    .attr('r', 5)
+    .attr('fill', '#69b3a2')
+    .call(
+      d3
+        .drag()
+        .on('start', dragStarted)
+        .on('drag', dragged)
+        .on('end', dragEnded)
+    );
+
+  node.append('title').text(d => d.id);
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y);
+
+    node.attr('cx', d => d.x).attr('cy', d => d.y);
+  });
+
+  function dragStarted(event, d) {
+    if (!event.active) simulation.alphaTarget(0.3).restart();
+    d.fx = d.x;
+    d.fy = d.y;
+  }
+
+  function dragged(event, d) {
+    d.fx = event.x;
+    d.fy = event.y;
+  }
+
+  function dragEnded(event, d) {
+    if (!event.active) simulation.alphaTarget(0);
+    d.fx = null;
+    d.fy = null;
+  }
 }
+
+// Load the sample graph and render it
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('network.json')
+    .then(resp => resp.json())
+    .then(data => renderNetwork(data))
+    .catch(err => console.error('Failed to load graph', err));
+});


### PR DESCRIPTION
## Summary
- implement a basic D3 force-directed layout in `render.js`
- autoload `network.json` when the page is opened
- document how to run the viewer

## Testing
- `pre-commit run --files docs/3d_viewer/render.js docs/3d_viewer/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6887255493308320ab04039d7759b0fd