### PR TITLE
Add CrossUniverseBridge UI router

### DIFF
--- a/protocols/ui_hook.py
+++ b/protocols/ui_hook.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+
+from protocols.agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
+
+# Exposed hook manager and agent instance
+bridge_hook_manager = HookManager()
+bridge_agent = CrossUniverseBridgeAgent()
+
+
+async def register_bridge_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and store cross-universe provenance via the UI."""
+    result = bridge_agent.register_bridge(payload)
+    await bridge_hook_manager.trigger("bridge_registered", result)
+    return result
+
+
+async def get_provenance_ui(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return provenance information for ``coin_id`` via the UI."""
+    result = bridge_agent.get_provenance(payload)
+    await bridge_hook_manager.trigger("provenance_returned", result)
+    return result
+
+
+# Register with the central frontend router
+register_route("cross_universe_register_bridge", register_bridge_ui)
+register_route("cross_universe_get_provenance", get_provenance_ui)

--- a/tests/ui_hooks/test_cross_universe_bridge.py
+++ b/tests/ui_hooks/test_cross_universe_bridge.py
@@ -1,0 +1,37 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from protocols.agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
+
+import protocols.ui_hook as ui_hook
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_cross_universe_routes(monkeypatch):
+    dummy = DummyHookManager()
+    agent = CrossUniverseBridgeAgent()
+    monkeypatch.setattr(ui_hook, "bridge_hook_manager", dummy, raising=False)
+    monkeypatch.setattr(ui_hook, "bridge_agent", agent, raising=False)
+
+    payload = {
+        "coin_id": "c123",
+        "source_universe": "U1",
+        "source_coin": "s456",
+        "proof": "p789",
+    }
+    result = await dispatch_route("cross_universe_register_bridge", payload)
+    assert result == {"valid": True}
+    assert agent.get_provenance({"coin_id": "c123"}) == [payload]
+    assert dummy.events == [("bridge_registered", ({"valid": True},), {})]
+
+    result2 = await dispatch_route("cross_universe_get_provenance", {"coin_id": "c123"})
+    assert result2 == [payload]
+    assert dummy.events[-1] == ("provenance_returned", ([payload],), {})


### PR DESCRIPTION
## Summary
- introduce `protocols/ui_hook.py` to expose CrossUniverseBridgeAgent
- register routes for registering bridge provenance and retrieving provenance
- unit tests covering router integration and agent state

## Testing
- `flake8 protocols/ui_hook.py tests/ui_hooks/test_cross_universe_bridge.py`
- `pytest tests/protocols/test_cross_universe_bridge_agent.py tests/ui_hooks/test_coordination.py tests/ui_hooks/test_cross_universe_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879cad78fc8320930ed6d6d47b6f4f