### PR TITLE
Add memory utilities to InternalAgentProtocol

### DIFF
--- a/protocols/agents/codex_agent.py
+++ b/protocols/agents/codex_agent.py
@@ -1,0 +1,23 @@
+"""Base agent class for Codex experiments."""
+
+from protocols.core.internal_protocol import InternalAgentProtocol
+from protocols.utils.introspection import IntrospectiveMixin
+
+
+class CodexAgent(IntrospectiveMixin, InternalAgentProtocol):
+    """Enhanced agent with handy memory helpers."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__()
+        if name:
+            self.name = name
+
+    # CODExAgent: future mixins may hook here for analytics or trust scoring
+
+    def remember(self, key: str, value: object) -> None:
+        """Store ``value`` under ``key`` in ``self.memory``."""
+        self.memory[key] = value
+
+    def recall(self, key: str, default: object | None = None) -> object | None:
+        """Retrieve from memory."""
+        return self.memory.get(key, default)

--- a/protocols/core/internal_protocol.py
+++ b/protocols/core/internal_protocol.py
@@ -1,6 +1,8 @@
 """Base protocol for memory-bound, message-driven agents."""
 from typing import Callable, Dict, Any, List
 import logging
+import json
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -12,17 +14,59 @@ class InternalAgentProtocol:
         self.name: str = self.__class__.__name__
         self.hooks: Dict[str, Callable[[dict], Any]] = {}
 
+    # ------------------------------------------------------------------
+    # Core communication helpers
+    # ------------------------------------------------------------------
+
     def send(self, topic: str, payload: dict) -> None:
+        """Queue an outbound event and log it."""
         logger.info(f"[{self.name}] SEND {topic}: {payload}")
         self.inbox.append({"topic": topic, "payload": payload})
 
     def receive(self, topic: str, handler: Callable[[dict], Any]) -> None:
+        """Register a handler for ``topic`` events."""
         self.hooks[topic] = handler
 
+    def validate_event(self, event: dict) -> bool:
+        """Basic schema check for incoming events."""
+        if not isinstance(event, dict):
+            logger.error(f"[{self.name}] Invalid event type: {type(event)}")
+            return False
+        if "event" not in event:
+            logger.error(f"[{self.name}] Event missing 'event' field: {event}")
+            return False
+        return True
+
     def process_event(self, event: dict):
+        """Dispatch an event to a registered handler after validation."""
+        if not self.validate_event(event):
+            return {"error": "invalid_event"}
+
         topic = event.get("event")
         payload = event.get("payload", {})
         if topic in self.hooks:
             return self.hooks[topic](payload)
         logger.warning(f"[{self.name}] Unknown event: {topic}")
         return {"error": f"Unhandled event {topic}"}
+
+    # ------------------------------------------------------------------
+    # Memory utilities
+    # ------------------------------------------------------------------
+    def snapshot_memory(self, path: str) -> None:
+        """Persist the agent's current memory and inbox to ``path``."""
+        data = {"memory": self.memory, "inbox": self.inbox}
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        logger.info(f"[{self.name}] Memory snapshot saved to {path}")
+
+    def load_snapshot(self, path: str) -> None:
+        """Restore memory and inbox from a snapshot file if it exists."""
+        p = Path(path)
+        if not p.exists():
+            logger.warning(f"[{self.name}] Snapshot {path} not found")
+            return
+        with open(p, "r") as f:
+            data = json.load(f)
+        self.memory = data.get("memory", {})
+        self.inbox = data.get("inbox", [])
+        logger.info(f"[{self.name}] Memory snapshot loaded from {path}")

--- a/tests/protocols/test_codex_agent.py
+++ b/tests/protocols/test_codex_agent.py
@@ -1,0 +1,8 @@
+from protocols.agents.codex_agent import CodexAgent
+
+
+def test_memory_helpers():
+    agent = CodexAgent()
+    agent.remember("k", 42)
+    assert agent.recall("k") == 42
+    assert agent.recall("missing", 0) == 0

--- a/tests/protocols/test_internal_protocol_utils.py
+++ b/tests/protocols/test_internal_protocol_utils.py
@@ -1,0 +1,27 @@
+import json
+from protocols.core.internal_protocol import InternalAgentProtocol
+
+class DummyAgent(InternalAgentProtocol):
+    def __init__(self):
+        super().__init__()
+        self.receive("echo", lambda p: p)
+
+def test_snapshot_round_trip(tmp_path):
+    agent = DummyAgent()
+    agent.memory["foo"] = 1
+    agent.send("echo", {"x": 2})
+
+    snap = tmp_path / "snap.json"
+    agent.snapshot_memory(str(snap))
+
+    new_agent = DummyAgent()
+    new_agent.load_snapshot(snap)
+    assert new_agent.memory == {"foo": 1}
+    assert new_agent.inbox == [{"topic": "echo", "payload": {"x": 2}}]
+
+
+def test_validate_event():
+    agent = DummyAgent()
+    assert not agent.validate_event("bad")
+    assert not agent.validate_event({})
+    assert agent.validate_event({"event": "echo"})


### PR DESCRIPTION
## Summary
- extend `InternalAgentProtocol` with validation and snapshot helpers
- create a reusable `CodexAgent` class built on the protocol
- test snapshotting, validation, and new Codex agent memory helpers

## Testing
- `pytest tests/protocols/test_internal_protocol_utils.py tests/protocols/test_codex_agent.py tests/test_collaborative_planner_agent.py::test_planner_delegates_to_capable_agent -q`

------
https://chatgpt.com/codex/tasks/task_e_68872ffc6a948320b283054428e6bf35