### PR TITLE
Add helper functions for graph exports

### DIFF
--- a/tests/test_streamlit_helpers.py
+++ b/tests/test_streamlit_helpers.py
@@ -21,3 +21,25 @@ def test_alert_handles_missing_escape(monkeypatch):
     helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
     helpers.alert("hello")
     assert calls
+
+
+def test_graph_to_graphml_buffer(monkeypatch):
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+    import networkx as nx
+
+    g = nx.DiGraph()
+    g.add_edge("a", "b", weight=1.0)
+
+    buf = helpers.graph_to_graphml_buffer(g)
+    assert b"<graphml" in buf.getvalue()
+
+
+def test_figure_to_png_buffer():
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+
+    class DummyFig:
+        def write_image(self, fh, format="png"):
+            fh.write(b"img")
+
+    buf = helpers.figure_to_png_buffer(DummyFig())
+    assert buf.getvalue() == b"img"


### PR DESCRIPTION
## Summary
- create utility functions to build GraphML and PNG buffers
- use these helpers in the UI
- avoid disk temp file by using `StringIO`
- test helper functions

## Testing
- `mypy`
- `make test` *(fails: sqlalchemy operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_68879a23e070832091dc60d34a0a10f9