### PR TITLE
Add event handling tests for agents

### DIFF
--- a/tests/protocols/test_anomaly_spotter_agent.py
+++ b/tests/protocols/test_anomaly_spotter_agent.py
@@ -40,3 +40,11 @@ def test_llm_backend_called_and_flags_notes():
     assert result["flagged"] is True
     assert result["outliers"] == []
 
+
+def test_process_event_routes_and_returns():
+    agent = AnomalySpotterAgent()
+    metrics = [1, 2, 1, 1]
+    result = agent.process_event({"event": "DATA_METRICS", "payload": {"metrics": metrics}})
+    assert result["flagged"] is False
+    assert result["outliers"] == []
+

--- a/tests/protocols/test_coordination_sentinel_agent.py
+++ b/tests/protocols/test_coordination_sentinel_agent.py
@@ -1,0 +1,22 @@
+import protocols.agents.coordination_sentinel_agent as cs_module
+from protocols.agents.coordination_sentinel_agent import CoordinationSentinelAgent
+
+
+def test_inspect_validations_process_event(monkeypatch):
+    result_obj = {"flags": ["coordination"], "coordination_clusters": {"t": []}, "overall_risk_score": 0.5}
+
+    def fake_analyze(vals):
+        fake_analyze.calls = vals
+        return result_obj
+
+    monkeypatch.setattr(cs_module, "analyze_coordination_patterns", fake_analyze)
+
+    agent = CoordinationSentinelAgent()
+    payload = {"validations": [{"v": 1}]}
+    res = agent.process_event({"event": "VALIDATIONS", "payload": payload})
+
+    assert res == result_obj
+    assert agent.inbox[-1]["topic"] == "COORDINATION_RESULT"
+    assert agent.inbox[-1]["payload"]["flags"] == ["coordination"]
+    assert fake_analyze.calls == payload["validations"]
+

--- a/tests/protocols/test_cross_universe_bridge_agent.py
+++ b/tests/protocols/test_cross_universe_bridge_agent.py
@@ -35,3 +35,17 @@ def test_llm_backend_called():
 
     assert calls == ["verify proof42"]
 
+
+def test_process_event_register_and_fetch():
+    agent = CrossUniverseBridgeAgent()
+    payload = {
+        "coin_id": "c1",
+        "source_universe": "U",
+        "source_coin": "s1",
+        "proof": "p1",
+    }
+    result = agent.process_event({"event": "REGISTER_BRIDGE", "payload": payload})
+    assert result == {"valid": True}
+    prov = agent.process_event({"event": "GET_PROVENANCE", "payload": {"coin_id": "c1"}})
+    assert prov == [payload]
+

--- a/tests/protocols/test_harmony_synthesizer_agent.py
+++ b/tests/protocols/test_harmony_synthesizer_agent.py
@@ -30,3 +30,13 @@ def test_handle_generate_payload_only(monkeypatch):
     assert result == midi
     assert agent.inbox[-1]["topic"] == "MIDI_CREATED"
     assert agent.inbox[-1]["payload"] == {"midi": midi, "metrics": metrics}
+
+def test_process_event_generate(monkeypatch):
+    midi = b"evt"
+    monkeypatch.setattr(hs_agent_module, "generate_midi_from_metrics", lambda m: midi)
+    agent = HarmonySynthesizerAgent()
+    result = agent.process_event({"event": "GENERATE_MIDI", "payload": {"metrics": {"a": 1}}})
+    assert result == midi
+    assert agent.inbox[-1]["topic"] == "MIDI_CREATED"
+    assert agent.inbox[-1]["payload"]["midi"] == midi
+

--- a/tests/protocols/test_quantum_resonance_agent.py
+++ b/tests/protocols/test_quantum_resonance_agent.py
@@ -73,3 +73,24 @@ def test_adjust_for_entropy(monkeypatch):
     assert result == {"decoherence_rate": 0.123}
     assert stub_decoherence.calls == [10.0]
 
+
+def test_process_event_query_resonance_backend(monkeypatch):
+    stub_prediction.calls = []
+    stub_measure.calls = []
+    monkeypatch.setattr(QuantumContext, "quantum_prediction_engine", stub_prediction)
+    monkeypatch.setattr(QuantumContext, "measure_superposition", stub_measure)
+
+    llm_calls = []
+    def backend(prompt):
+        llm_calls.append(prompt)
+        return "note"
+
+    agent = QuantumResonanceAgent(llm_backend=backend)
+    event = {"event": "QUERY_RESONANCE", "payload": {"users": ["x", "y"]}}
+    result = agent.process_event(event)
+
+    assert result["resonance_level"] == 0.42
+    assert result["llm_note"] == "note"
+    assert llm_calls
+    assert stub_prediction.calls == [["x", "y"]]
+

--- a/tests/protocols/test_temporal_audit_agent.py
+++ b/tests/protocols/test_temporal_audit_agent.py
@@ -1,0 +1,22 @@
+import protocols.agents.temporal_audit_agent as ta_module
+from protocols.agents.temporal_audit_agent import TemporalAuditAgent
+
+
+def test_audit_batch_process_event_sends_alert(monkeypatch):
+    returned = {"flags": ["large_time_gap"], "detail": "x"}
+
+    def fake_analyze(vals):
+        fake_analyze.calls = vals
+        return returned
+
+    monkeypatch.setattr(ta_module, "analyze_temporal_consistency", fake_analyze)
+
+    agent = TemporalAuditAgent()
+    payload = {"validations": [{"foo": "bar"}]}
+    result = agent.process_event({"event": "NEW_VALIDATION_BATCH", "payload": payload})
+
+    assert result == returned
+    assert agent.inbox[-1]["topic"] == "TEMPORAL_ALERT"
+    assert agent.inbox[-1]["payload"]["flags"] == ["large_time_gap"]
+    assert fake_analyze.calls == payload["validations"]
+


### PR DESCRIPTION
## Summary
- expand AnomalySpotterAgent tests with process_event
- expand CrossUniverseBridgeAgent tests with event dispatch
- expand HarmonySynthesizerAgent tests with process_event
- expand QuantumResonanceAgent tests using process_event and llm backend
- add new TemporalAuditAgent test module
- add new CoordinationSentinelAgent test module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872e8c4c408320a3e0feb825e38c5a