### PR TITLE
Add scalar_one_or_none to SQLAlchemy stub

### DIFF
--- a/stubs/sqlalchemy_stub.py
+++ b/stubs/sqlalchemy_stub.py
@@ -163,8 +163,8 @@ class Result:
         return self._data[0] if self._data else None
 
     def scalar_one_or_none(self):
-        """Return the single element or ``None`` if the result set is empty."""
-        return self._data[0] if len(self._data) == 1 else None
+        """Return the first element or ``None`` if the result set is empty."""
+        return self._data[0] if self._data else None
 
     def all(self):  # pragma: no cover - trivial
         return list(self._data)


### PR DESCRIPTION
## Summary
- adjust `sqlalchemy_stub.Result.scalar_one_or_none` to simply return the first element or `None`

## Testing
- `pytest tests/test_federation_cli_db.py::test_create_fork_success -q` *(fails: unhashable type: 'Column')*

------
https://chatgpt.com/codex/tasks/task_e_68872b1268d483209cb1dea9048b82ed