### PR TITLE
Add escape_markdown fallback and tests

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -11,6 +11,20 @@ from typing import Literal
 import streamlit as st
 
 
+try:  # pragma: no cover - depends on Streamlit version
+    _escape_md = st.escape_markdown
+except AttributeError:  # pragma: no cover - fallback for older versions
+    try:  # pragma: no cover - optional text_util path
+        from streamlit.text_util import escape_markdown as _escape_md  # type: ignore
+    except Exception:  # pragma: no cover - final fallback
+        def _escape_md(text: str) -> str:
+            return (
+                text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+            )
+
+
 def alert(message: str, level: Literal["warning", "error", "info"] = "info") -> None:
     """Display a styled Markdown alert box."""
     colors = {
@@ -23,7 +37,7 @@ def alert(message: str, level: Literal["warning", "error", "info"] = "info") -> 
         f"<div style='border-left: 4px solid {border_color}; "
         f"background-color: {bg_color}; padding: 0.5em; "
         f"border-radius: 0 4px 4px 0; margin-bottom: 1em;'>"
-        f"{st.escape_markdown(message)}</div>",
+        f"{_escape_md(message)}</div>",
         unsafe_allow_html=True,
     )
 

--- a/tests/test_streamlit_helpers.py
+++ b/tests/test_streamlit_helpers.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+import types
+
+
+def test_alert_handles_missing_escape(monkeypatch):
+    stub = types.ModuleType("streamlit")
+
+    calls = []
+
+    def markdown(text, **kwargs):
+        calls.append(text)
+
+    stub.markdown = markdown
+    stub.text_util = types.ModuleType("streamlit.text_util")
+    # no escape_markdown attribute provided on stub or text_util
+
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    monkeypatch.setitem(sys.modules, "streamlit.text_util", stub.text_util)
+
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+    helpers.alert("hello")
+    assert calls


### PR DESCRIPTION
## Summary
- use `_escape_md` with fallback implementations in `streamlit_helpers.alert`
- add regression test for missing `escape_markdown`

## Testing
- `pip install -r requirements-minimal.txt`
- `pytest -q` *(fails: 18 failed, 163 passed, 23 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68873a6a53f08320b335d6e7f7a26e9e