### PR TITLE
Add optional llm backend typing

### DIFF
--- a/protocols/agents/guardian_interceptor_agent.py
+++ b/protocols/agents/guardian_interceptor_agent.py
@@ -12,7 +12,7 @@ The agent can optionally leverage an ``llm_backend`` callable for deeper text
 analysis when inspecting or proposing fixes.
 """
 
-from typing import Dict, List
+from typing import Callable, Dict, List
 import uuid
 import time  # retained for potential future hooks
 
@@ -39,10 +39,11 @@ class GuardianInterceptorAgent(InternalAgentProtocol):
     Parameters
     ----------
     llm_backend : callable, optional
-        Optional function used to perform advanced analysis of suggestions.
+        Optional function used to perform advanced analysis of suggestions. If
+        omitted, built-in heuristics operate without LLM assistance.
     """
 
-    def __init__(self, llm_backend=None) -> None:
+    def __init__(self, llm_backend: Callable[[str], str] | None = None) -> None:
         super().__init__()
         self.name = "GuardianInterceptor"
         self.llm_backend = llm_backend


### PR DESCRIPTION
## Summary
- add dummy backend fallback for LLM capable agents
- type llm_backend parameters
- wire CI_PRProtectorAgent, MetaValidatorAgent and ObserverAgent to use the backend
- keep GuardianInterceptorAgent behaviour intact

## Testing
- `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest tests/test_agents_llm_backend.py -q`
- `pytest -q` *(fails: async fallback plugin and DB tests)*

------
https://chatgpt.com/codex/tasks/task_e_68879cff097083209bc41c631cac2dc0