### PR TITLE
Conditional pytest asyncio fallback

### DIFF
--- a/tests/async_fallback.py
+++ b/tests/async_fallback.py
@@ -1,10 +1,15 @@
 import asyncio
 import inspect
+import importlib.util
 import pytest
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_pyfunc_call(pyfuncitem):
-    testfunc = pyfuncitem.obj
-    if inspect.iscoroutinefunction(testfunc):
-        asyncio.run(testfunc(**pyfuncitem.funcargs))
-        return True
+
+_has_pytest_asyncio = importlib.util.find_spec("pytest_asyncio") is not None
+
+if not _has_pytest_asyncio:
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_pyfunc_call(pyfuncitem):
+        testfunc = pyfuncitem.obj
+        if inspect.iscoroutinefunction(testfunc):
+            asyncio.run(testfunc(**pyfuncitem.funcargs))
+            return True


### PR DESCRIPTION
## Summary
- add runtime check for pytest_asyncio in async fallback
- register async pyfunc hook only when pytest_asyncio isn't available

## Testing
- `pytest -q` *(fails: 31 failed, 113 passed, 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688728bd94608320907574c629b0d3b8