### PR TITLE
Fix Streamlit smoke test wait loop in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true &
-          sleep 15
-          curl -f http://localhost:8501 || (echo "Streamlit UI not ready" && exit 1)
+          for i in {1..30}; do
+            if curl -f http://localhost:8501 >/dev/null 2>&1; then
+              echo "Streamlit started after $i seconds"
+              break
+            fi
+            sleep 1
+          done
+          if ! curl -f http://localhost:8501 >/dev/null 2>&1; then
+            echo "Streamlit failed to start within timeout"
+            pkill streamlit
+            exit 1
+          fi
+          curl -f http://localhost:8501
           pkill streamlit


### PR DESCRIPTION
## Summary
- update CI to use Streamlit readiness loop

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: TypeError: test_get_me_success() got an unexpected keyword argument 'tmp_path_factory', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68873a528e988320ba2136a26a3067ef