### PR TITLE
Fix harmony synthesizer test imports

### DIFF
--- a/tests/protocols/test_harmony_synthesizer_agent.py
+++ b/tests/protocols/test_harmony_synthesizer_agent.py
@@ -1,4 +1,8 @@
-import protocols.agents.harmony_synthesizer_agent as hs_agent_module
+import importlib
+
+hs_agent_module = importlib.import_module(
+    "protocols.agents.harmony_synthesizer_agent"
+)
 from protocols.agents.harmony_synthesizer_agent import HarmonySynthesizerAgent
 
 


### PR DESCRIPTION
## Summary
- load `harmony_synthesizer_agent` using `importlib.import_module`
- keep patching `generate_midi_from_metrics`

## Testing
- `pytest tests/protocols/test_harmony_synthesizer_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887318c3cec8320865607d8d301a0ba