### PR TITLE
Add vote registry planning stub

### DIFF
--- a/vote_registry.py
+++ b/vote_registry.py
@@ -1,0 +1,57 @@
+"""Vote Registry Planning Module
+
+This module will provide a registry of validator votes across the
+superNova_2177 ecosystem. It currently contains development notes and
+placeholder structures only.
+
+Planned features
+----------------
+
+* **OAuth or wallet-based identity linking** to tie validators to verified
+  accounts or blockchain wallets.
+* **Public frontend for vote timelines** allowing anyone to inspect how
+  validators have voted over time.
+* **Real-time consensus graphs across forks** for visualizing agreement
+  metrics and divergence between branches of discussion.
+* **tri_species_vote_registry.json** preparation which will capture voter
+  entries for ``human``, ``ai`` and ``company`` types.
+"""
+
+from typing import Any, Dict
+
+# ---------------------------------------------------------------------------
+# Placeholder functions
+# ---------------------------------------------------------------------------
+
+def record_vote(vote: Dict[str, Any]) -> None:
+    """Record a single vote entry.
+
+    Parameters
+    ----------
+    vote: dict
+        Information about the vote cast. The exact schema is still under
+        design and will eventually align with ``tri_species_vote_registry.json``.
+    """
+    pass  # Implementation pending
+
+
+def load_votes() -> Dict[str, Any]:
+    """Return all recorded votes (stub)."""
+    return {}
+
+# Future considerations ------------------------------------------------------
+#
+# - OAuth or wallet integrations will require secure token handling and possibly
+#   a new ``identity`` table in the database linking validator IDs to provider
+#   accounts or on-chain addresses.
+# - The frontend for vote timelines may live inside the
+#   ``transcendental_resonance_frontend`` package or a new web application. It
+#   should expose an API endpoint for querying vote history and display an
+#   interactive timeline.
+# - Consensus graphs across forks will subscribe to registry updates in real
+#   time, likely via websockets or server-sent events, and plot diverging
+#   consensus levels between branches.
+# - ``tri_species_vote_registry.json`` should store metadata about each vote
+#   including voter type (``human``, ``ai``, ``company``) and context so that
+#   threshold calculations can reference species distributions.
+


### PR DESCRIPTION
## Summary
- add `vote_registry.py` planning module with notes for upcoming work

## Testing
- `pytest -q` *(fails: requests has no attribute get, unexpected keyword argument tmp_path_factory, unsupported operand types)*

------
https://chatgpt.com/codex/tasks/task_e_68873a395eb483209806eba704292cf4