### PR TITLE
Fix git detection in patch_monitor_hook

### DIFF
--- a/scripts/patch_monitor_hook.py
+++ b/scripts/patch_monitor_hook.py
@@ -1,23 +1,24 @@
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
-from shutil import which
+import shutil
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from governance.patch_monitor import check_patch_compliance  # noqa: E402
 
 
 def main() -> int:
-    git_cmd = which("git")
+    git_cmd = shutil.which("git")
     if git_cmd is None:
-        print("git executable not found; install git with `apt install git`")
+        print("git executable not found; install git with 'apt install git'")
         return 1
     try:
         diff = subprocess.check_output(  # nosec B607,B603
-            [git_cmd, "diff", "--cached"], text=True
+            [git_cmd, "diff", "--cached"],
+            text=True,
         )
-    except FileNotFoundError:
-        print("git executable not found; install git with `apt install git`")
+    except FileNotFoundError as e:
+        print(f"Failed to run git diff: {e}")
         return 1
     except subprocess.CalledProcessError as e:
         print(f"Failed to generate diff: {e}")

--- a/tests/test_patch_monitor_hook_script.py
+++ b/tests/test_patch_monitor_hook_script.py
@@ -6,19 +6,19 @@ from scripts import patch_monitor_hook
 
 
 def test_main_git_missing(monkeypatch, capsys):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: None)
+    monkeypatch.setattr(patch_monitor_hook.shutil, "which", lambda cmd: None)
     assert patch_monitor_hook.main() == 1
     out = capsys.readouterr().out.strip()
-    assert "git executable not found; install git with `apt install git`" in out
+    assert "git executable not found; install git with 'apt install git'" in out
 
 
 def test_main_git_error(monkeypatch, capsys):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
+    monkeypatch.setattr(patch_monitor_hook.shutil, "which", lambda cmd: "/git")
 
     def fake_check_output(cmd, text=True):
         raise subprocess.CalledProcessError(1, cmd)
 
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
+    monkeypatch.setattr(patch_monitor_hook.shutil, "which", lambda cmd: "/git")
     monkeypatch.setattr(
         patch_monitor_hook.subprocess, "check_output", fake_check_output
     )
@@ -28,7 +28,7 @@ def test_main_git_error(monkeypatch, capsys):
 
 
 def test_main_success(monkeypatch):
-    monkeypatch.setattr(patch_monitor_hook, "which", lambda cmd: "/git")
+    monkeypatch.setattr(patch_monitor_hook.shutil, "which", lambda cmd: "/git")
     monkeypatch.setattr(
         patch_monitor_hook.subprocess, "check_output", lambda *a, **k: "diff"
     )


### PR DESCRIPTION
## Summary
- update `patch_monitor_hook` script to resolve git path with `shutil.which`
- handle missing git executable earlier and improve error message
- update tests for the new logic

## Testing
- `pytest -q` *(fails: AttributeError in many unrelated tests)*
- `pytest tests/test_patch_monitor_hook_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879c482e988320b73e016f47b36c9c