### PR TITLE
Update docs for proper testing setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,14 +38,18 @@ You can also install both requirement files to match the CI environment:
 pip install -r requirements-minimal.txt -r requirements-dev.txt
 ```
 
+If the packages are missing, stub implementations found under `stubs/`
+will activate automatically and may cause confusing test failures.
+
 The GitHub Actions workflows (`.github/workflows/ci.yml` and `pr-tests.yml`) run these commands automatically whenever you push or open a pull request.
 
 ## Pre-commit Hooks
 
-Install the development tools and enable the git hooks so code is automatically formatted and linted:
+Install the development tools and enable the git hooks so code is automatically
+formatted and linted. The hooks rely on packages from both requirement files:
 
 ```bash
-pip install -r requirements-dev.txt
+pip install -r requirements-minimal.txt -r requirements-dev.txt
 pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,12 @@ make lint     # run mypy type checks
 
 ### Pre-commit Hooks
 
-Set up pre-commit to automatically format and lint the code:
+Set up pre-commit to automatically format and lint the code. The hooks depend on
+packages from **both** `requirements-minimal.txt` and
+`requirements-dev.txt`:
 
 ```bash
-pip install -r requirements-dev.txt
+pip install -r requirements-minimal.txt -r requirements-dev.txt
 pre-commit install
 ```
 
@@ -320,10 +322,11 @@ pip install -r requirements.txt  # installs streamlit-ace
 
 ### Test Requirements
 
-Before running `pre-commit` or `pytest`, install the minimal set of packages required for the tests:
+Before running `pre-commit` or `pytest`, install **both** requirement
+files so that all dependencies are available:
 
 ```bash
-pip install -r requirements-minimal.txt
+pip install -r requirements-minimal.txt -r requirements-dev.txt
 ```
 
 `requirements-minimal.txt` installs `fastapi`, `pydantic`,
@@ -333,15 +336,8 @@ pip install -r requirements-minimal.txt
 `email-validator`). With these installed, running `pytest` should
 succeed (`99 passed`).
 
-> **Important**
-> CI and local testing rely on these packages. Always run
-> `pip install -r requirements-minimal.txt` **before** invoking
-> `pre-commit` or `pytest`. Skipping this step triggers the simplified
-> stubs in `stubs/` and can cause numerous test failures.
-
-If the packages are missing, stub implementations in `stubs/`
-activate automatically. This allows `pytest` to succeed but may not
-exercise the full functionality of optional modules.
+Missing packages trigger the simplified stubs in `stubs/`, which can
+lead to confusing test failures.
 
 ### Real Module Dependencies
 


### PR DESCRIPTION
## Summary
- clarify that tests and pre-commit hooks require the packages from both requirement files
- mention `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- warn that missing packages trigger the stub implementations

## Testing
- `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError in sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68873f39ab94832081ccb40e1adb059f