### PR TITLE
Add consensus forecast UI route

### DIFF
--- a/consensus/ui_hook.py
+++ b/consensus/ui_hook.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from consensus_forecaster_agent import forecast_consensus_trend
+
+# Exposed hook manager for observers
+ui_hook_manager = HookManager()
+
+
+async def forecast_consensus_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Forecast consensus trend from a UI payload."""
+    validations = payload.get("validations", [])
+    network_analysis = payload.get("network_analysis")
+
+    result = forecast_consensus_trend(validations, network_analysis)
+    minimal = {
+        "forecast_score": result.get("forecast_score", 0.0),
+        "trend": result.get("trend", "stable"),
+    }
+    if "risk_modifier" in result:
+        minimal["risk_modifier"] = result["risk_modifier"]
+    if "flags" in result:
+        minimal["flags"] = result["flags"]
+
+    await ui_hook_manager.trigger("consensus_forecast_run", minimal)
+    return minimal
+
+
+# Register route with the frontend bridge
+register_route("forecast_consensus", forecast_consensus_ui)

--- a/tests/test_consensus_ui_hook.py
+++ b/tests/test_consensus_ui_hook.py
@@ -1,0 +1,36 @@
+import pytest
+
+from consensus import ui_hook as cons_ui_hook
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_forecast_consensus_ui(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("consensus.ui_hook.ui_hook_manager", dummy, raising=False)
+
+    called = {}
+
+    def fake_forecast(validations, network_analysis=None):
+        called["args"] = (validations, network_analysis)
+        return {"forecast_score": 0.7, "trend": "increasing"}
+
+    monkeypatch.setattr(cons_ui_hook, "forecast_consensus_trend", fake_forecast)
+
+    payload = {
+        "validations": [{"score": 0.6}],
+        "network_analysis": {"overall_risk_score": 0.1},
+    }
+
+    result = await cons_ui_hook.forecast_consensus_ui(payload)
+
+    assert result == {"forecast_score": 0.7, "trend": "increasing"}
+    assert called["args"] == (payload["validations"], payload["network_analysis"])
+    assert dummy.events == [("consensus_forecast_run", (result,), {})]

--- a/tests/ui_hooks/test_consensus.py
+++ b/tests/ui_hooks/test_consensus.py
@@ -1,0 +1,27 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from consensus.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_forecast_consensus_via_router():
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("consensus_forecast_run", listener)
+
+    payload = {
+        "validations": [
+            {"score": 0.1, "timestamp": "2025-01-01T00:00:00Z"},
+            {"score": 0.2, "timestamp": "2025-01-02T00:00:00Z"},
+            {"score": 0.3, "timestamp": "2025-01-03T00:00:00Z"},
+        ]
+    }
+
+    result = await dispatch_route("forecast_consensus", payload)
+
+    assert result["trend"] == "increasing"
+    assert events == [result]


### PR DESCRIPTION
## Summary
- create `consensus/ui_hook.py` with `forecast_consensus_ui`
- register new route `forecast_consensus`
- test payload parsing and routing

## Testing
- `pytest tests/test_consensus_ui_hook.py tests/ui_hooks/test_consensus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a9d0237483209f50c601014bec23