### PR TITLE
Fix coordination concurrency in streamlit

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -6,7 +6,10 @@ import json
 import uuid
 from pathlib import Path
 from datetime import datetime
-from sqlalchemy.orm import select
+# SQLAlchemy 2.x exposes `select` at the top level. Importing from
+# `sqlalchemy.orm` is no longer valid, so we import from the main package
+# for compatibility with newer versions.
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from db_models import (


### PR DESCRIPTION
## Summary
- allow `network_coordination_detector` to use threads by default
- document the concurrency choice in the module
- fix SQLAlchemy import for federation CLI

## Testing
- `pytest tests/test_network_coordination_detector.py::test_analyze_coordination_patterns_detects_clusters -q`
- `pytest tests/test_federation_cli.py::test_list_forks_serializes_decimal_config -q`
- `flake8 network/network_coordination_detector.py`

------
https://chatgpt.com/codex/tasks/task_e_68873e53202483208a9753b25e9b7274