### PR TITLE
Add UI hook for coordination analysis

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -1,0 +1,25 @@
+"""Lightweight router for UI callbacks."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Union
+
+Handler = Callable[[Dict[str, Any]], Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
+
+ROUTES: Dict[str, Handler] = {}
+
+
+def register_route(name: str, func: Handler) -> None:
+    """Register a handler for ``name`` events."""
+    ROUTES[name] = func
+
+
+async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Dispatch ``payload`` to the registered handler."""
+    if name not in ROUTES:
+        raise KeyError(name)
+    handler = ROUTES[name]
+    result = handler(payload)
+    if isinstance(result, Awaitable):
+        result = await result
+    return result

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+
+from .network_coordination_detector import analyze_coordination_patterns
+
+# Exposed hook manager for external subscribers
+ui_hook_manager = HookManager()
+
+
+async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run coordination analysis from UI payload.
+
+    Parameters
+    ----------
+    payload : dict
+        JSON payload containing ``"validations"`` list.
+
+    Returns
+    -------
+    dict
+        Minimal result with ``overall_risk_score`` and ``graph``.
+    """
+    validations = payload.get("validations", [])
+    result = analyze_coordination_patterns(validations)
+    minimal = {
+        "overall_risk_score": result.get("overall_risk_score", 0.0),
+        "graph": result.get("graph", {}),
+    }
+    # Emit event for observers
+    await ui_hook_manager.trigger("coordination_analysis_run", minimal)
+    return minimal
+
+
+# Register with the central frontend router
+register_route("coordination_analysis", trigger_coordination_analysis_ui)

--- a/tests/ui_hooks/test_coordination.py
+++ b/tests/ui_hooks/test_coordination.py
@@ -1,0 +1,32 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from network.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_coordination_analysis_via_router():
+    calls = []
+
+    async def listener(data):
+        calls.append(data)
+
+    ui_hook_manager.register_hook("coordination_analysis_run", listener)
+
+    payload = {
+        "validations": [
+            {
+                "validator_id": "v1",
+                "hypothesis_id": "h1",
+                "score": 0.9,
+                "timestamp": "2025-01-01T00:00:00Z",
+                "note": "ok",
+            }
+        ]
+    }
+
+    result = await dispatch_route("coordination_analysis", payload)
+
+    assert "overall_risk_score" in result  # nosec B101
+    assert "graph" in result  # nosec B101
+    assert calls == [result]  # nosec B101


### PR DESCRIPTION
## Summary
- add `frontend_bridge` router for dispatching UI callbacks
- add `trigger_coordination_analysis_ui` hook in `network/ui_hook.py`
- register the hook with the new router
- test dispatch and hook invocation through `tests/ui_hooks/test_coordination.py`

## Testing
- `pre-commit run --files network/ui_hook.py frontend_bridge.py tests/ui_hooks/test_coordination.py`
- `pytest -q` *(fails: FastAPI object not callable and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688738284608832098475dc199a56cf2