### PR TITLE
Fix log handler for file output

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -631,7 +631,7 @@ file_handler.setFormatter(
         "%(asctime)s | %(levelname)s | %(threadName)s | %(message)s (%(filename)s:%(lineno)d) | 감사합니다!"
     )
 )
-logging.getLogger().addHandler(console_handler)
+logging.getLogger().addHandler(file_handler)
 
 try:  # pragma: no cover - optional in some environments
     import streamlit as st  # type: ignore


### PR DESCRIPTION
## Summary
- ensure second handler uses `file_handler` in `superNova_2177.py`

## Testing
- `pytest -q` *(fails: 20 failed, 124 passed, 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688726ced0ec8320bbea7ecae25db492