### PR TITLE
Fix patch monitor git detection

### DIFF
--- a/scripts/patch_monitor_hook.py
+++ b/scripts/patch_monitor_hook.py
@@ -1,18 +1,23 @@
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
+from shutil import which
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from governance.patch_monitor import check_patch_compliance  # noqa: E402
 
 
 def main() -> int:
+    git_cmd = which("git")
+    if git_cmd is None:
+        print("git executable not found; install git with `apt install git`")
+        return 1
     try:
         diff = subprocess.check_output(  # nosec B607,B603
-            ["git", "diff", "--cached"], text=True
+            [git_cmd, "diff", "--cached"], text=True
         )
     except FileNotFoundError:
-        print("git executable not found")
+        print("git executable not found; install git with `apt install git`")
         return 1
     except subprocess.CalledProcessError as e:
         print(f"Failed to generate diff: {e}")

--- a/tests/test_patch_monitor_hook_script.py
+++ b/tests/test_patch_monitor_hook_script.py
@@ -6,20 +6,17 @@ from scripts import patch_monitor_hook
 
 
 def test_main_git_missing(monkeypatch, capsys):
-    monkeypatch.setattr(
-        patch_monitor_hook.subprocess,
-        "check_output",
-        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
-    )
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: None)
     assert patch_monitor_hook.main() == 1
     out = capsys.readouterr().out.strip()
-    assert "git executable not found" in out
+    assert "git executable not found; install git with `apt install git`" in out
 
 
 def test_main_git_error(monkeypatch, capsys):
     def fake_check_output(cmd, text=True):
         raise subprocess.CalledProcessError(1, cmd)
 
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
     monkeypatch.setattr(
         patch_monitor_hook.subprocess, "check_output", fake_check_output
     )
@@ -29,6 +26,7 @@ def test_main_git_error(monkeypatch, capsys):
 
 
 def test_main_success(monkeypatch):
+    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
     monkeypatch.setattr(
         patch_monitor_hook.subprocess, "check_output", lambda *a, **k: "diff"
     )


### PR DESCRIPTION
## Summary
- improve git executable detection in `patch_monitor_hook`
- update tests for new error message

## Testing
- `pytest tests/test_patch_monitor_hook_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68879a32c8288320b53a104a233b5944