### PR TITLE
Fix git path resolution

### DIFF
--- a/scripts/patch_monitor_hook.py
+++ b/scripts/patch_monitor_hook.py
@@ -8,14 +8,14 @@ from governance.patch_monitor import check_patch_compliance  # noqa: E402
 
 
 def main() -> int:
-    git_cmd = which("git")
-    if git_cmd is None:
-        print("git executable not found")
-        return 1
+    git_cmd = which("git") or "git"
     try:
         diff = subprocess.check_output(  # nosec B607,B603
             [git_cmd, "diff", "--cached"], text=True
         )
+    except FileNotFoundError:
+        print("git executable not found")
+        return 1
     except subprocess.CalledProcessError as e:
         print(f"Failed to generate diff: {e}")
         return 1

--- a/tests/test_patch_monitor_hook_script.py
+++ b/tests/test_patch_monitor_hook_script.py
@@ -7,6 +7,11 @@ from scripts import patch_monitor_hook
 
 def test_main_git_missing(monkeypatch, capsys):
     monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: None)
+    monkeypatch.setattr(
+        patch_monitor_hook.subprocess,
+        "check_output",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
     assert patch_monitor_hook.main() == 1
     out = capsys.readouterr().out.strip()
     assert "git executable not found" in out


### PR DESCRIPTION
## Summary
- use `shutil.which` to locate `git` for patch monitor hook
- update tests for the new fallback logic

## Testing
- `pytest -q` *(fails: TypeError, AssertionError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68873aac17148320b1bbc0c59fa1f560