### PR TITLE
Add async UI bridge tests

### DIFF
--- a/tests/ui_hooks/test_audit_hooks.py
+++ b/tests/ui_hooks/test_audit_hooks.py
@@ -1,0 +1,55 @@
+import json
+import pytest
+
+from audit.ui_hook import log_hypothesis_ui, attach_trace_ui
+from db_models import LogEntry, SystemState
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_log_hypothesis_ui(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    payload = {"hypothesis_text": "foo", "causal_node_ids": ["a", "b"]}
+    key = await log_hypothesis_ui(payload, test_db)
+
+    state = test_db.query(SystemState).filter(SystemState.key == key).first()
+    assert state is not None
+    assert dummy.events == [
+        ("audit_log", ({"action": "log_hypothesis", "key": key},), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_ui(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    log = LogEntry(
+        timestamp=__import__("datetime").datetime.utcnow(),
+        event_type="test",
+        payload=json.dumps({"foo": "bar"}),
+        previous_hash="p",
+        current_hash="c",
+    )
+    test_db.add(log)
+    test_db.commit()
+
+    payload = {"log_id": log.id, "causal_node_ids": ["x"], "summary": "trace"}
+    await attach_trace_ui(payload, test_db)
+
+    refreshed = test_db.query(LogEntry).filter(LogEntry.id == log.id).first()
+    data = json.loads(refreshed.payload)
+    assert data["causal_node_ids"] == ["x"]
+    assert data["causal_commentary"] == "trace"
+    assert dummy.events == [
+        ("audit_log", ({"action": "attach_trace", "log_id": log.id},), {})
+    ]

--- a/tests/ui_hooks/test_network_ui_bridge.py
+++ b/tests/ui_hooks/test_network_ui_bridge.py
@@ -1,0 +1,33 @@
+import pytest
+
+from network import ui_hook as net_ui_hook
+
+
+@pytest.mark.asyncio
+async def test_trigger_coordination_analysis_ui(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    net_ui_hook.ui_hook_manager.register_hook("coordination_analysis_run", listener)
+
+    called = {}
+
+    def fake_analyze(validations):
+        called["validations"] = validations
+        return {
+            "overall_risk_score": 0.5,
+            "graph": {"nodes": [], "edges": []},
+            "flags": ["ok"],
+        }
+
+    monkeypatch.setattr(net_ui_hook, "analyze_coordination_patterns", fake_analyze)
+
+    payload = {"validations": [{"validator_id": "v", "hypothesis_id": "h"}]}
+
+    result = await net_ui_hook.trigger_coordination_analysis_ui(payload)
+
+    assert result == {"overall_risk_score": 0.5, "graph": {"nodes": [], "edges": []}}
+    assert events == [result]
+    assert called["validations"] == payload["validations"]


### PR DESCRIPTION
## Summary
- add new async bridge tests under `tests/ui_hooks/`
- test network coordination bridge directly
- test audit bridge hooks using the temporary `Session`

## Testing
- `pytest tests/ui_hooks -q`

------
https://chatgpt.com/codex/tasks/task_e_68879ca3b4b48320a5852cff716b5869