### PR TITLE
Add module docs and public API exports

### DIFF
--- a/protocols/utils/forking.py
+++ b/protocols/utils/forking.py
@@ -1,4 +1,6 @@
-"""Create mutated copies of existing agents."""
+"""Utilities for creating mutated copies of agents."""
+
+__all__ = ["fork_agent"]
 from typing import Any, Dict
 import copy
 

--- a/protocols/utils/reflection.py
+++ b/protocols/utils/reflection.py
@@ -1,4 +1,6 @@
-"""Utility for self-corrective reflection based on memory logs."""
+"""Self-reflection helpers for agents."""
+
+__all__ = ["self_reflect"]
 from typing import List
 
 def self_reflect(agent, memory_log: List[dict]) -> dict:

--- a/protocols/utils/skills.py
+++ b/protocols/utils/skills.py
@@ -1,4 +1,10 @@
-"""Basic skill system for agents."""
+"""Skill management utilities.
+
+This module defines a minimal skill system consisting of the ``Skill``
+class and an ``EmbodiedAgent`` capable of registering and invoking skills.
+"""
+
+__all__ = ["Skill", "EmbodiedAgent"]
 from typing import Callable, Dict
 from protocols.core.internal_protocol import InternalAgentProtocol
 


### PR DESCRIPTION
## Summary
- add module docstrings to utils modules
- expose public APIs via `__all__` lists
- run pydocstyle on updated utils modules

## Testing
- `pydocstyle protocols/utils/skills.py protocols/utils/forking.py protocols/utils/reflection.py`

------
https://chatgpt.com/codex/tasks/task_e_68872ccb7e788320bcedd87fbf137e31