### PR TITLE
Fix missing requests in minimal requirements

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -12,6 +12,8 @@ pydantic-settings
 structlog
 prometheus-client
 streamlit
+requests
+types-requests
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration


### PR DESCRIPTION
## Summary
- include `requests` in the minimal requirements file
- add optional type hints with `types-requests`

## Testing
- `pytest -q` *(fails: 18 failed, 162 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68873a60f178832090e4f4108fabfac5