### PR TITLE
Add network coordination UI hook with routing and tests

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -23,3 +23,15 @@ async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(result, Awaitable):
         result = await result
     return result
+
+
+# Register network UI hooks
+from network.ui_hook import trigger_coordination_analysis
+
+
+async def _coordination_wrapper(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Adapter to run coordination analysis from a standard payload."""
+    return await trigger_coordination_analysis(payload.get("validations", []))
+
+
+register_route("coordination_analysis", _coordination_wrapper)

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -1,39 +1,27 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import List, Dict, Any
 
-from frontend_bridge import register_route
 from hook_manager import HookManager
-
 from .network_coordination_detector import analyze_coordination_patterns
 
-# Exposed hook manager for external subscribers
+# Hook manager allowing observers to react to coordination analysis events
 ui_hook_manager = HookManager()
 
 
-async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Run coordination analysis from UI payload.
+async def trigger_coordination_analysis(data: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Run ``analyze_coordination_patterns`` on ``data`` and emit a hook.
 
     Parameters
     ----------
-    payload : dict
-        JSON payload containing ``"validations"`` list.
+    data:
+        List of validation dictionaries passed from the UI layer.
 
     Returns
     -------
     dict
-        Minimal result with ``overall_risk_score`` and ``graph``.
+        The full coordination analysis result.
     """
-    validations = payload.get("validations", [])
-    result = analyze_coordination_patterns(validations)
-    minimal = {
-        "overall_risk_score": result.get("overall_risk_score", 0.0),
-        "graph": result.get("graph", {}),
-    }
-    # Emit event for observers
-    await ui_hook_manager.trigger("coordination_analysis_run", minimal)
-    return minimal
-
-
-# Register with the central frontend router
-register_route("coordination_analysis", trigger_coordination_analysis_ui)
+    result = analyze_coordination_patterns(data)
+    await ui_hook_manager.trigger("coordination_analysis_run", result)
+    return result

--- a/tests/ui_hooks/test_network.py
+++ b/tests/ui_hooks/test_network.py
@@ -1,0 +1,23 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+
+
+@pytest.mark.asyncio
+async def test_coordination_analysis_bridge_returns_keys():
+    payload = {
+        "validations": [
+            {
+                "validator_id": "v1",
+                "hypothesis_id": "h1",
+                "score": 0.9,
+                "timestamp": "2025-01-01T00:00:00Z",
+                "note": "ok",
+            }
+        ]
+    }
+
+    result = await dispatch_route("coordination_analysis", payload)
+
+    assert "overall_risk_score" in result  # nosec B101
+    assert "graph" in result  # nosec B101


### PR DESCRIPTION
## Summary
- implement `trigger_coordination_analysis` in `network/ui_hook.py`
- register the hook via `frontend_bridge.py`
- add `tests/ui_hooks/test_network.py` verifying router output

## Testing
- `pytest -q tests/ui_hooks/test_coordination.py tests/ui_hooks/test_network.py`
- `pytest -q tests/ui_hooks/test_network.py`

------
https://chatgpt.com/codex/tasks/task_e_68879cabccf88320b16b9c0000bede4f