### PR TITLE
Add llm response parser utility

### DIFF
--- a/protocols/utils/llm_response_parser.py
+++ b/protocols/utils/llm_response_parser.py
@@ -1,0 +1,17 @@
+"""LLM response parser utility."""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["parse_llm_response"]
+
+
+def parse_llm_response(text: str) -> dict | str:
+    """Return parsed JSON if ``text`` is valid JSON, else return original string."""
+    try:
+        return json.loads(text)
+    except Exception:
+        logger.warning("Failed to parse LLM response as JSON: %s", text)
+        return text

--- a/tests/protocols/test_llm_response_parser.py
+++ b/tests/protocols/test_llm_response_parser.py
@@ -1,0 +1,15 @@
+import logging
+from protocols.utils.llm_response_parser import parse_llm_response
+
+
+def test_parse_llm_response_json():
+    text = '{"foo": 1}'
+    assert parse_llm_response(text) == {"foo": 1}
+
+
+def test_parse_llm_response_invalid_returns_text_and_logs(caplog):
+    text = '{foo}'
+    with caplog.at_level(logging.WARNING):
+        result = parse_llm_response(text)
+    assert result == text
+    assert any('Failed to parse LLM response' in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `parse_llm_response` helper for decoding LLM JSON
- unit tests for the helper

## Testing
- `pytest tests/protocols/test_llm_response_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879cfc73a08320b0ea30bf26117ffd