### PR TITLE
Add hypothesis UI hooks and tests

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -23,3 +23,12 @@ async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(result, Awaitable):
         result = await result
     return result
+
+# Built-in hypothesis-related routes
+from hypothesis.ui_hook import (
+    rank_hypotheses_by_confidence_ui,
+    detect_conflicting_hypotheses_ui,
+)
+
+register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
+register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)

--- a/hypothesis/ui_hook.py
+++ b/hypothesis/ui_hook.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from db_models import SessionLocal
+from hook_manager import HookManager
+from hypothesis_reasoner import (
+    rank_hypotheses_by_confidence as _rank_hypotheses_by_confidence,
+    detect_conflicting_hypotheses as _detect_conflicting_hypotheses,
+)
+
+ui_hook_manager = HookManager()
+
+
+async def rank_hypotheses_by_confidence_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Rank hypotheses using the reasoning layer and emit an event."""
+    top_k = int(payload.get("top_k", 5))
+    db = SessionLocal()
+    try:
+        ranking = _rank_hypotheses_by_confidence(db, top_k=top_k)
+    finally:
+        db.close()
+    await ui_hook_manager.trigger("hypothesis_ranking", ranking)
+    return {"ranking": ranking}
+
+
+async def detect_conflicting_hypotheses_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Detect conflicting hypotheses and emit an event."""
+    db = SessionLocal()
+    try:
+        conflicts = _detect_conflicting_hypotheses(db)
+    finally:
+        db.close()
+    await ui_hook_manager.trigger("hypothesis_conflicts", conflicts)
+    return {"conflicts": conflicts}

--- a/tests/ui_hooks/test_hypothesis.py
+++ b/tests/ui_hooks/test_hypothesis.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+
+from frontend_bridge import dispatch_route
+from hypothesis.ui_hook import ui_hook_manager
+from hypothesis_tracker import (
+    register_hypothesis,
+    update_hypothesis_score,
+    _get_hypothesis_record,
+)
+from tests.conftest import _setup_sqlite
+from sqlalchemy import create_engine
+from db_models import SystemState
+import hypothesis_reasoner
+
+
+@pytest.fixture
+def patched_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(create_engine, "__module__", "sqlalchemy.engine", raising=False)
+    engine, SessionLocal, teardown = _setup_sqlite(monkeypatch, tmp_path / "test.db")
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        teardown()
+
+
+@pytest.fixture(autouse=True)
+def config_patch(monkeypatch):
+    monkeypatch.setattr(hypothesis_reasoner, "CONFIG", type("C", (), {"TEXT_SIMILARITY_THRESHOLD": 0.7})())
+    yield
+
+
+def _sync_state(db, hyp_id):
+    record = _get_hypothesis_record(db, hyp_id)
+    if record is None:
+        return
+    record = dict(record)
+    record["hypothesis_id"] = record.pop("id")
+    db.add(SystemState(key=f"hypothesis_{hyp_id}", value=json.dumps(record)))
+    db.commit()
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_ui_routes(patched_db):
+    events = []
+
+    async def ranking_listener(data):
+        events.append(("rank", data))
+
+    async def conflict_listener(data):
+        events.append(("conflict", data))
+
+    ui_hook_manager.register_hook("hypothesis_ranking", ranking_listener)
+    ui_hook_manager.register_hook("hypothesis_conflicts", conflict_listener)
+
+    h1 = register_hypothesis("same text", patched_db)
+    h2 = register_hypothesis("same text", patched_db)
+    h3 = register_hypothesis("different text", patched_db)
+
+    update_hypothesis_score(patched_db, h1, 0.9)
+    update_hypothesis_score(patched_db, h2, 0.1)
+    update_hypothesis_score(patched_db, h3, 0.5)
+
+    _sync_state(patched_db, h1)
+    _sync_state(patched_db, h2)
+    _sync_state(patched_db, h3)
+
+    ranking = await dispatch_route("rank_hypotheses_by_confidence", {"top_k": 2})
+    assert len(ranking["ranking"]) == 2
+    assert events[0] == ("rank", ranking["ranking"])
+
+    conflicts = await dispatch_route("detect_conflicting_hypotheses", {})
+    assert events[1] == ("conflict", conflicts["conflicts"])
+    assert any(set(pair) == {h1, h2} for pair in conflicts["conflicts"])


### PR DESCRIPTION
## Summary
- add new `hypothesis/ui_hook.py` for hypothesis-related UI callbacks
- register ranking and conflict detection routes in `frontend_bridge`
- test new UI hooks via dispatch through the router

## Testing
- `pytest tests/ui_hooks/test_hypothesis.py -q`
- `pytest -q` *(fails: 21 failed, 165 passed, 23 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68879ca981e88320b73642f8ab49fa6e