### PR TITLE
Fix async fallback when pytest-asyncio installed

### DIFF
--- a/tests/async_fallback.py
+++ b/tests/async_fallback.py
@@ -1,10 +1,28 @@
 import asyncio
 import inspect
+import importlib.util
 import pytest
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_pyfunc_call(pyfuncitem):
-    testfunc = pyfuncitem.obj
-    if inspect.iscoroutinefunction(testfunc):
-        asyncio.run(testfunc(**pyfuncitem.funcargs))
-        return True
+
+class _AsyncioFallback:
+    """Minimal async runner used when ``pytest_asyncio`` isn't installed."""
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_pyfunc_call(self, pyfuncitem):
+        testfunc = pyfuncitem.obj
+        if inspect.iscoroutinefunction(testfunc):
+            sig = inspect.signature(testfunc)
+            kwargs = {name: pyfuncitem.funcargs[name] for name in sig.parameters}
+            asyncio.run(testfunc(**kwargs))
+            return True
+
+
+def pytest_configure(config):
+    """Register async fallback if ``pytest_asyncio`` isn't available."""
+
+    if importlib.util.find_spec("pytest_asyncio") is not None or config.pluginmanager.hasplugin(
+        "pytest_asyncio"
+    ):
+        return
+
+    config.pluginmanager.register(_AsyncioFallback(), name="asyncio-fallback")


### PR DESCRIPTION
## Summary
- avoid registering async fallback if pytest-asyncio is available
- run async tests with correct fixture arguments

## Testing
- `pytest tests/test_hook_manager.py::test_hook_manager_basic_async_and_sync -q`
- `pytest -q` *(fails: KeyError: 'access_token' in test_app.py)*

------
https://chatgpt.com/codex/tasks/task_e_688728cc7ff88320ad268d29b607fe56