### PR TITLE
Add duplicate detection to CrossUniverseBridgeAgent

### DIFF
--- a/protocols/agents/cross_universe_bridge_agent.py
+++ b/protocols/agents/cross_universe_bridge_agent.py
@@ -43,6 +43,10 @@ class CrossUniverseBridgeAgent(InternalAgentProtocol):
         if self.llm_backend:
             self.llm_backend(f"verify {proof}")
 
+        # avoid duplicate records for the same coin_id
+        if any(r["coin_id"] == coin_id for r in self._records):
+            return {"valid": False, "duplicate": True}
+
         entry = {
             "coin_id": coin_id,
             "source_universe": src_universe,

--- a/tests/protocols/test_cross_universe_bridge_agent.py
+++ b/tests/protocols/test_cross_universe_bridge_agent.py
@@ -49,3 +49,23 @@ def test_process_event_register_and_fetch():
     prov = agent.process_event({"event": "GET_PROVENANCE", "payload": {"coin_id": "c1"}})
     assert prov == [payload]
 
+
+def test_duplicate_registration_rejected():
+    agent = CrossUniverseBridgeAgent()
+    payload = {
+        "coin_id": "dup",
+        "source_universe": "U9",
+        "source_coin": "s9",
+        "proof": "p9",
+    }
+
+    first = agent.register_bridge(payload)
+    assert first == {"valid": True}
+
+    second = agent.register_bridge(payload)
+    assert second == {"valid": False, "duplicate": True}
+
+    # provenance should still only contain the original record
+    prov = agent.get_provenance({"coin_id": "dup"})
+    assert prov == [payload]
+


### PR DESCRIPTION
## Summary
- guard against duplicate coin_id entries when registering bridges
- test that duplicates are rejected

## Testing
- `pytest tests/protocols/test_cross_universe_bridge_agent.py::test_duplicate_registration_rejected -q`
- `pytest -q` *(fails: test_app.py, async_fallback_plugin, audit_bridge, federation_cli, db tests, orm_consistency, prediction_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68879cd25b408320ad47cbd56446f6e6