### PR TITLE
Implement unsubscribe method for MessageHub

### DIFF
--- a/protocols/utils/messaging.py
+++ b/protocols/utils/messaging.py
@@ -1,18 +1,23 @@
 """Publish/subscribe message hub for agents."""
-from typing import Callable, Dict, List
+
 import uuid
 from collections import defaultdict
+from typing import Callable, Dict, List
+
 
 class Message:
     """A versioned agent message with metadata."""
+
     def __init__(self, topic: str, data: dict, version: str = "1.0"):
         self.id = str(uuid.uuid4())
         self.topic = topic
         self.version = version
         self.data = data
 
+
 class MessageHub:
     """Shared communication hub for agents, tools, and diagnostics."""
+
     def __init__(self):
         self.subscribers: Dict[str, List[Callable[[Message], None]]] = defaultdict(list)
         self.history: List[Message] = []
@@ -26,6 +31,10 @@ class MessageHub:
 
     def subscribe(self, topic: str, handler: Callable[[Message], None]) -> None:
         self.subscribers[topic].append(handler)
+
+    def unsubscribe(self, topic: str, handler: Callable[[Message], None]) -> None:
+        if handler in self.subscribers.get(topic, []):
+            self.subscribers[topic].remove(handler)
 
     def get_messages(self, topic: str | None = None) -> List[Message]:
         if topic:

--- a/tests/protocols/test_message_hub.py
+++ b/tests/protocols/test_message_hub.py
@@ -29,6 +29,23 @@ def test_publish_invokes_callbacks():
         assert msg.data == expected  # nosec B101
 
 
+def test_unsubscribe_stops_callbacks():
+    hub = MessageHub()
+    received = []
+
+    def handler(msg: Message) -> None:
+        received.append(msg)
+
+    hub.subscribe("task", handler)
+    hub.publish("task", {"n": 1})
+
+    hub.unsubscribe("task", handler)
+    hub.publish("task", {"n": 2})
+
+    assert len(received) == 1  # nosec B101
+    assert received[0].data == {"n": 1}  # nosec B101
+
+
 def test_get_messages_history_and_filtering():
     hub = MessageHub()
     hub.publish("a", {"n": 1})


### PR DESCRIPTION
## Summary
- add `unsubscribe` to remove message handlers from the hub
- test new unsubscribe functionality in the message hub

## Testing
- `pre-commit run --files protocols/utils/messaging.py tests/protocols/test_message_hub.py`
- `pytest tests/protocols/test_message_hub.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68872ceca76083208058f870e43229f4