### PR TITLE
Return lists from build_validation_graph

### DIFF
--- a/network/network_coordination_detector.py
+++ b/network/network_coordination_detector.py
@@ -99,9 +99,9 @@ def build_validation_graph(validations: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     return {
         "edges": edges,
-        "nodes": set(validator_data.keys()),
+        "nodes": list(validator_data.keys()),
         "hypothesis_coverage": dict(hypothesis_validators),
-        "communities": communities,
+        "communities": [list(c) for c in communities],
     }
 
 
@@ -503,7 +503,7 @@ def analyze_coordination_patterns(validations: List[Dict[str, Any]]) -> Dict[str
             "overall_risk_score": 0.0,
             "coordination_clusters": [],
             "flags": ["no_validations"],
-            "graph": {"edges": [], "nodes": set(), "communities": []},
+            "graph": {"edges": [], "nodes": [], "communities": []},
             "risk_breakdown": {"temporal": 0, "score": 0, "semantic": 0},
         }
 
@@ -559,7 +559,7 @@ def analyze_coordination_patterns(validations: List[Dict[str, Any]]) -> Dict[str
             "overall_risk_score": 0.0,
             "coordination_clusters": [],
             "flags": ["coordination_analysis_failed"],
-            "graph": {"edges": [], "nodes": set(), "communities": []},
+            "graph": {"edges": [], "nodes": [], "communities": []},
             "risk_breakdown": {"temporal": 0, "score": 0, "semantic": 0},
         }
 


### PR DESCRIPTION
## Summary
- return lists instead of sets from `build_validation_graph`
- adjust callers to expect lists

## Testing
- `pytest tests/test_network_coordination_detector.py::test_analyze_coordination_patterns_empty -q`
- `pytest tests/test_network_coordination_detector.py::test_analyze_coordination_patterns_detects_clusters -q`
- `pytest tests/test_network_coordination_detector.py::test_detect_semantic_coordination_embeddings -q`
- `pytest tests/test_network_coordination_detector.py::test_detect_semantic_coordination_no_numpy_sklearn -q`
- `pytest tests/test_network_coordination_detector.py::test_detect_semantic_coordination_sentence_transformer_failure -q`
- `pytest -q` *(fails: TypeError and AttributeError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_688728c15f9c8320886e755ecc812373