### PR TITLE
Add guardian UI hooks

### DIFF
--- a/protocols/agents/guardian_ui_hook.py
+++ b/protocols/agents/guardian_ui_hook.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+
+from .guardian_interceptor_agent import GuardianInterceptorAgent
+
+# Exposed hook manager and agent instance
+guardian_hook_manager = HookManager()
+guardian_agent = GuardianInterceptorAgent()
+
+
+async def inspect_suggestion_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Inspect a suggestion from the UI via ``GuardianInterceptorAgent``."""
+    result = guardian_agent.inspect_suggestion(payload)
+    await guardian_hook_manager.trigger("suggestion_inspected", result)
+    return result
+
+
+async def propose_fix_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Propose a fix for an issue via ``GuardianInterceptorAgent``."""
+    result = guardian_agent.propose_fix(payload)
+    await guardian_hook_manager.trigger("fix_proposed", result)
+    return result
+
+
+# Register with the central frontend router
+register_route("inspect_suggestion", inspect_suggestion_ui)
+register_route("propose_fix", propose_fix_ui)

--- a/tests/ui_hooks/test_guardian_ui_hook.py
+++ b/tests/ui_hooks/test_guardian_ui_hook.py
@@ -1,0 +1,31 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+import protocols.agents.guardian_ui_hook as ui_hook
+from protocols.agents.guardian_interceptor_agent import GuardianInterceptorAgent
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_guardian_routes(monkeypatch):
+    dummy = DummyHookManager()
+    agent = GuardianInterceptorAgent()
+    monkeypatch.setattr(ui_hook, "guardian_hook_manager", dummy, raising=False)
+    monkeypatch.setattr(ui_hook, "guardian_agent", agent, raising=False)
+
+    payload = {"content": "delete file"}
+    judgment = await dispatch_route("inspect_suggestion", payload)
+    assert judgment["risk_level"] == "HIGH"
+    assert dummy.events == [("suggestion_inspected", (judgment,), {})]
+
+    fix_payload = {"issue": "bug", "context": "ctx"}
+    patch = await dispatch_route("propose_fix", fix_payload)
+    assert "patch" in patch
+    assert dummy.events[-1] == ("fix_proposed", (patch,), {})


### PR DESCRIPTION
## Summary
- expose GuardianInterceptor functionality to the UI
- register `inspect_suggestion` and `propose_fix` routes
- tests for new routes

## Testing
- `pytest tests/ui_hooks/test_guardian_ui_hook.py tests/test_agent_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a9cbff608320a00f40c54f077dca