### PR TITLE
Refactor PyVis rendering

### DIFF
--- a/tests/test_ui_pyvis_helper.py
+++ b/tests/test_ui_pyvis_helper.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import types
+
+
+def load_ui(monkeypatch):
+    stub = types.ModuleType("streamlit")
+
+    def __getattr__(name):
+        if name == "secrets":
+            raise RuntimeError("no secrets")
+        return lambda *a, **k: None
+
+    stub.__getattr__ = __getattr__
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+
+    mpl = types.ModuleType("matplotlib")
+    plt = types.ModuleType("matplotlib.pyplot")
+    mpl.pyplot = plt
+    monkeypatch.setitem(sys.modules, "matplotlib", mpl)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", plt)
+
+    return importlib.reload(importlib.import_module("ui"))
+
+
+def test_render_pyvis_to_html(monkeypatch):
+    ui = load_ui(monkeypatch)
+
+    class DummyNetwork:
+        def __init__(self):
+            self.called = False
+        def generate_html(self, **kwargs):
+            self.called = True
+            return "<html><body>graph</body></html>"
+
+    net = DummyNetwork()
+    html = ui.render_pyvis_to_html(net)
+    assert html.startswith("<html")
+    assert net.called


### PR DESCRIPTION
## Summary
- refactor PyVis output in `ui.py` to use an in-memory buffer
- add `render_pyvis_to_html` helper
- use the helper for download and on-screen display
- add unit test covering the helper

## Testing
- `flake8 ui.py tests/test_ui_pyvis_helper.py`
- `pytest tests/test_ui_pyvis_helper.py -q`
- `pytest -q` *(fails: AttributeError in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68879c4b89888320a715fa64748b6dd5