### PR TITLE
Update frontend references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ python setup_env.py
 
 # optional: build the Transcendental Resonance frontend
 # python setup_env.py --build-ui
+# The NiceGUI web interface now lives in `transcendental_resonance_frontend/`.
+# References to the old `web_ui` directory continue to work but will emit a
+# warning.
 
 # Try demo mode
 supernova-validate --demo

--- a/install/install_android.sh
+++ b/install/install_android.sh
@@ -9,6 +9,15 @@ if [ ! -d superNova_2177 ]; then
 fi
 cd superNova_2177
 pip install -r requirements.txt
+FRONTEND_DIR=transcendental_resonance_frontend
+if [ ! -d "$FRONTEND_DIR" ] && [ -d web_ui ]; then
+    echo "Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'" >&2
+    FRONTEND_DIR=web_ui
+fi
+if [ -d "$FRONTEND_DIR" ]; then
+    pip install -r "$FRONTEND_DIR/requirements.txt"
+    nicegui "$FRONTEND_DIR/src/main.py" --port 8080 &
+fi
 uvicorn superNova_2177:app --host 0.0.0.0 --port 8000 &
 sleep 2
 python - <<'PY'

--- a/install/install_desktop.bat
+++ b/install/install_desktop.bat
@@ -3,6 +3,15 @@ python -m venv venv
 call venv\Scripts\activate
 pip install --upgrade pip
 pip install -r requirements.txt
+set FRONTEND_DIR=transcendental_resonance_frontend
+if not exist %FRONTEND_DIR% if exist web_ui (
+    echo Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'
+    set FRONTEND_DIR=web_ui
+)
+if exist %FRONTEND_DIR% (
+    pip install -r %FRONTEND_DIR%\requirements.txt
+    start nicegui %FRONTEND_DIR%\src\main.py
+)
 start uvicorn superNova_2177:app --reload
 timeout /t 2
 start http://localhost:8080

--- a/install/install_desktop.sh
+++ b/install/install_desktop.sh
@@ -10,6 +10,15 @@ fi
 source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
+FRONTEND_DIR=transcendental_resonance_frontend
+if [ ! -d "$FRONTEND_DIR" ] && [ -d web_ui ]; then
+    echo "Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'" >&2
+    FRONTEND_DIR=web_ui
+fi
+if [ -d "$FRONTEND_DIR" ]; then
+    pip install -r "$FRONTEND_DIR/requirements.txt"
+    nicegui "$FRONTEND_DIR/src/main.py" &
+fi
 uvicorn superNova_2177:app --reload &
 sleep 2
 xdg-open http://localhost:8080 || open http://localhost:8080

--- a/setup_env.py
+++ b/setup_env.py
@@ -53,7 +53,16 @@ def run_app() -> None:
 
 def build_frontend(pip: list) -> None:
     """Install UI deps and build the Transcendental Resonance frontend."""
-    ui_reqs = Path('transcendental_resonance_frontend') / 'requirements.txt'
+    frontend_dir = Path('transcendental_resonance_frontend')
+    if not frontend_dir.exists():
+        legacy = Path('web_ui')
+        if legacy.exists():
+            print(
+                "Warning: 'web_ui' is deprecated; using it for compatibility.",
+                file=sys.stderr,
+            )
+            frontend_dir = legacy
+    ui_reqs = frontend_dir / 'requirements.txt'
     if ui_reqs.is_file():
         try:
             subprocess.check_call(pip + ['install', '-r', str(ui_reqs)])
@@ -61,7 +70,7 @@ def build_frontend(pip: list) -> None:
             logging.error('Failed to install UI dependencies: %s', exc)
             logging.error('Check your internet connection and try again.')
             raise
-    ui_script = Path('transcendental_resonance_frontend') / 'src' / 'main.py'
+    ui_script = frontend_dir / 'src' / 'main.py'
     nicegui = [venv_bin('nicegui')] if not in_virtualenv() else ['nicegui']
     try:
         subprocess.check_call(nicegui + ['build', str(ui_script)])

--- a/web_ui/__init__.py
+++ b/web_ui/__init__.py
@@ -1,0 +1,10 @@
+import warnings
+from importlib import import_module
+
+warnings.warn(
+    "The 'web_ui' package has been renamed to 'transcendental_resonance_frontend'.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+module = import_module('transcendental_resonance_frontend')
+globals().update(module.__dict__)


### PR DESCRIPTION
## Summary
- provide legacy `web_ui` package redirecting to `transcendental_resonance_frontend`
- handle old `web_ui` path in setup script
- install and launch the renamed frontend in desktop/Android installers
- mention renamed UI in README

## Testing
- `pytest -q` *(fails: TypeError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68873a2fee20832091b20e079d7e1de5