### PR TITLE
Update docs for new frontend path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ python setup_env.py
 # optional: build the Transcendental Resonance frontend
 # python setup_env.py --build-ui
 # The NiceGUI web interface now lives in `transcendental_resonance_frontend/`.
-# References to the old `web_ui` directory continue to work but will emit a
-# warning.
+# A thin wrapper in `web_ui/__init__.py` remains for backward compatibility but
+# using `web_ui` is deprecated.
 
 # optional: launch the Streamlit UI
 # python setup_env.py --launch-ui

--- a/install/install_android.sh
+++ b/install/install_android.sh
@@ -10,8 +10,9 @@ fi
 cd superNova_2177
 pip install -r requirements.txt
 FRONTEND_DIR=transcendental_resonance_frontend
+# Legacy fallback for older clones
 if [ ! -d "$FRONTEND_DIR" ] && [ -d web_ui ]; then
-    echo "Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'" >&2
+    echo "Using legacy 'web_ui' directory (deprecated)" >&2
     FRONTEND_DIR=web_ui
 fi
 if [ -d "$FRONTEND_DIR" ]; then

--- a/install/install_desktop.bat
+++ b/install/install_desktop.bat
@@ -4,8 +4,9 @@ call venv\Scripts\activate
 pip install --upgrade pip
 pip install -r requirements.txt
 set FRONTEND_DIR=transcendental_resonance_frontend
+rem Legacy fallback for older clones
 if not exist %FRONTEND_DIR% if exist web_ui (
-    echo Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'
+    echo Using legacy 'web_ui' directory (deprecated)
     set FRONTEND_DIR=web_ui
 )
 if exist %FRONTEND_DIR% (

--- a/install/install_desktop.sh
+++ b/install/install_desktop.sh
@@ -11,8 +11,9 @@ source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 FRONTEND_DIR=transcendental_resonance_frontend
+# Legacy fallback for older clones
 if [ ! -d "$FRONTEND_DIR" ] && [ -d web_ui ]; then
-    echo "Warning: 'web_ui' has been renamed to 'transcendental_resonance_frontend'" >&2
+    echo "Using legacy 'web_ui' directory (deprecated)" >&2
     FRONTEND_DIR=web_ui
 fi
 if [ -d "$FRONTEND_DIR" ]; then


### PR DESCRIPTION
## Summary
- mention the new `transcendental_resonance_frontend` folder in the README
- mark the fallback logic in install scripts as legacy

## Testing
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post')*

------
https://chatgpt.com/codex/tasks/task_e_68879a1f788c8320acc739d4702b57f7