### PR TITLE
Refactor llm_backend interfaces

### DIFF
--- a/protocols/agents/ci_pr_protector_agent.py
+++ b/protocols/agents/ci_pr_protector_agent.py
@@ -15,13 +15,9 @@ Components:
 - writes safe response directly into PR comment or diff patch
 """
 
-import json
 import logging
-import subprocess
-import uuid
 
 from protocols.core.internal_protocol import InternalAgentProtocol
-from protocols.utils.skills import Skill
 
 logger = logging.getLogger("CI_PR_PROTECTOR")
 
@@ -31,17 +27,15 @@ class CI_PRProtectorAgent(InternalAgentProtocol):
 
     Parameters
     ----------
-    talk_to_llm_fn : callable
-        Default function used to query the LLM when ``llm_backend`` is not
-        provided.
     llm_backend : callable, optional
-        Optional override used for all LLM requests.
+        Optional override used for all LLM requests. When omitted,
+        ``talk_to_llm_fn`` is used instead.
     """
 
-    def __init__(self, talk_to_llm_fn, llm_backend=None):
+    def __init__(self, llm_backend=None):
         super().__init__()
         self.name = "CI_PRProtector"
-        self.talk_to_llm = talk_to_llm_fn  # Function to call LLM
+        self.talk_to_llm = talk_to_llm_fn  # default function to call LLM
         self.llm_backend = llm_backend
         self.receive("CI_FAILURE", self.handle_ci_failure)
         self.receive("PR_DIFF_FAIL", self.handle_pr_error)
@@ -101,7 +95,7 @@ Explanation:
 # --- Hook to LLM (example) ---
 
 
-def dummy_llm_talker(prompt):
+def talk_to_llm_fn(prompt):
     # Replace with real API call to GPT/Claude etc.
     return """```python
 # patch
@@ -114,5 +108,5 @@ This is a dummy patch. Replace me.
 
 
 # Usage:
-# agent = CI_PRProtectorAgent(dummy_llm_talker)
+# agent = CI_PRProtectorAgent(llm_backend=talk_to_llm_fn)
 # agent.send("CI_FAILURE", {"repo": "superNova_2177", "branch": "main", "logs": "Traceback..."})

--- a/tests/test_agents_llm_backend.py
+++ b/tests/test_agents_llm_backend.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 
 from protocols.agents.ci_pr_protector_agent import CI_PRProtectorAgent
-from protocols.agents.guardian_interceptor_agent import GuardianInterceptorAgent
+from protocols.agents.guardian_interceptor_agent import \
+    GuardianInterceptorAgent
 from protocols.agents.meta_validator_agent import MetaValidatorAgent
 from protocols.agents.observer_agent import ObserverAgent
 
@@ -13,10 +14,7 @@ def test_ci_pr_protector_uses_llm_backend():
         calls.append(prompt)
         return """```python\nprint('ok')\n```"""
 
-    def default(prompt):
-        raise AssertionError("default LLM should not be called")
-
-    agent = CI_PRProtectorAgent(default, llm_backend=backend)
+    agent = CI_PRProtectorAgent(llm_backend=backend)
     result = agent.handle_ci_failure({"repo": "r", "branch": "b", "logs": "fail"})
 
     assert calls and "fail" in calls[0]
@@ -73,4 +71,3 @@ def test_observer_agent_llm_backend_called():
     agent.observe(payload)
 
     assert calls and "agent a" in calls[0]
-


### PR DESCRIPTION
## Summary
- refactor CI_PRProtectorAgent to accept a single `llm_backend` argument
- rename dummy_llm_talker -> `talk_to_llm_fn`
- simplify imports
- adjust llm_backend tests

## Testing
- `pip install -q -r requirements-minimal.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement streamlit_json)*
- `pytest -q` *(fails: 31 failed, 113 passed, 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887290ef0008320a8071d40e1c5f364