### PR TITLE
Implement frontend bridge dispatch

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -1,25 +1,50 @@
-"""Lightweight router for UI callbacks."""
+"""Aggregate UI hook modules and dispatch events to handlers."""
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Dict, Union
+from typing import Any, Awaitable, Callable, Dict, List, Union
+
+from hook_manager import HookManager
 
 Handler = Callable[[Dict[str, Any]], Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
 
-ROUTES: Dict[str, Handler] = {}
+# Central hook manager used to register all UI handlers
+hook_manager = HookManager()
 
 
 def register_route(name: str, func: Handler) -> None:
-    """Register a handler for ``name`` events."""
-    ROUTES[name] = func
+    """Register *func* as the handler for the given route ``name``."""
+    hook_manager.register_hook(name, func)
 
 
 async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Dispatch ``payload`` to the registered handler."""
-    if name not in ROUTES:
+    """Dispatch ``payload`` to the handler bound to ``name``."""
+    if name not in hook_manager.hooks:
         raise KeyError(name)
-    handler = ROUTES[name]
-    result = handler(payload)
-    if isinstance(result, Awaitable):
-        result = await result
-    return result
+    results: List[Dict[str, Any]] = await hook_manager.trigger(name, payload)
+    return results[0] if results else {}
+
+
+# Backwards compatible API
+dispatch = dispatch_route
+register = register_route
+
+
+def _load_builtin_hooks() -> None:
+    """Import builtin hook modules so their routes register."""
+    try:  # network hooks automatically register themselves
+        __import__("network.ui_hook")
+    except Exception:  # pragma: no cover - optional in minimal installs
+        pass
+
+    try:  # audit hooks need explicit registration
+        from audit.ui_hook import log_hypothesis_ui, attach_trace_ui
+
+        register_route("log_hypothesis", log_hypothesis_ui)
+        register_route("attach_trace", attach_trace_ui)
+    except Exception:  # pragma: no cover - optional dependency
+        pass
+
+
+_load_builtin_hooks()
+

--- a/tests/ui_hooks/test_frontend_bridge.py
+++ b/tests/ui_hooks/test_frontend_bridge.py
@@ -1,0 +1,81 @@
+import importlib
+import types
+
+import pytest
+
+import frontend_bridge
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+    def register_hook(self, name, func):
+        self.events.append(("register", name, func))
+
+
+@pytest.fixture(autouse=True)
+def reload_bridge():
+    """Reload ``frontend_bridge`` for isolation between tests."""
+    importlib.reload(frontend_bridge)
+    import network.ui_hook as nh
+    importlib.reload(nh)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_register_and_dispatch_custom():
+    calls = []
+
+    async def handler(payload):
+        calls.append(payload)
+        return {"ok": True}
+
+    frontend_bridge.register("custom", handler)
+
+    result = await frontend_bridge.dispatch("custom", {"a": 1})
+    assert result == {"ok": True}
+    assert calls == [{"a": 1}]
+
+
+@pytest.mark.asyncio
+async def test_coordination_route_via_bridge(monkeypatch):
+    import network.ui_hook as nh
+
+    # Patch analysis function to avoid heavy work
+    monkeypatch.setattr(
+        nh,
+        "analyze_coordination_patterns",
+        lambda _v: {"overall_risk_score": 0.5, "graph": {}},
+    )
+
+    dummy = DummyHookManager()
+    monkeypatch.setattr(nh, "ui_hook_manager", dummy, raising=False)
+
+    payload = {
+        "validations": [
+            {
+                "validator_id": "v1",
+                "hypothesis_id": "h1",
+                "score": 0.9,
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ]
+    }
+
+    result = await frontend_bridge.dispatch("coordination_analysis", payload)
+
+    assert result == {"overall_risk_score": 0.5, "graph": {}}
+    assert dummy.events == [
+        ("coordination_analysis_run", (result,), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unknown_route_raises():
+    with pytest.raises(KeyError):
+        await frontend_bridge.dispatch("missing", {})
+


### PR DESCRIPTION
## Summary
- implement new frontend bridge router using `HookManager`
- add dispatch alias and builtin hook imports
- provide tests for the dispatching logic

## Testing
- `pytest tests/ui_hooks/test_frontend_bridge.py -q`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post')*

------
https://chatgpt.com/codex/tasks/task_e_68879cae6fb88320a92d2eec1ffc47c4