### PR TITLE
Connect audit UI with dispatcher

### DIFF
--- a/audit/ui_bridge.py
+++ b/audit/ui_bridge.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Bridge audit UI callbacks to the central frontend router."""
+
+from typing import Any, Dict
+
+from db_models import SessionLocal
+from frontend_bridge import register_route
+
+from .ui_hook import attach_trace_ui, log_hypothesis_ui
+
+
+async def log_hypothesis_route(payload: Dict[str, Any]) -> str:
+    """Route wrapper for :func:`log_hypothesis_ui` using a new DB session."""
+    db = SessionLocal()
+    try:
+        return await log_hypothesis_ui(payload, db)
+    finally:
+        db.close()
+
+
+async def attach_trace_route(payload: Dict[str, Any]) -> None:
+    """Route wrapper for :func:`attach_trace_ui` using a new DB session."""
+    db = SessionLocal()
+    try:
+        await attach_trace_ui(payload, db)
+    finally:
+        db.close()
+
+
+# Register routes with the central dispatcher on import
+register_route("log_hypothesis", log_hypothesis_route)
+register_route("attach_trace", attach_trace_route)

--- a/tests/ui_hooks/test_audit.py
+++ b/tests/ui_hooks/test_audit.py
@@ -1,0 +1,64 @@
+import json
+
+import pytest
+
+# Import the bridge module so routes are registered
+import audit.ui_bridge  # noqa: F401
+from db_models import LogEntry, SystemState
+from frontend_bridge import dispatch_route
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_log_hypothesis_via_router(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    payload = {"hypothesis_text": "foo", "causal_node_ids": ["a", "b"]}
+    key = await dispatch_route("log_hypothesis", payload)
+
+    state = test_db.query(SystemState).filter(SystemState.key == key).first()
+    assert state is not None  # nosec B101
+
+    assert dummy.events == [  # nosec B101
+        ("audit_log", ({"action": "log_hypothesis", "key": key},), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_via_router(test_db, monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("audit.ui_hook.hook_manager", dummy, raising=False)
+
+    log = LogEntry(
+        timestamp=__import__("datetime").datetime.utcnow(),
+        event_type="test",
+        payload=json.dumps({"foo": "bar"}),
+        previous_hash="p",
+        current_hash="c",
+    )
+    test_db.add(log)
+    test_db.commit()
+
+    payload = {
+        "log_id": log.id,
+        "causal_node_ids": ["x"],
+        "summary": "trace",
+    }
+    await dispatch_route("attach_trace", payload)
+
+    refreshed = test_db.query(LogEntry).filter(LogEntry.id == log.id).first()
+    data = json.loads(refreshed.payload)
+    assert data["causal_node_ids"] == ["x"]  # nosec B101
+    assert data["causal_commentary"] == "trace"  # nosec B101
+
+    assert dummy.events == [  # nosec B101
+        ("audit_log", ({"action": "attach_trace", "log_id": log.id},), {})
+    ]


### PR DESCRIPTION
## Summary
- add `audit/ui_bridge.py` which registers audit routes
- test audit UI hooks via dispatch routing

## Testing
- `pre-commit run --files audit/ui_bridge.py tests/ui_hooks/test_audit.py`
- `pytest tests/ui_hooks/test_audit.py tests/ui_hooks/test_coordination.py tests/test_audit_ui_hook.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879eef58e88320b1315eebff01fe98