### PR TITLE
Add message hub unsubscribe support

### DIFF
--- a/protocols/utils/messaging.py
+++ b/protocols/utils/messaging.py
@@ -33,8 +33,15 @@ class MessageHub:
         self.subscribers[topic].append(handler)
 
     def unsubscribe(self, topic: str, handler: Callable[[Message], None]) -> None:
-        if handler in self.subscribers.get(topic, []):
-            self.subscribers[topic].remove(handler)
+        """Remove ``handler`` for ``topic`` if present."""
+        handlers = self.subscribers.get(topic)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            # handler wasn't subscribed
+            pass
 
     def get_messages(self, topic: str | None = None) -> List[Message]:
         if topic:

--- a/tests/protocols/test_message_hub.py
+++ b/tests/protocols/test_message_hub.py
@@ -46,6 +46,26 @@ def test_unsubscribe_stops_callbacks():
     assert received[0].data == {"n": 1}  # nosec B101
 
 
+def test_unsubscribe_missing_handler_is_noop():
+    """Unsubscribing a non-existent handler should not raise or alter state."""
+    hub = MessageHub()
+    received = []
+
+    def handler(msg: Message) -> None:
+        received.append(msg)
+
+    # Unsubscribe before subscribing
+    hub.unsubscribe("task", handler)
+    hub.subscribe("task", handler)
+    hub.unsubscribe("task", handler)
+
+    # Second unsubscribe should be a no-op
+    hub.unsubscribe("task", handler)
+    hub.publish("task", {"n": 1})
+
+    assert len(received) == 0  # nosec B101
+
+
 def test_get_messages_history_and_filtering():
     hub = MessageHub()
     hub.publish("a", {"n": 1})


### PR DESCRIPTION
## Summary
- remove handlers with `MessageHub.unsubscribe`
- expand message hub tests for unsubscribing

## Testing
- `pre-commit run --files protocols/utils/messaging.py tests/protocols/test_message_hub.py`
- `pytest tests/protocols/test_message_hub.py::test_publish_invokes_callbacks tests/protocols/test_message_hub.py::test_unsubscribe_stops_callbacks tests/protocols/test_message_hub.py::test_unsubscribe_missing_handler_is_noop tests/protocols/test_message_hub.py::test_get_messages_history_and_filtering -q`

------
https://chatgpt.com/codex/tasks/task_e_68879ccfeebc8320b579ab9b8847d77f