### PR TITLE
Standardize Streamlit port

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,4 +1,4 @@
 [server]
 headless = true
 enableCORS = false
-port = 8501
+port = 8888

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Implemented seasonal quest toggle and milestone CLI.
 - Created moderation helpers for profanity and consent.
 - Added resonance music stub and summary route.
+- Standardized Streamlit default port to **8888**.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ directly as that bypasses Streamlit's runtime.
 Exporting plots as static images requires the `kaleido` package. Install it
 using `pip install -r requirements.txt` if it isn't already available.
 
-Open [http://localhost:8501](http://localhost:8501) in your browser to interact with the demo. Use the **Reset to Demo** button below the editor to reload `sample_validations.json` at any time.
+Open [http://localhost:8888](http://localhost:8888) in your browser to interact with the demo. Use the **Reset to Demo** button below the editor to reload `sample_validations.json` at any time.
 
 `ui.py` reads configuration from `st.secrets` when running under Streamlit. If
 the secrets dictionary is unavailable (such as during local development), the


### PR DESCRIPTION
## Summary
- set Streamlit port to 8888 in config
- update README to open the demo on the same port
- document the port change in the changelog

## Testing
- `pytest -q` *(fails: AttributeError `'async_generator' object has no attribute 'post'` and others)*

------
https://chatgpt.com/codex/tasks/task_e_68879a1df0188320be77f500d13335da