### PR TITLE
Ensure coin purchases update in-memory state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ if "superNova_2177" not in sys.modules:
     import types
     import importlib
     import importlib.machinery
+    import uuid
     from decimal import Decimal
     from functools import lru_cache
 
@@ -144,6 +145,9 @@ if "superNova_2177" not in sys.modules:
         def set_marketplace_listing(self, lid, data):
             self.listings[lid] = data
 
+        def delete_marketplace_listing(self, lid):
+            self.listings.pop(lid, None)
+
     class SystemStateService:
         def __init__(self, db):
             pass
@@ -162,13 +166,25 @@ if "superNova_2177" not in sys.modules:
         def process_event(self, event):
             ev = event.get("event")
             if ev == "ADD_USER":
+                root_id = event.get("root_coin_id") or f"root_{uuid.uuid4().hex}"
                 self.storage.set_user(
                     event["user"],
                     {
-                        "root_coin_id": event.get("root_coin_id") or "root",
+                        "root_coin_id": root_id,
                         "karma": event.get("karma", "0"),
                         "consent_given": event.get("consent", True),
                         "is_genesis": event.get("is_genesis", False),
+                        "coins_owned": [root_id],
+                    },
+                )
+                self.storage.set_coin(
+                    root_id,
+                    {
+                        "owner": event["user"],
+                        "value": event.get(
+                            "root_coin_value", str(self.config.ROOT_INITIAL_VALUE)
+                        ),
+                        "is_root": True,
                     },
                 )
             elif ev == "MINT":
@@ -205,8 +221,35 @@ if "superNova_2177" not in sys.modules:
                 listing = self.storage.get_marketplace_listing(event["listing_id"])
                 if listing:
                     coin = self.storage.get_coin(listing["coin_id"])
-                    if coin:
-                        coin["owner"] = event["buyer"]
+                    buyer = self.storage.get_user(event["buyer"])
+                    seller = self.storage.get_user(listing.get("seller"))
+                    if (
+                        coin
+                        and buyer
+                        and seller
+                        and (buyer_root := self.storage.get_coin(buyer.get("root_coin_id")))
+                        and (seller_root := self.storage.get_coin(seller.get("root_coin_id")))
+                    ):
+                        price = Decimal(str(listing.get("price", "0")))
+                        total = Decimal(str(event.get("total_cost", price)))
+                        buyer_val = Decimal(str(buyer_root.get("value", "0")))
+                        if buyer_val >= total:
+                            buyer_root["value"] = str(buyer_val - total)
+                            seller_root["value"] = str(
+                                Decimal(str(seller_root.get("value", "0"))) + price
+                            )
+                            coin_id = listing["coin_id"]
+                            coin["owner"] = event["buyer"]
+                            buyer.setdefault("coins_owned", []).append(coin_id)
+                            seller_coins = seller.setdefault("coins_owned", [])
+                            if coin_id in seller_coins:
+                                seller_coins.remove(coin_id)
+                            self.storage.set_coin(buyer["root_coin_id"], buyer_root)
+                            self.storage.set_coin(seller["root_coin_id"], seller_root)
+                            self.storage.set_coin(coin_id, coin)
+                            self.storage.set_user(event["buyer"], buyer)
+                            self.storage.set_user(listing.get("seller"), seller)
+                            self.storage.delete_marketplace_listing(event["listing_id"])
             elif ev == "REACT":
                 coin = self.storage.get_coin(event["coin_id"])
                 if coin:


### PR DESCRIPTION
## Summary
- expand lightweight agent in tests to persist new users' root coins
- update BUY_COIN handling in the stub agent to adjust user balances and remove listings
- add `delete_marketplace_listing` to test storage

## Testing
- `pytest tests/test_app.py::test_buy_coin_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68873a7f1f208320ae0ca896e92cb363