### PR TITLE
Update frontend module paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ python setup_env.py
 # The NiceGUI web interface now lives in `transcendental_resonance_frontend/`.
 # References to the old `web_ui` directory continue to work but will emit a
 # warning.
+# Launch the frontend directly with
+# ```bash
+# python -m transcendental_resonance_frontend
+# ```
+# Or explore the demo data using
+# ```bash
+# python -m transcendental_resonance_frontend.demo
+# ```
 
 # optional: launch the Streamlit UI
 # python setup_env.py --launch-ui

--- a/transcendental_resonance_frontend/__main__.py
+++ b/transcendental_resonance_frontend/__main__.py
@@ -1,0 +1,4 @@
+"""Entry point for ``python -m transcendental_resonance_frontend``."""
+
+# Importing ``main`` starts the NiceGUI application.
+from .src import main  # noqa: F401

--- a/web_ui/__main__.py
+++ b/web_ui/__main__.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for running ``web_ui`` as a module."""
+
+import warnings
+from runpy import run_module
+
+warnings.warn(
+    "The 'web_ui' package has been renamed to 'transcendental_resonance_frontend'.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+run_module("transcendental_resonance_frontend", run_name="__main__")


### PR DESCRIPTION
## Summary
- add `__main__` entry points for the new frontend and legacy package
- document how to run the frontend directly

## Testing
- `mypy`
- `pytest -q` *(fails: sqlalchemy errors)*
- `streamlit run ui.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_6887829f9be483209a44165f98866b4c