### PR TITLE
Update agent registry key

### DIFF
--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -11,9 +11,9 @@ from .utils.remote import handshake, ping_agent  # noqa: F401
 
 # Expose agent classes for convenience
 for _name, _info in AGENT_REGISTRY.items():
-    globals()[_name] = _info["cls"]
+    globals()[_name] = _info["class"]
 
-__all__ = [
+__all__ = (
     "AgentProfile",
     "AgentTaskContract",
     "self_reflect",
@@ -22,4 +22,4 @@ __all__ = [
     "fork_agent",
     "ValidatorElf",
     "DreamWeaver",
-] + list(AGENT_REGISTRY.keys()) + ["AGENT_REGISTRY"]
+) + tuple(AGENT_REGISTRY.keys()) + ("AGENT_REGISTRY",)

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -16,62 +16,62 @@ from .agents.codex_agent import CodexAgent
 # Mapping of agent names to metadata dictionaries
 AGENT_REGISTRY = {
     "CI_PRProtectorAgent": {
-        "cls": CI_PRProtectorAgent,
+        "class": CI_PRProtectorAgent,
         "description": "Repairs CI/PR failures by proposing patches.",
         "llm_capable": True,
     },
     "GuardianInterceptorAgent": {
-        "cls": GuardianInterceptorAgent,
+        "class": GuardianInterceptorAgent,
         "description": "Inspects LLM suggestions for risky content.",
         "llm_capable": True,
     },
     "MetaValidatorAgent": {
-        "cls": MetaValidatorAgent,
+        "class": MetaValidatorAgent,
         "description": "Audits patches and adjusts trust scores.",
         "llm_capable": True,
     },
     "ObserverAgent": {
-        "cls": ObserverAgent,
+        "class": ObserverAgent,
         "description": "Monitors agent outputs and suggests forks when needed.",
         "llm_capable": False,
     },
     "CollaborativePlannerAgent": {
-        "cls": CollaborativePlannerAgent,
+        "class": CollaborativePlannerAgent,
         "description": "Coordinates tasks and delegates to the best agent.",
         "llm_capable": False,
     },
     "CoordinationSentinelAgent": {
-        "cls": CoordinationSentinelAgent,
+        "class": CoordinationSentinelAgent,
         "description": "Detects suspicious validator coordination patterns.",
         "llm_capable": False,
     },
     "HarmonySynthesizerAgent": {
-        "cls": HarmonySynthesizerAgent,
+        "class": HarmonySynthesizerAgent,
         "description": "Transforms metrics into short MIDI snippets.",
         "llm_capable": False,
     },
     "TemporalAuditAgent": {
-        "cls": TemporalAuditAgent,
+        "class": TemporalAuditAgent,
         "description": "Audits timestamps for suspicious gaps or disorder.",
         "llm_capable": False,
     },
     "CrossUniverseBridgeAgent": {
-        "cls": CrossUniverseBridgeAgent,
+        "class": CrossUniverseBridgeAgent,
         "description": "Validates cross-universe remix provenance.",
         "llm_capable": True,
     },
     "AnomalySpotterAgent": {
-        "cls": AnomalySpotterAgent,
+        "class": AnomalySpotterAgent,
         "description": "Flags anomalies in metrics streams.",
         "llm_capable": True,
     },
     "QuantumResonanceAgent": {
-        "cls": QuantumResonanceAgent,
+        "class": QuantumResonanceAgent,
         "description": "Tracks resonance via quantum simulation.",
         "llm_capable": True,
     },
     "CodexAgent": {
-        "cls": CodexAgent,
+        "class": CodexAgent,
         "description": "Base agent with in-memory utilities.",
         "llm_capable": False,
     },

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -24,5 +24,5 @@ def test_registry_classes_correct():
         module = importlib.import_module(f"protocols.agents.{mod_name}")
         for name, obj in inspect.getmembers(module, inspect.isclass):
             if name.endswith("Agent"):
-                assert AGENT_REGISTRY[name]["cls"] is obj
+                assert AGENT_REGISTRY[name]["class"] is obj
 

--- a/ui.py
+++ b/ui.py
@@ -570,7 +570,7 @@ def main() -> None:
                 alert("Invalid backend selected", "error")
                 st.session_state["agent_output"] = None
                 st.stop()
-            agent_cls = AGENT_REGISTRY.get(agent_choice, {}).get("cls")
+            agent_cls = AGENT_REGISTRY.get(agent_choice, {}).get("class")
             if agent_cls is None:
                 alert("Unknown agent selected", "error")
             else:


### PR DESCRIPTION
## Summary
- standardize AGENT_REGISTRY by replacing the `cls` key with `class`
- expose new key via protocols package
- adjust Streamlit UI to look up agents by the `class` key
- update unit tests
- clean up `__all__` formatting

## Testing
- `pytest tests/test_agent_registry.py -q`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'get', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887a99914a083208a7c82a1c5a8f8a7