### PR TITLE
Add AI API packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ dependencies = [
     "streamlit",
     "asyncpg",
     "email-validator",
-    "streamlit-ace"
+    "streamlit-ace",
+    "openai",
+    "anthropic",
+    "google-generativeai"
 ]
 
 [project.scripts]

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,5 +1,6 @@
 altair==5.5.0
 annotated-types==0.7.0
+anthropic==0.59.0
 anyio==4.9.0
 asyncpg==0.30.0
 attrs==25.3.0
@@ -24,6 +25,13 @@ fonttools==4.59.0
 fsspec==2025.7.0
 gitdb==4.0.12
 GitPython==3.1.45
+google-ai-generativelanguage==0.6.15
+google-api-core==2.25.1
+google-api-python-client==2.177.0
+google-auth==2.40.3
+google-auth-httplib2==0.2.0
+google-generativeai==0.8.5
+googleapis-common-protos==1.70.0
 greenlet==3.2.3
 h11==0.16.0
 hf-xet==1.1.5
@@ -62,6 +70,7 @@ nvidia-cusparselt-cu12==0.6.3
 nvidia-nccl-cu12==2.26.2
 nvidia-nvjitlink-cu12==12.6.85
 nvidia-nvtx-cu12==12.6.77
+openai==1.97.1
 packaging==25.0
 pandas==2.3.1
 passlib==1.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,6 @@ email-validator
 httpx==0.27.0
 streamlit-ace
 kaleido
+openai
+anthropic
+google-generativeai


### PR DESCRIPTION
## Summary
- add `openai`, `anthropic`, and `google-generativeai` to default requirements
- include same AI packages in `pyproject.toml`
- lock versions of new dependencies in `requirements.lock`

## Testing
- `make test` *(fails: AttributeError in async generator)*

------
https://chatgpt.com/codex/tasks/task_e_68879cf9cc4c8320b84f68de165c1e75