### PR TITLE
Improve Streamlit smoke test

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -44,8 +44,8 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          streamlit run ui.py --server.headless true --server.port 8501 &
-          for i in {1..30}; do
+          streamlit run ui.py --server.headless true --server.port 8501 >streamlit.log 2>&1 &
+          for i in {1..20}; do
             if curl -f http://localhost:8501 >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"
               break
@@ -59,3 +59,9 @@ jobs:
           fi
           curl -f http://localhost:8501
           pkill streamlit
+      - name: Print Streamlit logs on failure
+        if: failure()
+        run: |
+          echo "::group::Streamlit logs"
+          cat streamlit.log || true
+          echo "::endgroup::"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,3 +70,15 @@ The `vote_registry.py` module is under active development. Planned tasks include
 - OAuth or wallet-based identity linking for validators.
 - Public frontend pages showing vote timelines per species.
 - Real-time consensus graphs across divergent forks.
+
+## Troubleshooting
+
+If the Streamlit UI fails to start when running tests or the smoke test in the
+CI pipeline, inspect `streamlit.log` for errors and confirm that port `8501` is
+free. You can terminate any leftover processes with:
+
+```bash
+pkill streamlit || true
+```
+
+Rerun the tests after addressing the issue.


### PR DESCRIPTION
## Summary
- capture Streamlit output in `pr-tests.yml`
- shorten Streamlit smoke test timeout
- emit logs if the smoke test fails
- document troubleshooting tips in `DEVELOPMENT.md`

## Testing
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post')*

------
https://chatgpt.com/codex/tasks/task_e_68879c62c7888320b886c1b509fe0754