### PR TITLE
Add HarmonySynthesizerAgent tests

### DIFF
--- a/tests/protocols/test_harmony_synthesizer_agent.py
+++ b/tests/protocols/test_harmony_synthesizer_agent.py
@@ -1,0 +1,32 @@
+import protocols.agents.HarmonySynthesizerAgent as hs_agent_module
+from protocols.agents.HarmonySynthesizerAgent import HarmonySynthesizerAgent
+
+
+def test_handle_generate_with_provider(monkeypatch):
+    midi = b"abc"
+    monkeypatch.setattr(hs_agent_module, "generate_midi_from_metrics", lambda m: midi)
+
+    provided_metrics = {"x": 1.0}
+
+    def provider():
+        return provided_metrics
+
+    agent = HarmonySynthesizerAgent(metrics_provider=provider)
+    result = agent.handle_generate()
+
+    assert result == midi
+    assert agent.inbox[-1]["topic"] == "MIDI_CREATED"
+    assert agent.inbox[-1]["payload"] == {"midi": midi, "metrics": provided_metrics}
+
+
+def test_handle_generate_payload_only(monkeypatch):
+    midi = b"xyz"
+    monkeypatch.setattr(hs_agent_module, "generate_midi_from_metrics", lambda m: midi)
+
+    metrics = {"y": 2}
+    agent = HarmonySynthesizerAgent()
+    result = agent.handle_generate({"metrics": metrics})
+
+    assert result == midi
+    assert agent.inbox[-1]["topic"] == "MIDI_CREATED"
+    assert agent.inbox[-1]["payload"] == {"midi": midi, "metrics": metrics}


### PR DESCRIPTION
## Summary
- add unit tests for HarmonySynthesizerAgent

## Testing
- `pytest tests/protocols/test_harmony_synthesizer_agent.py -q`
- `pytest -q` *(fails: AttributeError/TypeError due to missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887291ebb548320ac968be01c823316