### PR TITLE
Fix vote counter defaults in federation_cli

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -154,9 +154,9 @@ def vote_fork(args: argparse.Namespace) -> None:
             print("Vote already recorded for this fork")
             return
 
-        fork.vote_count += 1
+        fork.vote_count = (fork.vote_count or 0) + 1
         if vote_bool:
-            fork.yes_count += 1
+            fork.yes_count = (fork.yes_count or 0) + 1
         if basis is None:
             fork.consensus = fork.yes_count / fork.vote_count
         else:  # parity-based quantum consensus


### PR DESCRIPTION
## Summary
- prevent TypeError when fork counters are None

## Testing
- `pytest -q tests/test_federation_cli_db.py::test_vote_fork_success_and_duplicate -q`
- `pytest -q` *(fails: TypeError in test_app.py and others)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68873a5f25c0832083ff06b7d94a3a06