### PR TITLE
Refactor ObserverAgent to use InternalAgentProtocol

### DIFF
--- a/tests/test_agents_llm_backend.py
+++ b/tests/test_agents_llm_backend.py
@@ -1,4 +1,3 @@
-import types
 from collections import defaultdict
 
 from protocols.agents.ci_pr_protector_agent import CI_PRProtectorAgent
@@ -70,8 +69,8 @@ def test_observer_agent_llm_backend_called():
 
     registry = {"a": object()}
     agent = ObserverAgent(Hub(), registry, Fatigue(), llm_backend=backend)
-    msg = types.SimpleNamespace(data={"agent": "a", "task": "t", "result": {}})
-    agent.observe(msg)
+    payload = {"agent": "a", "task": "t", "result": {}}
+    agent.observe(payload)
 
     assert calls and "agent a" in calls[0]
 


### PR DESCRIPTION
## Summary
- make ObserverAgent subclass `InternalAgentProtocol`
- integrate protocol hooks for receiving hub events and sending notifications
- adjust ObserverAgent test to use new payload interface

## Testing
- `pytest tests/test_agents_llm_backend.py::test_observer_agent_llm_backend_called -q`

------
https://chatgpt.com/codex/tasks/task_e_688727deba2c83208684e735454c4c38