### PR TITLE
Improve disclaimer git checks

### DIFF
--- a/scripts/check_disclaimers.py
+++ b/scripts/check_disclaimers.py
@@ -1,19 +1,27 @@
 import subprocess  # nosec B404
 import sys
+from shutil import which
 
 from governance.patch_monitor import check_patch_compliance
 
 
-def get_diff(base: str) -> str:
-    """Return git diff from base to HEAD."""
-    cmd = ["git", "diff", f"{base}...HEAD"]
+def get_diff(base: str, git_cmd: str) -> str:
+    """Return git diff from base to HEAD using ``git_cmd``."""
+    cmd = [git_cmd, "diff", f"{base}...HEAD"]
     return subprocess.check_output(cmd, text=True)  # nosec B603
 
 
 def main() -> int:
     base = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
+    git_cmd = which("git")
+    if git_cmd is None:
+        print("git executable not found; install git with `apt install git`")
+        return 1
     try:
-        diff = get_diff(base)
+        diff = get_diff(base, git_cmd)
+    except FileNotFoundError:
+        print("git executable not found; install git with `apt install git`")
+        return 1
     except subprocess.CalledProcessError as e:
         print(f"Failed to generate diff: {e}")
         return 1

--- a/tests/test_check_disclaimers_script.py
+++ b/tests/test_check_disclaimers_script.py
@@ -1,0 +1,31 @@
+import subprocess
+
+import pytest
+
+from scripts import check_disclaimers
+
+
+def test_main_git_missing(monkeypatch, capsys):
+    monkeypatch.setattr(check_disclaimers, "which", lambda cmd: None)
+    assert check_disclaimers.main() == 1
+    out = capsys.readouterr().out.strip()
+    assert "git executable not found" in out
+
+
+def test_main_git_error(monkeypatch, capsys):
+    monkeypatch.setattr(check_disclaimers, "which", lambda cmd: "/git")
+
+    def fake_check_output(cmd, text=True):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(check_disclaimers.subprocess, "check_output", fake_check_output)
+    assert check_disclaimers.main() == 1
+    out = capsys.readouterr().out.strip()
+    assert "Failed to generate diff" in out
+
+
+def test_main_success(monkeypatch):
+    monkeypatch.setattr(check_disclaimers, "which", lambda cmd: "/git")
+    monkeypatch.setattr(check_disclaimers.subprocess, "check_output", lambda *a, **k: "diff")
+    monkeypatch.setattr(check_disclaimers, "check_patch_compliance", lambda diff: [])
+    assert check_disclaimers.main() == 0


### PR DESCRIPTION
## Summary
- ensure `check_disclaimers.py` verifies `git` availability using `shutil.which`
- handle `FileNotFoundError` around `git diff`
- include helpful install message when `git` is missing
- add unit tests for `check_disclaimers` script

## Testing
- `pytest tests/test_check_disclaimers_script.py -q`
- `pytest -q` *(fails: AttributeError: <module 'requests'> has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_68873a2bcbf88320af42b4a56bbb8eae