### PR TITLE
Add hypothesis UI hooks

### DIFF
--- a/hypothesis/ui_hook.py
+++ b/hypothesis/ui_hook.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from db_models import SessionLocal
+from hypothesis_tracker import register_hypothesis, update_hypothesis_score
+
+# Exposed hook manager for observers
+ui_hook_manager = HookManager()
+
+
+async def create_hypothesis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a hypothesis from a UI payload."""
+    db = SessionLocal()
+    try:
+        hid = register_hypothesis(
+            payload.get("text", ""),
+            db,
+            payload.get("metadata"),
+        )
+    finally:
+        db.close()
+
+    await ui_hook_manager.trigger("hypothesis_created", {"id": hid})
+    return {"hypothesis_id": hid}
+
+
+async def update_hypothesis_score_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update hypothesis score from UI payload."""
+    db = SessionLocal()
+    try:
+        success = update_hypothesis_score(
+            db,
+            payload.get("hypothesis_id", ""),
+            payload.get("new_score", 0.0),
+            status=payload.get("status"),
+            source_audit_id=payload.get("source_audit_id"),
+            reason=payload.get("reason"),
+            metadata_update=payload.get("metadata_update"),
+        )
+    finally:
+        db.close()
+
+    await ui_hook_manager.trigger(
+        "hypothesis_score_updated", {"id": payload.get("hypothesis_id"), "success": success}
+    )
+    return {"success": success}
+
+
+# Register with central frontend router
+register_route("create_hypothesis", create_hypothesis_ui)
+register_route("update_hypothesis_score", update_hypothesis_score_ui)

--- a/tests/ui_hooks/test_hypothesis_ui.py
+++ b/tests/ui_hooks/test_hypothesis_ui.py
@@ -1,0 +1,65 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from hypothesis.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_create_hypothesis_via_router(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("hypothesis_created", listener)
+
+    captured = {}
+
+    def fake_register(text, db, metadata=None):
+        captured["args"] = (text, metadata)
+        return "H1"
+
+    class DummySession:
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr("hypothesis.ui_hook.register_hypothesis", fake_register)
+    monkeypatch.setattr("hypothesis.ui_hook.SessionLocal", lambda: DummySession())
+
+    result = await dispatch_route("create_hypothesis", {"text": "foo", "metadata": {"a": 1}})
+
+    assert result == {"hypothesis_id": "H1"}
+    assert captured["args"] == ("foo", {"a": 1})
+    assert captured.get("closed")
+    assert events == [{"id": "H1"}]
+
+
+@pytest.mark.asyncio
+async def test_update_hypothesis_score_via_router(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("hypothesis_score_updated", listener)
+
+    captured = {}
+
+    def fake_update(db, hid, score, *, status=None, source_audit_id=None, reason=None, metadata_update=None):
+        captured["args"] = (hid, score, status, source_audit_id, reason, metadata_update)
+        return True
+
+    class DummySession:
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr("hypothesis.ui_hook.update_hypothesis_score", fake_update)
+    monkeypatch.setattr("hypothesis.ui_hook.SessionLocal", lambda: DummySession())
+
+    payload = {"hypothesis_id": "H1", "new_score": 0.5, "status": "open", "reason": "r"}
+    result = await dispatch_route("update_hypothesis_score", payload)
+
+    assert result == {"success": True}
+    assert captured["args"] == ("H1", 0.5, "open", None, "r", None)
+    assert captured.get("closed")
+    assert events == [{"id": "H1", "success": True}]


### PR DESCRIPTION
## Summary
- add async API wrappers for creating and updating hypotheses
- register the new routes with the frontend bridge
- test registered routes call tracker functions and emit hook events

## Testing
- `pytest -q`
- `pytest tests/ui_hooks/test_hypothesis_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879ef0559c8320bffe9cdea1f20558