### PR TITLE
Add page container helper

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,17 @@
+import pytest
+
+nicegui = pytest.importorskip("nicegui")
+try:
+    from nicegui.element import Element
+except Exception:
+    pytest.skip("nicegui.element not available", allow_module_level=True)
+
+from utils.layout import page_container
+
+
+def test_page_container_returns_element():
+    cm = page_container()
+    assert hasattr(cm, "__enter__") and hasattr(cm, "__exit__")
+    with cm as element:
+        assert isinstance(element, Element)
+

--- a/transcendental-resonance-frontend/src/pages/ai_assist_page.py
+++ b/transcendental-resonance-frontend/src/pages/ai_assist_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def ai_assist_page(vibenode_id: int):
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('AI Assist').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/events_page.py
+++ b/transcendental-resonance-frontend/src/pages/events_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def events_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Events').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/forks_page.py
+++ b/transcendental-resonance-frontend/src/pages/forks_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def forks_page() -> None:
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Universe Forks').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/groups_page.py
+++ b/transcendental-resonance-frontend/src/pages/groups_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def groups_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Groups').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/messages_page.py
+++ b/transcendental-resonance-frontend/src/pages/messages_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def messages_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Messages').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/music_page.py
+++ b/transcendental-resonance-frontend/src/pages/music_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def music_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Music Generator').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/network_analysis_page.py
+++ b/transcendental-resonance-frontend/src/pages/network_analysis_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -16,9 +17,7 @@ async def network_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Network Analysis').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/notifications_page.py
+++ b/transcendental-resonance-frontend/src/pages/notifications_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def notifications_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Notifications').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/profile_page.py
+++ b/transcendental-resonance-frontend/src/pages/profile_page.py
@@ -10,6 +10,7 @@ from utils.styles import (
     get_theme_name,
     THEMES,
 )
+from utils.layout import page_container
 from .login_page import login_page
 from .vibenodes_page import vibenodes_page
 from .groups_page import groups_page
@@ -35,9 +36,7 @@ async def profile_page():
     score_data = api_call('GET', '/users/me/influence-score') or {}
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label(f'Welcome, {user_data["username"]}').classes(
             'text-2xl font-bold mb-4'
         ).style(f'color: {THEME["accent"]};')

--- a/transcendental-resonance-frontend/src/pages/proposals_page.py
+++ b/transcendental-resonance-frontend/src/pages/proposals_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def proposals_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Proposals').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/status_page.py
+++ b/transcendental-resonance-frontend/src/pages/status_page.py
@@ -4,15 +4,14 @@ from nicegui import ui
 
 from utils.api import api_call
 from utils.styles import get_theme
+from utils.layout import page_container
 
 
 @ui.page('/status')
 async def status_page():
     """Display real-time system metrics."""
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('System Status').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/system_insights_page.py
+++ b/transcendental-resonance-frontend/src/pages/system_insights_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def system_insights_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('System Insights').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/upload_page.py
+++ b/transcendental-resonance-frontend/src/pages/upload_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def upload_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('Upload Media').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/pages/vibenodes_page.py
+++ b/transcendental-resonance-frontend/src/pages/vibenodes_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
+from utils.layout import page_container
 from .login_page import login_page
 
 
@@ -15,9 +16,7 @@ async def vibenodes_page():
         return
 
     THEME = get_theme()
-    with ui.column().classes('w-full p-4').style(
-        f'background: {THEME["gradient"]}; color: {THEME["text"]};'
-    ):
+    with page_container(THEME):
         ui.label('VibeNodes').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental-resonance-frontend/src/utils/layout.py
+++ b/transcendental-resonance-frontend/src/utils/layout.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Optional, Generator
+
+try:  # pragma: no cover - allow import without NiceGUI installed
+    from nicegui import ui
+    from nicegui.element import Element
+except Exception:  # pragma: no cover - fallback stub for testing
+    import types
+
+    class Element:  # type: ignore
+        """Fallback element used when NiceGUI is unavailable."""
+        pass
+
+    class _DummyContext:
+        def __enter__(self) -> Element:
+            return Element()
+
+        def __exit__(self, *_exc) -> None:
+            pass
+
+        def classes(self, *_args, **_kw) -> "_DummyContext":
+            return self
+
+        def style(self, *_args, **_kw) -> "_DummyContext":
+            return self
+
+    def _dummy_column() -> _DummyContext:
+        return _DummyContext()
+
+    ui = types.SimpleNamespace(column=_dummy_column)
+
+from .styles import get_theme
+
+
+@contextmanager
+def page_container(theme: Optional[dict] = None) -> Generator[Element, None, None]:
+    """Context manager for a themed page container.
+
+    Creates a ``ui.column`` with the standard padding and background
+    gradient for the currently active theme.
+    """
+    theme = theme or get_theme()
+    with ui.column().classes('w-full p-4').style(
+        f"background: {theme['gradient']}; color: {theme['text']};"
+    ) as container:
+        yield container
+


### PR DESCRIPTION
## Summary
- add layout helper for NiceGUI pages
- replace repeated column blocks with page_container usage
- provide unit test for the new helper

## Testing
- `pytest tests/test_layout.py -q`
- `pytest -q` *(fails: 'FastAPI' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68872ea2d5008320aef427d847426d1f