### PR TITLE
Add Streamlit theme helpers and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,15 @@ streamlit run ui.py
 ```
 Or run `make ui` from the repository root to start the demo.
 `ui.py` replaces the previous `app.py` script and is now the canonical entry
-point for the Streamlit interface.
+point for the Streamlit interface.  Common UI patterns like alerts, theme
+switching and layout containers live in `streamlit_helpers.py`:
+
+```python
+from streamlit_helpers import header, alert, theme_selector, centered_container
+```
+
+Import these helpers at the top of your Streamlit files to keep the UI code
+clean and consistent.
 Run these commands from the repository root. **Do not** execute `python ui.py`
 directly as that bypasses Streamlit's runtime.
 

--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -1,0 +1,17 @@
+# Extending the Streamlit UI
+
+`streamlit_helpers.py` exposes small utilities used by `ui.py` for common tasks.
+Import these helpers in your own modules to keep layouts consistent.
+
+```python
+import streamlit as st
+from streamlit_helpers import header, theme_selector, centered_container
+
+header("Custom Page", layout="wide")
+with centered_container():
+    theme_selector("Theme")
+    st.write("Hello World")
+```
+
+Running this example will render a page with the standard header, a theme switcher
+radio button and a centered content area.

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -7,6 +7,7 @@ applications to keep the UI code concise and consistent.
 from __future__ import annotations
 
 from typing import Literal
+from contextlib import contextmanager
 
 import streamlit as st
 
@@ -37,5 +38,48 @@ def header(title: str, *, layout: str = "centered") -> None:
     )
     st.header(title)
 
-__all__ = ["alert", "header"]
+
+def apply_theme(theme: str) -> None:
+    """Apply light or dark theme styles based on ``theme``."""
+    if theme == "dark":
+        st.markdown(
+            """
+            <style>
+            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
+
+def theme_selector(label: str = "Theme") -> str:
+    """Render a radio selector for the app theme and return the choice."""
+    if "theme" not in st.session_state:
+        st.session_state["theme"] = "light"
+    choice = st.radio(
+        label,
+        ["Light", "Dark"],
+        index=(1 if st.session_state["theme"] == "dark" else 0),
+        horizontal=True,
+    )
+    st.session_state["theme"] = choice.lower()
+    apply_theme(st.session_state["theme"])
+    return st.session_state["theme"]
+
+
+def centered_container(max_width: str = "900px") -> "st.delta_generator.DeltaGenerator":
+    """Return a container with standardized width constraints."""
+    st.markdown(
+        f"<style>.main .block-container{{max-width:{max_width};margin:auto;}}</style>",
+        unsafe_allow_html=True,
+    )
+    return st.container()
+
+__all__ = [
+    "alert",
+    "header",
+    "apply_theme",
+    "theme_selector",
+    "centered_container",
+]
 

--- a/ui.py
+++ b/ui.py
@@ -10,7 +10,13 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
-from streamlit_helpers import alert, header
+from streamlit_helpers import (
+    alert,
+    header,
+    theme_selector,
+    centered_container,
+    apply_theme,
+)
 
 try:
     import plotly.graph_objects as go
@@ -389,16 +395,8 @@ def main() -> None:
         st.session_state["agent_output"] = None
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
-
-    if st.session_state["theme"] == "dark":
-        st.markdown(
-            """
-            <style>
-            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
-            </style>
-            """,
-            unsafe_allow_html=True,
-        )
+    apply_theme(st.session_state["theme"])
+    centered_container()
 
     st.markdown(
         "Upload a JSON file with a `validations` array, paste JSON below, "
@@ -452,8 +450,7 @@ def main() -> None:
         st.subheader("Settings")
         demo_mode_choice = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
         demo_mode = demo_mode_choice == "Demo"
-        theme_choice = st.radio("Theme", ["Light", "Dark"], index=(1 if st.session_state["theme"]=="dark" else 0), horizontal=True)
-        st.session_state["theme"] = theme_choice.lower()
+        theme_selector("Theme")
 
         VCConfig.HIGH_RISK_THRESHOLD = st.slider(
             "High Risk Threshold", 0.1, 1.0, float(VCConfig.HIGH_RISK_THRESHOLD), 0.05


### PR DESCRIPTION
## Summary
- add `apply_theme`, `theme_selector`, and `centered_container` helpers
- use the new helpers in `ui.py`
- document helper usage in README
- provide example extension under `docs/`

## Testing
- `pytest -q` *(fails: TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68873a6fff808320aca9b9972d6d5ac4