### PR TITLE
Add network coordination analysis hook

### DIFF
--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict
 
 from frontend_bridge import register_route
@@ -9,6 +10,9 @@ from .network_coordination_detector import analyze_coordination_patterns
 
 # Exposed hook manager for external subscribers
 ui_hook_manager = HookManager()
+
+# Hook manager used for run_coordination_analysis
+hook_manager = HookManager()
 
 
 async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -37,3 +41,28 @@ async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str,
 
 # Register with the central frontend router
 register_route("coordination_analysis", trigger_coordination_analysis_ui)
+
+
+async def run_coordination_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run coordination analysis and emit a network_analysis hook."""
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a dict")
+
+    validations = payload.get("validations")
+    if not isinstance(validations, list):
+        raise ValueError("payload['validations'] must be a list")
+
+    result = analyze_coordination_patterns(validations)
+
+    minimal = {
+        "overall_risk_score": result.get("overall_risk_score", 0.0),
+        "flags": result.get("flags", []),
+        "clusters": result.get("coordination_clusters", []),
+    }
+
+    try:
+        hook_manager.fire_hooks("network_analysis", minimal)
+    except Exception:  # pragma: no cover - logging only
+        logging.exception("Failed to fire network_analysis hook")
+
+    return minimal

--- a/tests/test_network_ui_hook.py
+++ b/tests/test_network_ui_hook.py
@@ -1,0 +1,42 @@
+import pytest
+
+from network.ui_hook import run_coordination_analysis
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    def fire_hooks(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_run_coordination_analysis(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("network.ui_hook.hook_manager", dummy, raising=False)
+
+    payload = {
+        "validations": [
+            {
+                "validator_id": "v1",
+                "hypothesis_id": "h1",
+                "score": 0.9,
+                "timestamp": "2025-01-01T00:00:00Z",
+                "note": "ok",
+            }
+        ]
+    }
+
+    result = await run_coordination_analysis(payload)
+
+    assert "overall_risk_score" in result  # nosec B101
+    assert "flags" in result  # nosec B101
+    assert "clusters" in result  # nosec B101
+    assert dummy.events == [("network_analysis", (result,), {})]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_run_coordination_analysis_invalid():
+    with pytest.raises(ValueError):
+        await run_coordination_analysis({"invalid": 1})


### PR DESCRIPTION
## Summary
- implement `run_coordination_analysis` in `network/ui_hook.py`
- log analysis via hook manager
- add tests for the new helper

## Testing
- `pre-commit run --files network/ui_hook.py tests/test_network_ui_hook.py`
- `pytest tests/test_network_ui_hook.py tests/ui_hooks/test_coordination.py`

------
https://chatgpt.com/codex/tasks/task_e_68879c9c300c83208b888c9422d8bcb9