### PR TITLE
Ensure temp GraphML file cleanup

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -185,16 +185,20 @@ def run_analysis(validations, *, layout: str = "force"):
             G.add_edge(v1, v2, weight=w)
 
         # Offer GraphML download of the constructed graph
+        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".graphml")
         try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".graphml") as tmp:
-                nx.write_graphml(G, tmp.name)
-                tmp_path = tmp.name
-            with open(tmp_path, "rb") as gm_file:
+            nx.write_graphml(G, tmp_file.name)
+            with open(tmp_file.name, "rb") as gm_file:
                 data = gm_file.read()
-            os.remove(tmp_path)
             st.download_button("Download GraphML", data, file_name="graph.graphml")
         except Exception as exc:  # pragma: no cover - optional
             logger.warning(f"GraphML export failed: {exc}")
+        finally:
+            tmp_file.close()
+            try:
+                os.remove(tmp_file.name)
+            except OSError:
+                pass
 
         # Determine layout
         if layout == "circular":


### PR DESCRIPTION
## Summary
- clean up temporary GraphML export in `ui.py`

## Testing
- `pytest -q` *(fails: TypeError, AssertionError, and sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_688728c5ebe083208abc689e8f16233c