### PR TITLE
Add async audit UI hooks

### DIFF
--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Any, Dict
+
+from sqlalchemy.orm import Session
+
+from audit_bridge import log_hypothesis_with_trace, attach_trace_to_logentry
+from hook_manager import HookManager
+
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
+
+# Dedicated hook manager for emitting audit events
+hook_manager = HookManager()
+
+
+async def log_hypothesis_ui(payload: Dict[str, Any], db: Session) -> str:
+    """Asynchronously log a hypothesis from the UI.
+
+    Parameters
+    ----------
+    payload:
+        Dictionary containing ``hypothesis_text`` and optional
+        ``causal_node_ids`` and ``metadata``.
+    db:
+        Database session used to persist the log.
+
+    Returns
+    -------
+    str
+        Key under which the hypothesis was stored.
+    """
+    key = log_hypothesis_with_trace(
+        payload.get("hypothesis_text", ""),
+        payload.get("causal_node_ids", []),
+        db,
+        metadata=payload.get("metadata"),
+    )
+    await hook_manager.trigger(
+        "audit_log",
+        {"action": "log_hypothesis", "key": key},
+    )
+    return key
+
+
+async def attach_trace_ui(payload: Dict[str, Any], db: Session) -> None:
+    """Attach trace metadata to an existing log entry via the UI."""
+    attach_trace_to_logentry(
+        int(payload["log_id"]),
+        payload.get("causal_node_ids", []),
+        db,
+        summary=payload.get("summary"),
+    )
+    await hook_manager.trigger(
+        "audit_log",
+        {"action": "attach_trace", "log_id": int(payload["log_id"])},
+    )
+

--- a/tests/test_audit_ui_hook.py
+++ b/tests/test_audit_ui_hook.py
@@ -1,0 +1,61 @@
+import json
+import pytest
+
+from audit.ui_hook import log_hypothesis_ui, attach_trace_ui
+from db_models import LogEntry, SystemState
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_log_hypothesis_ui_records_state_and_emits_event(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    payload = {"hypothesis_text": "foo", "causal_node_ids": ["a", "b"]}
+    key = await log_hypothesis_ui(payload, test_db)
+
+    state = test_db.query(SystemState).filter(SystemState.key == key).first()
+    assert state is not None
+
+    assert dummy.events == [
+        ("audit_log", ({"action": "log_hypothesis", "key": key},), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_ui_updates_log_and_emits_event(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    log = LogEntry(
+        timestamp=__import__("datetime").datetime.utcnow(),
+        event_type="test",
+        payload=json.dumps({"foo": "bar"}),
+        previous_hash="p",
+        current_hash="c",
+    )
+    test_db.add(log)
+    test_db.commit()
+
+    payload = {
+        "log_id": log.id,
+        "causal_node_ids": ["x"],
+        "summary": "trace",
+    }
+    await attach_trace_ui(payload, test_db)
+
+    refreshed = test_db.query(LogEntry).filter(LogEntry.id == log.id).first()
+    data = json.loads(refreshed.payload)
+    assert data["causal_node_ids"] == ["x"]
+    assert data["causal_commentary"] == "trace"
+
+    assert dummy.events == [
+        ("audit_log", ({"action": "attach_trace", "log_id": log.id},), {})
+    ]


### PR DESCRIPTION
## Summary
- create `audit` package with new `ui_hook` module
- add `log_hypothesis_ui` and `attach_trace_ui` async helpers
- emit audit events via a dedicated `HookManager`
- test audit ui hooks

## Testing
- `pytest -q` *(fails: TypeError: test_network_analysis_requires_auth() got an unexpected keyword argument 'tmp_path_factory')*

------
https://chatgpt.com/codex/tasks/task_e_6887380e14888320a5ae04325ea642fe