### PR TITLE
Add modern theme and font to frontend

### DIFF
--- a/transcendental-resonance-frontend/README.md
+++ b/transcendental-resonance-frontend/README.md
@@ -31,4 +31,6 @@ Replace the backend URL with the `BACKEND_URL` environment variable if your API 
 
 ## Notes
 
-This UI is mobile-first with a futuristic aesthetic (dark mode and neon accents). A theme toggle is built in so you can switch between light and dark palettes. Future improvements include real-time notifications and internationalization.
+This UI is mobile-first with a futuristic aesthetic. A theme selector cycles between
+dark, light, and a new **modern** palette powered by the Inter font.
+Future improvements include real-time notifications and internationalization.

--- a/transcendental-resonance-frontend/src/main.py
+++ b/transcendental-resonance-frontend/src/main.py
@@ -4,7 +4,7 @@ from nicegui import ui, background_tasks
 import asyncio
 
 from .utils.api import clear_token, api_call
-from .utils.styles import apply_global_styles, set_theme, get_theme, THEMES
+from .utils.styles import apply_global_styles, set_theme, get_theme_name, THEMES
 from .pages import *  # register all pages
 from .pages.system_insights_page import system_insights_page  # noqa: F401
 
@@ -13,9 +13,14 @@ apply_global_styles()
 
 
 def toggle_theme() -> None:
-    """Switch between light and dark themes."""
-    current = get_theme()
-    new_name = "light" if current is THEMES["dark"] else "dark"
+    """Cycle through available themes."""
+    order = list(THEMES.keys())
+    current = get_theme_name()
+    try:
+        idx = order.index(current)
+    except ValueError:
+        idx = 0
+    new_name = order[(idx + 1) % len(order)]
     set_theme(new_name)
 
 
@@ -27,7 +32,7 @@ async def keep_backend_awake() -> None:
 
 
 ui.button(
-    "Toggle Theme",
+    "Theme",
     on_click=toggle_theme,
 ).classes("fixed top-0 right-0 m-2")
 

--- a/transcendental-resonance-frontend/src/utils/styles.py
+++ b/transcendental-resonance-frontend/src/utils/styles.py
@@ -20,6 +20,13 @@ THEMES: Dict[str, Dict[str, str]] = {
         "text": "#000000",
         "gradient": "linear-gradient(135deg, #ffffff 0%, #f3f3f3 100%)",
     },
+    "modern": {
+        "primary": "#6200EE",
+        "accent": "#03DAC5",
+        "background": "#f5f5f5",
+        "text": "#333333",
+        "gradient": "linear-gradient(135deg, #6200EE 0%, #03DAC5 100%)",
+    },
 }
 
 # Currently active theme name and accent color. They can be changed at runtime
@@ -54,8 +61,11 @@ def apply_global_styles() -> None:
 
     ui.add_head_html(
         f"""
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
         <style id="global-theme">
-            body {{ background: {theme['background']}; color: {theme['text']}; }}
+            body {{ font-family: 'Inter', sans-serif; background: {theme['background']}; color: {theme['text']}; }}
             .q-btn:hover {{ border: 1px solid {theme['accent']}; }}
             .futuristic-gradient {{ background: {theme['gradient']}; }}
         </style>


### PR DESCRIPTION
## Summary
- add new `modern` theme with neutral colors
- embed Inter font globally via Google Fonts
- cycle through all available themes in the UI
- document theme selector in the frontend README

## Testing
- `pytest -q` *(fails: TypeError, AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887249d36708320b498e87eb1d4911a