### PR TITLE
Add harmony MIDI UI hook

### DIFF
--- a/protocols/agents/harmony_ui_hook.py
+++ b/protocols/agents/harmony_ui_hook.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import base64
+from typing import Any, Callable, Dict, Optional
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+
+from .harmony_synthesizer_agent import HarmonySynthesizerAgent
+
+# Allow external modules/tests to provide a metrics provider
+metrics_provider: Optional[Callable[[], Dict[str, float]]] = None
+
+# Exposed hook manager for observers
+ui_hook_manager = HookManager()
+
+# Instantiate synthesizer agent
+synth_agent = HarmonySynthesizerAgent(metrics_provider)
+
+
+async def generate_midi_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate a MIDI snippet and return base64-encoded data."""
+    midi = synth_agent.handle_generate(payload)
+    encoded = base64.b64encode(midi).decode()
+    await ui_hook_manager.trigger("midi_generated", midi)
+    return {"midi_base64": encoded}
+
+
+# Register route with the central frontend router
+register_route("generate_midi", generate_midi_ui)

--- a/tests/ui_hooks/test_harmony_ui_hook.py
+++ b/tests/ui_hooks/test_harmony_ui_hook.py
@@ -1,0 +1,40 @@
+import base64
+
+import pytest
+
+import protocols.agents.harmony_ui_hook as harmony_hook
+from frontend_bridge import dispatch_route
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+class DummyAgent:
+    def __init__(self, midi: bytes):
+        self.midi = midi
+        self.calls: list[dict[str, object] | None] = []
+
+    def handle_generate(self, payload=None):
+        self.calls.append(payload)
+        return self.midi
+
+
+@pytest.mark.asyncio
+async def test_generate_midi_route(monkeypatch):
+    midi = b"demo"
+    agent = DummyAgent(midi)
+    hooks = DummyHookManager()
+    monkeypatch.setattr(harmony_hook, "synth_agent", agent, raising=False)
+    monkeypatch.setattr(harmony_hook, "ui_hook_manager", hooks, raising=False)
+
+    payload = {"metrics": {"a": 1}}
+    result = await dispatch_route("generate_midi", payload)
+
+    assert result == {"midi_base64": base64.b64encode(midi).decode()}  # nosec B101
+    assert agent.calls == [payload]  # nosec B101
+    assert hooks.events == [("midi_generated", (midi,), {})]  # nosec B101


### PR DESCRIPTION
## Summary
- enable MIDI generation over the UI
- expose `generate_midi` route via `harmony_ui_hook`
- test UI route integration

## Testing
- `pre-commit run --files protocols/agents/harmony_ui_hook.py tests/ui_hooks/test_harmony_ui_hook.py`
- `pytest tests/ui_hooks/test_harmony_ui_hook.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a9cdd380832081469ad0ff579265