### PR TITLE
Support thread-based coordination detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,8 @@ jupyter notebook docs/Network_Graph_Visualization.ipynb
 * `diversity_analyzer.py` — Detects echo chambers and affiliation bias
 * `temporal_consistency_checker.py` — Tracks time-based volatility
 * `network_coordination_detector.py` — Spots suspicious group behavior using
-  sentence‑embedding similarity
+  sentence‑embedding similarity. Set `NOVA_COORDINATION_USE_THREADS=1` if
+  Streamlit cannot spawn processes
 
 ## 🧪 Status
 

--- a/tests/test_network_coordination_detector.py
+++ b/tests/test_network_coordination_detector.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+os.environ["NOVA_COORDINATION_USE_THREADS"] = "1"
+
 from network.network_coordination_detector import (
     calculate_sophisticated_risk_score,
     analyze_coordination_patterns,


### PR DESCRIPTION
## Summary
- add `NOVA_COORDINATION_USE_THREADS` to avoid spawning processes under Streamlit
- switch to `ThreadPoolExecutor` when the flag is set
- document the new flag in README
- update network coordination tests to use the thread pool

## Testing
- `pytest tests/test_network_coordination_detector.py::test_calculate_sophisticated_risk_score_basic -q`
- `pytest -q` *(fails: ImportError: cannot import name 'select' from 'sqlalchemy.orm')*

------
https://chatgpt.com/codex/tasks/task_e_68873e53202483208a9753b25e9b7274