### PR TITLE
Add introspection audit UI hook

### DIFF
--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from sqlalchemy.orm import Session
+
+from hook_manager import HookManager
+
+from .introspection_pipeline import run_full_audit
+
+# Exposed hook manager so other modules can subscribe to audit events
+ui_hook_manager = HookManager()
+
+
+async def trigger_full_audit_ui(payload: Dict[str, Any], db: Session) -> Dict[str, Any]:
+    """Run a full introspection audit triggered from the UI.
+
+    Parameters
+    ----------
+    payload : dict
+        Dictionary containing ``"hypothesis_id"`` key specifying the hypothesis to audit.
+    db : Session
+        Database session used during the audit.
+
+    Returns
+    -------
+    dict
+        Structured audit bundle produced by :func:`run_full_audit`.
+    """
+    hypothesis_id = payload["hypothesis_id"]  # raises KeyError if missing
+
+    audit_bundle = run_full_audit(hypothesis_id, db)
+
+    # Allow external listeners to process the audit result asynchronously
+    await ui_hook_manager.trigger("full_audit_completed", audit_bundle)
+
+    return audit_bundle

--- a/tests/ui_hooks/test_introspection.py
+++ b/tests/ui_hooks/test_introspection.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import MagicMock
+
+from introspection.ui_hook import trigger_full_audit_ui
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_full_audit_ui_runs_pipeline_and_emits_event(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("introspection.ui_hook.ui_hook_manager", dummy, raising=False)
+
+    calls = {}
+
+    def fake_run(hid, db):
+        calls["run"] = (hid, db)
+        return {"bundle": True}
+
+    monkeypatch.setattr("introspection.ui_hook.run_full_audit", fake_run)
+
+    db = MagicMock()
+    payload = {"hypothesis_id": "H1"}
+    result = await trigger_full_audit_ui(payload, db)
+
+    assert result == {"bundle": True}
+    assert calls["run"] == ("H1", db)
+    assert dummy.events == [("full_audit_completed", ({"bundle": True},), {})]
+
+
+@pytest.mark.asyncio
+async def test_full_audit_ui_requires_id(monkeypatch):
+    db = MagicMock()
+    with pytest.raises(KeyError):
+        await trigger_full_audit_ui({}, db)


### PR DESCRIPTION
## Summary
- add `trigger_full_audit_ui` helper for introspection audits
- emit `full_audit_completed` event via HookManager
- test the new UI hook logic

## Testing
- `pytest -q tests/ui_hooks/test_introspection.py`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68879c9e6e7483209aedc3a7f8a5363c