### PR TITLE
Add optional UI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ python setup_env.py
 # optional: build the Transcendental Resonance frontend
 # python setup_env.py --build-ui
 
+# optional: launch the Streamlit UI
+# python setup_env.py --launch-ui
+
 # Try demo mode
 supernova-validate --demo
 
@@ -56,12 +59,14 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
    dependencies locally. Install any missing system libraries first (see
    [System Packages](#system-packages)). You can also pass `--locked` to install packages from
    `requirements.lock` for deterministic builds. Additional flags `--run-app`
-   and `--build-ui` can automatically start the API or compile the frontend:
+   and `--build-ui` can automatically start the API or compile the frontend. Use
+   `--launch-ui` to open the Streamlit dashboard after install:
    ```bash
    python setup_env.py
    # python setup_env.py --run-app    # launch API after install
    # python setup_env.py --locked     # install from requirements.lock
     # python setup_env.py --build-ui   # build Transcendental Resonance frontend assets
+    # python setup_env.py --launch-ui  # run the Streamlit UI on port 8888
    ```
   You can also let `install.py` choose the appropriate installer for your
   platform:

--- a/setup_env.py
+++ b/setup_env.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import argparse
 import logging
+import importlib.util
 from pathlib import Path
 
 ENV_DIR = 'venv'
@@ -51,6 +52,28 @@ def run_app() -> None:
         raise
 
 
+def run_ui() -> None:
+    """Launch the Streamlit UI using the environment's Python."""
+    python_exe = sys.executable if in_virtualenv() else venv_bin('python')
+    if importlib.util.find_spec('streamlit') is None:
+        logging.error('Streamlit is not installed. Install it with "pip install streamlit" and try again.')
+        return
+    try:
+        subprocess.check_call([
+            python_exe,
+            '-m',
+            'streamlit',
+            'run',
+            'ui.py',
+            '--server.port',
+            '8888',
+        ])
+    except subprocess.CalledProcessError as exc:
+        logging.error('Failed to launch the Streamlit UI: %s', exc)
+        logging.error('Ensure Streamlit is installed and functioning correctly.')
+        raise
+
+
 def build_frontend(pip: list) -> None:
     """Install UI deps and build the Transcendental Resonance frontend."""
     ui_reqs = Path('transcendental_resonance_frontend') / 'requirements.txt'
@@ -78,6 +101,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description='Set up the environment')
     parser.add_argument('--run-app', action='store_true', help='start the API after installation')
     parser.add_argument('--build-ui', action='store_true', help='build the Transcendental Resonance frontend after installation')
+    parser.add_argument('--launch-ui', action='store_true', help='start the Streamlit UI after installation')
     parser.add_argument('--locked', action='store_true',
                         help='install dependencies from requirements.lock')
     args = parser.parse_args()
@@ -121,6 +145,13 @@ def main() -> None:
         except subprocess.CalledProcessError:
             logging.error('Failed to run the application.')
             logging.error('Resolve the errors above and re-run with --run-app.')
+
+    if args.launch_ui:
+        try:
+            run_ui()
+        except subprocess.CalledProcessError:
+            logging.error('Failed to launch the UI.')
+            logging.error('Resolve the errors above and re-run with --launch-ui.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `--launch-ui` flag in setup_env.py to open Streamlit on port 8888
- implement `run_ui` helper with a clear error if Streamlit isn't installed
- document the new flag in README

## Testing
- `pytest -q` *(fails: TypeError: test_get_me_success() got an unexpected keyword argument 'tmp_path_factory')*

------
https://chatgpt.com/codex/tasks/task_e_68873a35ad4883209e3b8d05015c5367