### PR TITLE
Remove redundant condition around diary Markdown export

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
+
 from streamlit_helpers import alert, header
 
 try:
@@ -370,9 +371,15 @@ def main() -> None:
 
     ts_placeholder = st.empty()
     if "session_start_ts" not in st.session_state:
-        st.session_state["session_start_ts"] = datetime.utcnow().isoformat(timespec="seconds")
+        st.session_state["session_start_ts"] = datetime.utcnow().isoformat(
+            timespec="seconds"
+        )
     ts_placeholder.markdown(
-        f"<div style='position:fixed;top:0;right:0;background:rgba(0,0,0,0.6);color:white;padding:0.25em 0.5em;border-radius:0 0 0 4px;'>Session start: {st.session_state['session_start_ts']} UTC</div>",
+        (
+            "<div style='position:fixed;top:0;right:0;background:rgba(0,0,0,0.6);"
+            "color:white;padding:0.25em 0.5em;border-radius:0 0 0 4px;'>"
+            f"Session start: {st.session_state['session_start_ts']} UTC</div>"
+        ),
         unsafe_allow_html=True,
     )
     if "diary" not in st.session_state:
@@ -452,7 +459,12 @@ def main() -> None:
         st.subheader("Settings")
         demo_mode_choice = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
         demo_mode = demo_mode_choice == "Demo"
-        theme_choice = st.radio("Theme", ["Light", "Dark"], index=(1 if st.session_state["theme"]=="dark" else 0), horizontal=True)
+        theme_choice = st.radio(
+            "Theme",
+            ["Light", "Dark"],
+            index=(1 if st.session_state["theme"] == "dark" else 0),
+            horizontal=True,
+        )
         st.session_state["theme"] = theme_choice.lower()
 
         VCConfig.HIGH_RISK_THRESHOLD = st.slider(
@@ -617,7 +629,7 @@ def main() -> None:
                 f"<p id='{anchor}'><strong>{entry['timestamp']}</strong>: {note}{extra}</p>",
                 unsafe_allow_html=True,
             )
-        if st.download_button(
+        st.download_button(
             "Export Diary as Markdown",
             "\n".join(
                 [
@@ -631,8 +643,7 @@ def main() -> None:
                 ]
             ),
             file_name="diary.md",
-        ):
-            pass
+        )
         st.download_button(
             "Export Diary as JSON",
             json.dumps(st.session_state["diary"], indent=2),


### PR DESCRIPTION
## Summary
- simplify the diary Markdown export button in the UI by removing an empty conditional

## Testing
- `pre-commit run --files ui.py`
- `pytest tests/test_dashboard_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68873ab1b30883209c4615241f4b996a