### PR TITLE
Fix Streamlit spawning issue in coordination detector

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -6,7 +6,10 @@ import json
 import uuid
 from pathlib import Path
 from datetime import datetime
-from sqlalchemy.orm import select
+# SQLAlchemy 2.x exposes `select` at the top level. Importing from
+# `sqlalchemy.orm` fails on newer versions, so use the root namespace
+# for compatibility.
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from db_models import (

--- a/tests/test_network_coordination_detector.py
+++ b/tests/test_network_coordination_detector.py
@@ -165,3 +165,13 @@ def test_detect_semantic_coordination_sentence_transformer_failure(monkeypatch):
     assert result["semantic_clusters"]
     assert result["semantic_clusters"][0]["similarity_score"] >= 0.8
 
+
+def test_force_threadpool(monkeypatch):
+    """Setting SUPERNOVA_FORCE_THREADPOOL uses threads instead of processes."""
+    monkeypatch.setenv("SUPERNOVA_FORCE_THREADPOOL", "1")
+    import importlib
+    import network.network_coordination_detector as mod
+
+    mod = importlib.reload(mod)
+    assert mod.ExecutorClass is mod.ThreadPoolExecutor
+


### PR DESCRIPTION
## Summary
- handle environments that can't spawn processes
- fall back to ThreadPoolExecutor via `SUPERNOVA_FORCE_THREADPOOL` flag
- document concurrency choice
- update tests for the new flag
- fix SQLAlchemy import for CLI utilities

## Testing
- `pytest tests/test_network_coordination_detector.py -q`
- `pytest tests/test_federation_cli.py tests/test_federation_cli_db.py -q`
- `pytest -q` *(fails: test_app.py, test_async_fallback_plugin.py, test_audit_bridge.py, test_federation_cli.py, test_federation_cli_db.py, test_orm_consistency.py, test_prediction_manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_68873ec85ff88320827ca7e1539f5437