### PR TITLE
Centralize optional imports

### DIFF
--- a/optional_import.py
+++ b/optional_import.py
@@ -1,0 +1,36 @@
+import importlib
+import types
+from types import ModuleType
+
+class _MissingModule(ModuleType):
+    """Stub module for missing optional dependencies."""
+
+    def __init__(self, name: str, message: str) -> None:
+        super().__init__(name)
+        self._message = message
+
+    def __getattr__(self, attr: str) -> ModuleType:
+        raise ImportError(self._message)
+
+    def __bool__(self) -> bool:  # pragma: no cover - bool check convenience
+        return False
+
+    @property
+    def _optional_missing(self) -> bool:  # marker for detection
+        return True
+
+
+def optional_import(module: str, attr: str | None = None):
+    """Return imported module or attribute, or a stub raising ImportError."""
+    try:
+        mod = importlib.import_module(module)
+        return getattr(mod, attr) if attr else mod
+    except Exception:
+        msg = f"Optional dependency '{module}' is required for this feature"
+
+        def _missing(*_a, **_k):
+            raise ImportError(msg)
+
+        _missing._optional_missing = True  # type: ignore[attr-defined]
+
+        return _missing if attr else _MissingModule(module, msg)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -9,15 +9,16 @@ from __future__ import annotations
 from typing import Literal
 from contextlib import contextmanager
 
-import streamlit as st
+from optional_import import optional_import
+
+st = optional_import("streamlit")
 
 
 try:  # pragma: no cover - depends on Streamlit version
     _escape_md = st.escape_markdown
-except AttributeError:  # pragma: no cover - fallback for older versions
-    try:  # pragma: no cover - optional text_util path
-        from streamlit.text_util import escape_markdown as _escape_md  # type: ignore
-    except Exception:  # pragma: no cover - final fallback
+except Exception:
+    _escape_md = optional_import("streamlit.text_util", "escape_markdown")
+    if getattr(_escape_md, "_optional_missing", False):
         def _escape_md(text: str) -> str:
             return (
                 text.replace("&", "&amp;")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,6 +324,12 @@ if "superNova_2177" not in sys.modules:
     stub_sn.SessionLocal = sa_stub.sessionmaker(bind=stub_engine)
     stub_sn.Base = sa_stub.declarative_base()
     stub_sn.USE_IN_MEMORY_STORAGE = True
+    stub_sn.SQLAlchemyStorage = type(
+        "SQLAlchemyStorage",
+        (),
+        {"set_coin": lambda self, *_a, **_k: None},
+    )
+    stub_sn.UserCreationError = type("UserCreationError", (Exception,), {})
 
     # Import FastAPI components with a lightweight fallback when the real
     # package isn't installed.  This avoids ``ModuleNotFoundError`` during test

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,0 +1,25 @@
+import types
+import sys
+import pytest
+
+from optional_import import optional_import
+
+
+def test_optional_import_present(monkeypatch):
+    fake = types.ModuleType("fakepkg")
+    fake.foo = lambda: "bar"
+    monkeypatch.setitem(sys.modules, "fakepkg", fake)
+    func = optional_import("fakepkg", "foo")
+    assert func() == "bar"
+
+
+def test_optional_import_missing_attr():
+    func = optional_import("fake_missing_mod", "foo")
+    with pytest.raises(ImportError):
+        func()
+
+
+def test_optional_import_module_missing():
+    mod = optional_import("another_missing_pkg")
+    with pytest.raises(ImportError):
+        mod.some_attr

--- a/ui.py
+++ b/ui.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import networkx as nx
-import streamlit as st
+from optional_import import optional_import
+
+st = optional_import("streamlit")
 from streamlit_helpers import (
     alert,
     header,
@@ -18,23 +20,15 @@ from streamlit_helpers import (
     apply_theme,
 )
 
-try:
-    import plotly.graph_objects as go
-except Exception:  # pragma: no cover - optional dependency
-    go = None
-
-try:
-    from pyvis.network import Network
-except Exception:  # pragma: no cover - optional dependency
-    Network = None
+go = optional_import("plotly.graph_objects")
+Network = optional_import("pyvis.network", "Network")
 
 from network.network_coordination_detector import build_validation_graph
 from validation_integrity_pipeline import analyze_validation_integrity
 
-try:
-    from validator_reputation_tracker import update_validator_reputations
-except Exception:  # pragma: no cover - optional dependency
-    update_validator_reputations = None
+update_validator_reputations = optional_import(
+    "validator_reputation_tracker", "update_validator_reputations"
+)
 
 from typing import Any, cast
 
@@ -223,7 +217,7 @@ def run_analysis(validations, *, layout: str = "force"):
             except Exception as exc:  # pragma: no cover - optional
                 logger.warning(f"Reputation calc failed: {exc}")
 
-        if go is not None:
+        if go:
             edge_x = []
             edge_y = []
             for u, v in G.edges():
@@ -285,7 +279,7 @@ def run_analysis(validations, *, layout: str = "force"):
                 )
             except Exception as exc:  # pragma: no cover - optional
                 logger.warning(f"Image export failed: {exc}")
-        elif Network is not None:
+        elif Network:
             net = Network(height="450px", width="100%")
             max_rep = max(reputations.values()) if reputations else 1.0
             for u, v, w in edges:


### PR DESCRIPTION
## Summary
- factor out `optional_import()` helper
- refactor UI and coordination code to use centralized optional imports
- provide Streamlit-safe helpers that degrade gracefully
- add tests covering optional import logic
- adjust stubs for missing types in tests

## Testing
- `pytest tests/test_optional_import.py -q`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post')*

------
https://chatgpt.com/codex/tasks/task_e_68873df470c48320b2e9b379e666cb92