### PR TITLE
Add validator reputation UI hook

### DIFF
--- a/tests/ui_hooks/test_reputation.py
+++ b/tests/ui_hooks/test_reputation.py
@@ -1,0 +1,27 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from validators.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_reputation_update_via_router():
+    calls = []
+
+    async def listener(data):
+        calls.append(data)
+
+    ui_hook_manager.register_hook("validator_reputations_updated", listener)
+
+    payload = {
+        "validations": [
+            {"validator_id": "v1", "score": 0.8},
+            {"validator_id": "v1", "score": 0.9},
+        ]
+    }
+
+    result = await dispatch_route("reputation_update", payload)
+
+    assert "validator_count" in result  # nosec B101
+    assert "avg_reputation" in result  # nosec B101
+    assert calls == [result]  # nosec B101

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from statistics import mean
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from validator_reputation_tracker import update_validator_reputations
+
+# Dedicated hook manager for validator reputation events
+ui_hook_manager = HookManager()
+
+
+async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update validator reputations using provided validations.
+
+    Parameters
+    ----------
+    payload : dict
+        JSON payload containing ``"validations"`` list.
+
+    Returns
+    -------
+    dict
+        Summary stats with ``validator_count`` and ``avg_reputation``.
+    """
+    validations = payload.get("validations", [])
+    result = update_validator_reputations(validations)
+    reputations = result.get("reputations", {})
+    summary = {
+        "validator_count": result.get("diversity", {}).get("validator_count", len(reputations)),
+        "avg_reputation": round(mean(reputations.values()), 3) if reputations else 0.0,
+    }
+    # Emit event for observers
+    await ui_hook_manager.trigger("validator_reputations_updated", summary)
+    return summary
+
+
+# Register with the central frontend router
+register_route("reputation_update", trigger_reputation_update_ui)


### PR DESCRIPTION
## Summary
- add validators/ui_hook.py with a route to update reputations
- expose dedicated hook manager and register route in frontend bridge
- test that the route works through dispatch_route and triggers hooks

## Testing
- `pytest -q tests/ui_hooks/test_reputation.py`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68879ef121e083208f5598b144d952c8