### PR TITLE
Add coordination sentinel agent test

### DIFF
--- a/tests/protocols/test_coordination_sentinel_agent.py
+++ b/tests/protocols/test_coordination_sentinel_agent.py
@@ -1,0 +1,22 @@
+import protocols.agents.coordination_sentinel_agent as cs_agent_module
+from protocols.agents.coordination_sentinel_agent import CoordinationSentinelAgent
+
+
+def test_inspect_validations_emits_result(monkeypatch):
+    sentinel = CoordinationSentinelAgent()
+    expected = {
+        "overall_risk_score": 0.42,
+        "coordination_clusters": {"dummy": 1},
+        "flags": ["flag1"],
+    }
+    monkeypatch.setattr(cs_agent_module, "analyze_coordination_patterns", lambda v: expected)
+
+    result = sentinel.inspect_validations({"validations": [1]})
+
+    assert result == expected
+    assert sentinel.inbox[-1]["topic"] == "COORDINATION_RESULT"
+    assert sentinel.inbox[-1]["payload"] == {
+        "flags": expected["flags"],
+        "clusters": expected["coordination_clusters"],
+        "risk": expected["overall_risk_score"],
+    }


### PR DESCRIPTION
## Summary
- add a new unit test for `CoordinationSentinelAgent`
- mock out `analyze_coordination_patterns` and ensure `COORDINATION_RESULT` is emitted

## Testing
- `pytest -q tests/protocols/test_coordination_sentinel_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68872e8e727c8320b536f821be8158ae