### PR TITLE
Add timeout constant and handle ping timeouts

### DIFF
--- a/protocols/utils/remote.py
+++ b/protocols/utils/remote.py
@@ -1,8 +1,10 @@
 """Remote ping and handshake helpers."""
 import requests
 
+DEFAULT_TIMEOUT = 5.0
 
-def ping_agent(url: str, timeout: float = 5.0) -> bool:
+
+def ping_agent(url: str, timeout: float = DEFAULT_TIMEOUT) -> bool:
     """Return ``True`` if the remote agent responds within ``timeout`` seconds."""
 
     try:
@@ -12,7 +14,7 @@ def ping_agent(url: str, timeout: float = 5.0) -> bool:
         return False
 
 
-def handshake(agent_id: str, url: str, timeout: float = 5.0) -> dict:
+def handshake(agent_id: str, url: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
     """Return handshake information including ping status."""
 
     return {"agent_id": agent_id, "remote_status": ping_agent(url, timeout=timeout)}

--- a/tests/protocols/test_remote_utils.py
+++ b/tests/protocols/test_remote_utils.py
@@ -41,3 +41,12 @@ def test_handshake_passes_timeout(monkeypatch):
     result = remote.handshake("agent42", "http://example.com", timeout=3)
     assert result == {"agent_id": "agent42", "remote_status": True}
     assert fake_ping.called_timeout == 3
+
+
+def test_ping_agent_handles_timeout(monkeypatch):
+    def fake_get(url, timeout=None):
+        raise requests.exceptions.Timeout
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert remote.ping_agent("http://example.com") is False
+


### PR DESCRIPTION
## Summary
- define `DEFAULT_TIMEOUT` constant in `protocols.utils.remote`
- use the constant in `ping_agent` and `handshake`
- test that `ping_agent` returns `False` on request timeouts

## Testing
- `pytest tests/protocols/test_remote_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879cc7737083208c2ef7e3461b84fd