### PR TITLE
Align Streamlit port usage to 8501

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          streamlit run ui.py --server.headless true &
+          streamlit run ui.py --server.headless true --server.port 8501 &
           for i in {1..30}; do
             if curl -f http://localhost:8501 >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          streamlit run ui.py --server.headless true &
+          streamlit run ui.py --server.headless true --server.port 8501 &
           for i in {1..30}; do
             if curl -f http://localhost:8501 >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
    # python setup_env.py --run-app    # launch API after install
    # python setup_env.py --locked     # install from requirements.lock
     # python setup_env.py --build-ui   # build Transcendental Resonance frontend assets
-    # python setup_env.py --launch-ui  # run the Streamlit UI on port 8888
+    # python setup_env.py --launch-ui  # run the Streamlit UI on port 8501
    ```
   You can also let `install.py` choose the appropriate installer for your
   platform:

--- a/setup_env.py
+++ b/setup_env.py
@@ -66,7 +66,7 @@ def run_ui() -> None:
             'run',
             'ui.py',
             '--server.port',
-            '8888',
+            '8501',
         ])
     except subprocess.CalledProcessError as exc:
         logging.error('Failed to launch the Streamlit UI: %s', exc)


### PR DESCRIPTION
## Summary
- default to port 8501 for `run_ui`
- update docs about Streamlit default port
- ensure CI workflows start Streamlit on port 8501

## Testing
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post')*
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68879a34cc2c8320a4fac481f6dbb0b9