### PR TITLE
Add safe cleanup when removing temp files

### DIFF
--- a/one_click_install.py
+++ b/one_click_install.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import platform
 import shutil
@@ -5,7 +6,6 @@ import subprocess
 import sys
 import tempfile
 import urllib.request
-import hashlib
 
 try:
     from tqdm import tqdm
@@ -23,7 +23,9 @@ PYTHON_INSTALLER_HASHES = {
     # bundled. Verification will be skipped for these downloads with a warning.
     "https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe": None,
     "https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg": None,
-    "https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz": "51412956d24a1ef7c97f1cb5f70e185c13e3de1f50d131c0aac6338080687afb",
+    "https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz": (
+        "51412956d24a1ef7c97f1cb5f70e185c13e3de1f50d131c0aac6338080687afb"
+    ),
 }
 
 
@@ -38,7 +40,9 @@ def download(url: str, dest: str, expected_sha256: str | None = None) -> None:
     print(f"Downloading {url}...")
     with urllib.request.urlopen(url) as resp, open(dest, "wb") as f:
         total = resp.length or int(resp.headers.get("Content-Length", 0))
-        with tqdm(total=total, unit="B", unit_scale=True, desc=os.path.basename(dest)) as pbar:
+        with tqdm(
+            total=total, unit="B", unit_scale=True, desc=os.path.basename(dest)
+        ) as pbar:
             while True:
                 chunk = resp.read(8192)
                 if not chunk:
@@ -74,26 +78,49 @@ def ensure_python312() -> str:
     tmp = tempfile.gettempdir()
     if system == "Windows":
         installer = os.path.join(tmp, "python312.exe")
-        download("https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe", installer)
-        subprocess.check_call([installer, "/quiet", "InstallAllUsers=1", "PrependPath=1"])
-        os.remove(installer)
+        download(
+            "https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe",
+            installer,
+        )
+        subprocess.check_call(
+            [installer, "/quiet", "InstallAllUsers=1", "PrependPath=1"]
+        )
+        try:
+            os.remove(installer)
+        except FileNotFoundError:
+            pass
     elif system == "Darwin":
         pkg = os.path.join(tmp, "python312.pkg")
-        download("https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg", pkg)
+        download(
+            "https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg", pkg
+        )
         subprocess.check_call(["sudo", "installer", "-pkg", pkg, "-target", "/"])
-        os.remove(pkg)
+        try:
+            os.remove(pkg)
+        except FileNotFoundError:
+            pass
     else:
         if shutil.which("apt-get"):
             subprocess.check_call(["sudo", "apt-get", "update"])
-            subprocess.check_call(["sudo", "apt-get", "install", "-y", "python3.12", "python3.12-venv"])
+            subprocess.check_call(
+                ["sudo", "apt-get", "install", "-y", "python3.12", "python3.12-venv"]
+            )
         else:
             tarball = os.path.join(tmp, "Python-3.12.0.tgz")
-            download("https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz", tarball)
+            download(
+                "https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz", tarball
+            )
             build_dir = os.path.join(tmp, "python-build")
             os.makedirs(build_dir, exist_ok=True)
             subprocess.check_call(["tar", "xf", tarball, "-C", build_dir])
             src = os.path.join(build_dir, "Python-3.12.0")
-            subprocess.check_call(["bash", "-c", f"cd {src} && ./configure --prefix=/usr/local && make -j$(nproc) && sudo make install"])
+            subprocess.check_call(
+                [
+                    "bash",
+                    "-c",
+                    f"cd {src} && ./configure --prefix=/usr/local && make -j$(nproc) && sudo make install",
+                ]
+            )
     path = shutil.which("python3.12")
     if path:
         return path
@@ -103,7 +130,18 @@ def ensure_python312() -> str:
 def bundle_dependencies(python: str) -> None:
     if not os.path.isdir(OFFLINE_DIR):
         print("Downloading dependencies for offline use...")
-        subprocess.check_call([python, "-m", "pip", "download", "-r", "requirements.txt", "-d", OFFLINE_DIR])
+        subprocess.check_call(
+            [
+                python,
+                "-m",
+                "pip",
+                "download",
+                "-r",
+                "requirements.txt",
+                "-d",
+                OFFLINE_DIR,
+            ]
+        )
         subprocess.check_call([python, "-m", "pip", "download", ".", "-d", OFFLINE_DIR])
 
 
@@ -111,9 +149,23 @@ def setup_environment(python: str) -> None:
     if not os.path.isdir(ENV_DIR):
         subprocess.check_call([python, "-m", "venv", ENV_DIR])
     pip = os.path.join(ENV_DIR, "Scripts" if os.name == "nt" else "bin", "pip")
-    subprocess.check_call([pip, "install", "--no-index", "--find-links", OFFLINE_DIR, "--upgrade", "pip"])
-    subprocess.check_call([pip, "install", "--no-index", "--find-links", OFFLINE_DIR, "-r", "requirements.txt"])
-    subprocess.check_call([pip, "install", "--no-index", "--find-links", OFFLINE_DIR, "-e", "."])
+    subprocess.check_call(
+        [pip, "install", "--no-index", "--find-links", OFFLINE_DIR, "--upgrade", "pip"]
+    )
+    subprocess.check_call(
+        [
+            pip,
+            "install",
+            "--no-index",
+            "--find-links",
+            OFFLINE_DIR,
+            "-r",
+            "requirements.txt",
+        ]
+    )
+    subprocess.check_call(
+        [pip, "install", "--no-index", "--find-links", OFFLINE_DIR, "-e", "."]
+    )
     if os.path.isfile(".env.example") and not os.path.isfile(".env"):
         shutil.copy(".env.example", ".env")
         print("Copied .env.example to .env")

--- a/ui.py
+++ b/ui.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
+
 from streamlit_helpers import alert
 
 try:
@@ -305,7 +306,10 @@ def run_analysis(validations, *, layout: str = "force"):
             net.show("graph.html")
             with open("graph.html") as f:
                 html_data = f.read()
-            os.remove("graph.html")
+            try:
+                os.remove("graph.html")
+            except FileNotFoundError:
+                pass
             st.components.v1.html(html_data, height=500)
         else:
             weights = [G[u][v]["weight"] * 3 for u, v in G.edges()]
@@ -369,9 +373,15 @@ def main() -> None:
 
     ts_placeholder = st.empty()
     if "session_start_ts" not in st.session_state:
-        st.session_state["session_start_ts"] = datetime.utcnow().isoformat(timespec="seconds")
+        st.session_state["session_start_ts"] = datetime.utcnow().isoformat(
+            timespec="seconds"
+        )
     ts_placeholder.markdown(
-        f"<div style='position:fixed;top:0;right:0;background:rgba(0,0,0,0.6);color:white;padding:0.25em 0.5em;border-radius:0 0 0 4px;'>Session start: {st.session_state['session_start_ts']} UTC</div>",
+        (
+            "<div style='position:fixed;top:0;right:0;background:rgba(0,0,0,0.6);"
+            "color:white;padding:0.25em 0.5em;border-radius:0 0 0 4px;'>"
+            f"Session start: {st.session_state['session_start_ts']} UTC</div>"
+        ),
         unsafe_allow_html=True,
     )
     if "diary" not in st.session_state:
@@ -452,7 +462,12 @@ def main() -> None:
         st.subheader("Settings")
         demo_mode_choice = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
         demo_mode = demo_mode_choice == "Demo"
-        theme_choice = st.radio("Theme", ["Light", "Dark"], index=(1 if st.session_state["theme"]=="dark" else 0), horizontal=True)
+        theme_choice = st.radio(
+            "Theme",
+            ["Light", "Dark"],
+            index=(1 if st.session_state["theme"] == "dark" else 0),
+            horizontal=True,
+        )
         st.session_state["theme"] = theme_choice.lower()
 
         VCConfig.HIGH_RISK_THRESHOLD = st.slider(
@@ -701,9 +716,7 @@ def main() -> None:
             ):
                 continue
             mentions = diary_mentions.get(rfc["id"], [])
-            heading = (
-                f"<mark>{rfc['id']}</mark>" if mentions else rfc["id"]
-            )
+            heading = f"<mark>{rfc['id']}</mark>" if mentions else rfc["id"]
             st.markdown(f"### {heading}", unsafe_allow_html=True)
             st.write(summarize_text(str(rfc["summary"])))
             if mentions:


### PR DESCRIPTION
## Summary
- avoid `FileNotFoundError` when deleting GraphML export
- ensure one-click installer removes temp files safely

## Testing
- `pre-commit run --files ui.py one_click_install.py` *(bandit skipped)*
- `pytest -q` *(fails: TypeError and ArgumentError)*

------
https://chatgpt.com/codex/tasks/task_e_688731940cb883208def0dedd63caa58