### PR TITLE
Fix patch monitor git invocation

### DIFF
--- a/scripts/patch_monitor_hook.py
+++ b/scripts/patch_monitor_hook.py
@@ -1,17 +1,15 @@
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
-from shutil import which
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from governance.patch_monitor import check_patch_compliance  # noqa: E402
 
 
 def main() -> int:
-    git_cmd = which("git") or "git"
     try:
         diff = subprocess.check_output(  # nosec B607,B603
-            [git_cmd, "diff", "--cached"], text=True
+            ["git", "diff", "--cached"], text=True
         )
     except FileNotFoundError:
         print("git executable not found")

--- a/tests/test_patch_monitor_hook_script.py
+++ b/tests/test_patch_monitor_hook_script.py
@@ -6,7 +6,6 @@ from scripts import patch_monitor_hook
 
 
 def test_main_git_missing(monkeypatch, capsys):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: None)
     monkeypatch.setattr(
         patch_monitor_hook.subprocess,
         "check_output",
@@ -18,17 +17,20 @@ def test_main_git_missing(monkeypatch, capsys):
 
 
 def test_main_git_error(monkeypatch, capsys):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
     def fake_check_output(cmd, text=True):
         raise subprocess.CalledProcessError(1, cmd)
-    monkeypatch.setattr(patch_monitor_hook.subprocess, "check_output", fake_check_output)
+
+    monkeypatch.setattr(
+        patch_monitor_hook.subprocess, "check_output", fake_check_output
+    )
     assert patch_monitor_hook.main() == 1
     out = capsys.readouterr().out.strip()
     assert "Failed to generate diff" in out
 
 
 def test_main_success(monkeypatch):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
-    monkeypatch.setattr(patch_monitor_hook.subprocess, "check_output", lambda *a, **k: "diff")
+    monkeypatch.setattr(
+        patch_monitor_hook.subprocess, "check_output", lambda *a, **k: "diff"
+    )
     monkeypatch.setattr(patch_monitor_hook, "check_patch_compliance", lambda diff: [])
     assert patch_monitor_hook.main() == 0


### PR DESCRIPTION
## Summary
- update `patch_monitor_hook` to call `git` directly
- adjust tests for updated hook

## Testing
- `pre-commit run --files scripts/patch_monitor_hook.py tests/test_patch_monitor_hook_script.py`
- `pytest -k patch_monitor_hook_script -q`

------
https://chatgpt.com/codex/tasks/task_e_68873f2ea548832091f8ab4c083d3078