### PR TITLE
Fix git hook path and tests

### DIFF
--- a/tests/test_patch_monitor_hook_script.py
+++ b/tests/test_patch_monitor_hook_script.py
@@ -1,0 +1,29 @@
+import subprocess
+
+import pytest
+
+from scripts import patch_monitor_hook
+
+
+def test_main_git_missing(monkeypatch, capsys):
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: None)
+    assert patch_monitor_hook.main() == 1
+    out = capsys.readouterr().out.strip()
+    assert "git executable not found" in out
+
+
+def test_main_git_error(monkeypatch, capsys):
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
+    def fake_check_output(cmd, text=True):
+        raise subprocess.CalledProcessError(1, cmd)
+    monkeypatch.setattr(patch_monitor_hook.subprocess, "check_output", fake_check_output)
+    assert patch_monitor_hook.main() == 1
+    out = capsys.readouterr().out.strip()
+    assert "Failed to generate diff" in out
+
+
+def test_main_success(monkeypatch):
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
+    monkeypatch.setattr(patch_monitor_hook.subprocess, "check_output", lambda *a, **k: "diff")
+    monkeypatch.setattr(patch_monitor_hook, "check_patch_compliance", lambda diff: [])
+    assert patch_monitor_hook.main() == 0


### PR DESCRIPTION
## Summary
- update `patch_monitor_hook.py` to locate `git` via PATH and handle errors
- add tests for git hook logic

## Testing
- `pytest -q tests/test_patch_monitor.py tests/test_patch_monitor_hook_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6887374565608320b194859e5c37c0b7