### PR TITLE
Fix optional request dependency

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -5,6 +5,7 @@ sqlalchemy>=2.0
 pytest-asyncio
 httpx==0.27.0
 email-validator
+requests
 fastapi
 python-multipart
 pydantic


### PR DESCRIPTION
## Summary
- include `requests` in the minimal dependency set

## Testing
- `pytest tests/protocols/test_remote_utils.py::test_ping_agent_uses_timeout -q`
- `pytest tests/protocols/test_remote_utils.py::test_ping_agent_custom_timeout -q`
- `pytest tests/test_layout.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688738f7c77483208d94accfe68f4f9d