### PR TITLE
Ensure async fallback plugin only loads when needed

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,12 @@
 """Test suite package configuration."""
 
-# Automatically register the async fallback plugin so that async tests run
-# even when ``pytest-asyncio`` is not installed.
-# The plugin module lives inside this package, so use the fully qualified name.
-pytest_plugins = ["tests.async_fallback"]
+import importlib.util
+
+# Automatically register the async fallback plugin so that async tests run even
+# when ``pytest-asyncio`` is not installed.  When the real plugin is available
+# we avoid loading the fallback entirely to prevent any interference.
+if importlib.util.find_spec("pytest_asyncio") is None:
+    pytest_plugins = ["tests.async_fallback"]
+else:  # pragma: no cover - nothing to load when pytest-asyncio is present
+    pytest_plugins = []
 


### PR DESCRIPTION
## Summary
- only register async test fallback if `pytest-asyncio` isn't installed
- `pytest-asyncio` is installed in CI via requirements-minimal/dev

## Testing
- `pytest tests/test_hook_manager.py::test_hook_manager_basic_async_and_sync tests/test_app.py::test_register_success -q`


------
https://chatgpt.com/codex/tasks/task_e_6887318f09bc83209fac55d04f3cfb6f