### PR TITLE
Add unit tests for coordination and temporal agents

### DIFF
--- a/tests/protocols/test_coordination_sentinel_agent.py
+++ b/tests/protocols/test_coordination_sentinel_agent.py
@@ -1,19 +1,27 @@
+import importlib
+
+import network.network_coordination_detector as detector
 import protocols.agents.coordination_sentinel_agent as cs_module
 from protocols.agents.coordination_sentinel_agent import CoordinationSentinelAgent
 
 
-def test_inspect_validations_process_event(monkeypatch):
-    result_obj = {"flags": ["coordination"], "coordination_clusters": {"t": []}, "overall_risk_score": 0.5}
+def test_inspect_validations_sends_result(monkeypatch):
+    result_obj = {
+        "flags": ["coordination"],
+        "coordination_clusters": {"t": []},
+        "overall_risk_score": 0.5,
+    }
 
     def fake_analyze(vals):
         fake_analyze.calls = vals
         return result_obj
 
-    monkeypatch.setattr(cs_module, "analyze_coordination_patterns", fake_analyze)
+    monkeypatch.setattr(detector, "analyze_coordination_patterns", fake_analyze)
+    importlib.reload(cs_module)
 
-    agent = CoordinationSentinelAgent()
+    agent = cs_module.CoordinationSentinelAgent()
     payload = {"validations": [{"v": 1}]}
-    res = agent.process_event({"event": "VALIDATIONS", "payload": payload})
+    res = agent.inspect_validations(payload)
 
     assert res == result_obj
     assert agent.inbox[-1]["topic"] == "COORDINATION_RESULT"

--- a/tests/protocols/test_temporal_audit_agent.py
+++ b/tests/protocols/test_temporal_audit_agent.py
@@ -1,22 +1,46 @@
+import importlib
+
+import temporal_consistency_checker as tcc
 import protocols.agents.temporal_audit_agent as ta_module
 from protocols.agents.temporal_audit_agent import TemporalAuditAgent
 
 
-def test_audit_batch_process_event_sends_alert(monkeypatch):
+def test_audit_batch_alert_on_large_gap(monkeypatch):
     returned = {"flags": ["large_time_gap"], "detail": "x"}
 
     def fake_analyze(vals):
         fake_analyze.calls = vals
         return returned
 
-    monkeypatch.setattr(ta_module, "analyze_temporal_consistency", fake_analyze)
+    monkeypatch.setattr(tcc, "analyze_temporal_consistency", fake_analyze)
+    importlib.reload(ta_module)
 
-    agent = TemporalAuditAgent()
+    agent = ta_module.TemporalAuditAgent()
     payload = {"validations": [{"foo": "bar"}]}
-    result = agent.process_event({"event": "NEW_VALIDATION_BATCH", "payload": payload})
+    result = agent.audit_batch(payload)
 
     assert result == returned
     assert agent.inbox[-1]["topic"] == "TEMPORAL_ALERT"
-    assert agent.inbox[-1]["payload"]["flags"] == ["large_time_gap"]
+    assert set(agent.inbox[-1]["payload"]["flags"]) == {"large_time_gap"}
+    assert fake_analyze.calls == payload["validations"]
+
+
+def test_audit_batch_alert_on_disorder(monkeypatch):
+    returned = {"flags": ["chronological_disorder"], "detail": "x"}
+
+    def fake_analyze(vals):
+        fake_analyze.calls = vals
+        return returned
+
+    monkeypatch.setattr(tcc, "analyze_temporal_consistency", fake_analyze)
+    importlib.reload(ta_module)
+
+    agent = ta_module.TemporalAuditAgent()
+    payload = {"validations": [{"foo": "bar"}]}
+    result = agent.audit_batch(payload)
+
+    assert result == returned
+    assert agent.inbox[-1]["topic"] == "TEMPORAL_ALERT"
+    assert "chronological_disorder" in agent.inbox[-1]["payload"]["flags"]
     assert fake_analyze.calls == payload["validations"]
 


### PR DESCRIPTION
## Summary
- add tests for CoordinationSentinelAgent and TemporalAuditAgent
- mock analysis functions directly in their source modules
- verify alerts/results when expected flags are present

## Testing
- `pytest tests/protocols/test_coordination_sentinel_agent.py::test_inspect_validations_sends_result -q`
- `pytest tests/protocols/test_temporal_audit_agent.py -q`
- `pytest -q` *(fails: AttributeError in tests/test_app.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68879cc2274c8320af8a0c2645e3791a