### PR TITLE
Add frontend action dispatch bridge

### DIFF
--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from audit_bridge import log_hypothesis_with_trace, attach_trace_to_logentry
 from hook_manager import HookManager
+from frontend_bridge import register_action
 
 
 logger = logging.getLogger(__name__)
@@ -55,4 +56,9 @@ async def attach_trace_ui(payload: Dict[str, Any], db: Session) -> None:
         "audit_log",
         {"action": "attach_trace", "log_id": int(payload["log_id"])},
     )
+
+
+# Register actions with the frontend bridge
+register_action("audit.log", log_hypothesis_ui)
+register_action("audit.attach_trace", attach_trace_ui)
 

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from frontend_bridge import register_route
+from frontend_bridge import register_action
 from hook_manager import HookManager
 
 from .network_coordination_detector import analyze_coordination_patterns
@@ -36,4 +36,4 @@ async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str,
 
 
 # Register with the central frontend router
-register_route("coordination_analysis", trigger_coordination_analysis_ui)
+register_action("network.run", trigger_coordination_analysis_ui)

--- a/tests/ui_hooks/test_coordination.py
+++ b/tests/ui_hooks/test_coordination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from frontend_bridge import dispatch_route
+from frontend_bridge import dispatch
 from network.ui_hook import ui_hook_manager
 
 
@@ -25,7 +25,7 @@ async def test_coordination_analysis_via_router():
         ]
     }
 
-    result = await dispatch_route("coordination_analysis", payload)
+    result = await dispatch("network.run", payload)
 
     assert "overall_risk_score" in result  # nosec B101
     assert "graph" in result  # nosec B101


### PR DESCRIPTION
## Summary
- implement centralized async action registry in `frontend_bridge.py`
- register network and audit UI hooks with new bridge
- expose `dispatch` for routing actions
- update coordination hook test

## Testing
- `pytest tests/ui_hooks/test_coordination.py tests/test_audit_ui_hook.py -q`
- `pytest -q` *(fails: KeyError 'access_token' and other SQLAlchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68879ca1d008832095d255fc0934664b