### PR TITLE
Refactor federation_cli queries

### DIFF
--- a/federation_cli.py
+++ b/federation_cli.py
@@ -33,7 +33,7 @@ def create_fork(args: argparse.Namespace) -> None:
     try:
         stmt = (
             select(Harmonizer)  # from sqlalchemy.orm
-            .filter_by(username=args.creator)
+            .where(Harmonizer.username == args.creator)
         )
         user = db.execute(stmt).scalar_one_or_none()
         if not user:
@@ -106,7 +106,7 @@ def fork_info(args: argparse.Namespace) -> None:
     try:
         stmt = (
             select(UniverseBranch)  # from sqlalchemy.orm
-            .filter_by(id=args.fork_id)
+            .where(UniverseBranch.id == args.fork_id)
         )
         fork = db.execute(stmt).scalar_one_or_none()
         if not fork:
@@ -138,12 +138,12 @@ def vote_fork(args: argparse.Namespace) -> None:
     try:
         stmt = (
             select(UniverseBranch)  # from sqlalchemy.orm
-            .filter_by(id=args.fork_id)
+            .where(UniverseBranch.id == args.fork_id)
         )
         fork = db.execute(stmt).scalar_one_or_none()
         stmt = (
             select(Harmonizer)  # from sqlalchemy.orm
-            .filter_by(username=args.voter)
+            .where(Harmonizer.username == args.voter)
         )
         voter = db.execute(stmt).scalar_one_or_none()
         if not fork or not voter:
@@ -152,7 +152,10 @@ def vote_fork(args: argparse.Namespace) -> None:
         # Avoid duplicate votes from the same harmonizer
         stmt = (
             select(BranchVote)  # from sqlalchemy.orm
-            .filter_by(branch_id=fork.id, voter_id=voter.id)
+            .where(
+                BranchVote.branch_id == fork.id,
+                BranchVote.voter_id == voter.id,
+            )
         )
         existing = db.execute(stmt).scalar_one_or_none()
         if existing:

--- a/stubs/sqlalchemy_stub.py
+++ b/stubs/sqlalchemy_stub.py
@@ -188,6 +188,11 @@ class Select:
 
         return self.filter(pred)
 
+    def where(self, *predicates):
+        for predicate in predicates:
+            self.filter(predicate)
+        return self
+
 def create_engine(*args, **kwargs):
     return Engine(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- update select queries to use `where` instead of `filter_by`
- extend SQLAlchemy stub with a `where` method

## Testing
- `pytest -q tests/test_federation_cli_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a929ba30832090bb26b4ee5b15c2