### PR TITLE
Remove redundant Streamlit install from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Install dependencies with fallback mirror
         run: |
           python -m pip install --upgrade pip
-          # Ensure Streamlit is present for smoke tests
-          pip install streamlit
           if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://pypi.org/simple; then
             echo "[INFO] Pip install succeeded using https://pypi.org/simple"
           else

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -22,8 +22,6 @@ jobs:
       - name: Install dependencies with fallback mirror
         run: |
           python -m pip install --upgrade pip
-          # Ensure Streamlit is present for smoke tests
-          pip install streamlit
           if pip install -r requirements-minimal.txt -r requirements-dev.txt --index-url=https://pypi.org/simple; then
             echo "[INFO] Pip install succeeded using https://pypi.org/simple"
           else


### PR DESCRIPTION
## Summary
- rely on requirements files to provide Streamlit
- drop now unnecessary install lines in CI workflows

## Testing
- `pytest -q` *(fails: sqlalchemy errors)

------
https://chatgpt.com/codex/tasks/task_e_6887390c2cf48320884c1b8f9e3a6c64