### PR TITLE
Centralize hook event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ You can run all checks manually with:
 pre-commit run --all-files
 ```
 
+### Hook Events
+
+See `docs/hooks.md` for a list of canonical hook events emitted by the
+application.
+
 ### Platform Quick Commands
 
 **Windows PowerShell**

--- a/agent_core.py
+++ b/agent_core.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, TYPE_CHECKING
 from virtual_diary import load_entries
 from config import Config, get_emoji_weights
+from hooks import events
 
 if TYPE_CHECKING:
     from superNova_2177 import (
@@ -131,7 +132,7 @@ class RemixAgent:
         # Track awarded fork badges for users
         self.fork_badges: Dict[str, list[str]] = {}
         # Register hook for cross remix creation events
-        self.hooks.register_hook("cross_remix_created", self.on_cross_remix_created)
+        self.hooks.register_hook(events.CROSS_REMIX_CREATED, self.on_cross_remix_created)
         self.event_count = 0
         self.processed_nonces = {}
         self._cleanup_thread = threading.Thread(
@@ -837,7 +838,7 @@ class RemixAgent:
         self.storage.set_coin(new_coin_id, new_coin.to_dict())
         # Trigger hooks after a successful cross remix
         self.hooks.fire_hooks(
-            "cross_remix_created", {"coin_id": new_coin_id, "user": user}
+            events.CROSS_REMIX_CREATED, {"coin_id": new_coin_id, "user": user}
         )
 
     def _apply_DAILY_DECAY(self, event: ApplyDailyDecayPayload) -> None:

--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -9,6 +9,7 @@ from audit_bridge import (
     log_hypothesis_with_trace,
 )
 from hook_manager import HookManager
+from hooks import events
 from protocols.utils.messaging import MessageHub
 from causal_graph import InfluenceGraph
 
@@ -45,7 +46,7 @@ async def log_hypothesis_ui(payload: Dict[str, Any], db: Session) -> str:
         metadata=payload.get("metadata"),
     )
     await hook_manager.trigger(
-        "audit_log",
+        events.AUDIT_LOG,
         {"action": "log_hypothesis", "key": key},
     )
     message_hub.publish("audit_log", {"action": "log_hypothesis", "key": key})
@@ -61,7 +62,7 @@ async def attach_trace_ui(payload: Dict[str, Any], db: Session) -> None:
         summary=payload.get("summary"),
     )
     await hook_manager.trigger(
-        "audit_log",
+        events.AUDIT_LOG,
         {"action": "attach_trace", "log_id": int(payload["log_id"])},
     )
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,20 @@
+# Hook Events
+
+The project uses a lightweight `HookManager` to allow different modules to notify
+subscribers when certain actions occur. The following constants from
+`hooks/events.py` define the canonical event names emitted across the codebase:
+
+- `BRIDGE_REGISTERED` – a cross‑universe bridge was registered.
+- `PROVENANCE_RETURNED` – provenance data was returned to the caller.
+- `COORDINATION_ANALYSIS_RUN` – coordination analysis finished running.
+- `NETWORK_ANALYSIS` – summary network metrics were produced.
+- `FULL_AUDIT_COMPLETED` – a full introspection audit completed.
+- `AUDIT_LOG` – an audit log entry was created or updated.
+- `HYPOTHESIS_RANKING` – hypotheses were ranked by confidence.
+- `HYPOTHESIS_CONFLICTS` – conflicting hypotheses were detected.
+- `REPUTATION_ANALYSIS_RUN` – validator reputation analysis finished.
+- `CROSS_REMIX_CREATED` – a cross‑remix coin was minted.
+- `ENTROPY_DIVERGENCE` – interaction entropy exceeded the threshold.
+
+Hook callbacks can be registered via `HookManager.register_hook` and will receive
+the payload passed to `trigger()` or `fire_hooks()`.

--- a/hooks/events.py
+++ b/hooks/events.py
@@ -1,0 +1,28 @@
+"""Canonical hook event names used across the codebase."""
+
+__all__ = [
+    "BRIDGE_REGISTERED",
+    "PROVENANCE_RETURNED",
+    "COORDINATION_ANALYSIS_RUN",
+    "NETWORK_ANALYSIS",
+    "FULL_AUDIT_COMPLETED",
+    "AUDIT_LOG",
+    "HYPOTHESIS_RANKING",
+    "HYPOTHESIS_CONFLICTS",
+    "REPUTATION_ANALYSIS_RUN",
+    "CROSS_REMIX_CREATED",
+    "ENTROPY_DIVERGENCE",
+]
+
+# UI events
+BRIDGE_REGISTERED = "bridge_registered"
+PROVENANCE_RETURNED = "provenance_returned"
+COORDINATION_ANALYSIS_RUN = "coordination_analysis_run"
+NETWORK_ANALYSIS = "network_analysis"
+FULL_AUDIT_COMPLETED = "full_audit_completed"
+AUDIT_LOG = "audit_log"
+HYPOTHESIS_RANKING = "hypothesis_ranking"
+HYPOTHESIS_CONFLICTS = "hypothesis_conflicts"
+REPUTATION_ANALYSIS_RUN = "reputation_analysis_run"
+CROSS_REMIX_CREATED = "cross_remix_created"
+ENTROPY_DIVERGENCE = "entropy_divergence"

--- a/hypothesis/ui_hook.py
+++ b/hypothesis/ui_hook.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from db_models import SessionLocal
 from hook_manager import HookManager
+from hooks import events
 from hypothesis_reasoner import (
     rank_hypotheses_by_confidence as _rank_hypotheses_by_confidence,
     detect_conflicting_hypotheses as _detect_conflicting_hypotheses,
@@ -20,7 +21,7 @@ async def rank_hypotheses_by_confidence_ui(payload: Dict[str, Any]) -> Dict[str,
         ranking = _rank_hypotheses_by_confidence(db, top_k=top_k)
     finally:
         db.close()
-    await ui_hook_manager.trigger("hypothesis_ranking", ranking)
+    await ui_hook_manager.trigger(events.HYPOTHESIS_RANKING, ranking)
     return {"ranking": ranking}
 
 
@@ -31,5 +32,5 @@ async def detect_conflicting_hypotheses_ui(payload: Dict[str, Any]) -> Dict[str,
         conflicts = _detect_conflicting_hypotheses(db)
     finally:
         db.close()
-    await ui_hook_manager.trigger("hypothesis_conflicts", conflicts)
+    await ui_hook_manager.trigger(events.HYPOTHESIS_CONFLICTS, conflicts)
     return {"conflicts": conflicts}

--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from sqlalchemy.orm import Session
 
 from hook_manager import HookManager
+from hooks import events
 
 from .introspection_pipeline import run_full_audit
 
@@ -32,6 +33,6 @@ async def trigger_full_audit_ui(payload: Dict[str, Any], db: Session) -> Dict[st
     audit_bundle = run_full_audit(hypothesis_id, db)
 
     # Allow external listeners to process the audit result asynchronously
-    await ui_hook_manager.trigger("full_audit_completed", audit_bundle)
+    await ui_hook_manager.trigger(events.FULL_AUDIT_COMPLETED, audit_bundle)
 
     return audit_bundle

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 from frontend_bridge import register_route
 from hook_manager import HookManager
+from hooks import events
 
 from .network_coordination_detector import analyze_coordination_patterns
 
@@ -35,7 +36,7 @@ async def trigger_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str,
         "graph": result.get("graph", {}),
     }
     # Emit event for observers
-    await ui_hook_manager.trigger("coordination_analysis_run", minimal)
+    await ui_hook_manager.trigger(events.COORDINATION_ANALYSIS_RUN, minimal)
     return minimal
 
 
@@ -61,7 +62,7 @@ async def run_coordination_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     try:
-        hook_manager.fire_hooks("network_analysis", minimal)
+        hook_manager.fire_hooks(events.NETWORK_ANALYSIS, minimal)
     except Exception:  # pragma: no cover - logging only
         logging.exception("Failed to fire network_analysis hook")
 

--- a/protocols/ui_hook.py
+++ b/protocols/ui_hook.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 from frontend_bridge import register_route
 from hook_manager import HookManager
+from hooks import events
 
 from protocols.agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
 
@@ -15,14 +16,14 @@ bridge_agent = CrossUniverseBridgeAgent()
 async def register_bridge_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and store cross-universe provenance via the UI."""
     result = bridge_agent.register_bridge(payload)
-    await bridge_hook_manager.trigger("bridge_registered", result)
+    await bridge_hook_manager.trigger(events.BRIDGE_REGISTERED, result)
     return result
 
 
 async def get_provenance_ui(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Return provenance information for ``coin_id`` via the UI."""
     result = bridge_agent.get_provenance(payload)
-    await bridge_hook_manager.trigger("provenance_returned", result)
+    await bridge_hook_manager.trigger(events.PROVENANCE_RETURNED, result)
     return result
 
 

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -582,6 +582,7 @@ DB_ENGINE_URL = None
 from prediction_manager import PredictionManager
 from resonance_music import generate_midi_from_metrics
 from hook_manager import HookManager
+from hooks import events
 
 # Import system configuration early so metrics can be started with the proper
 # port value. Other modules follow the same pattern by exposing a ``CONFIG``
@@ -2330,7 +2331,7 @@ class EntropyTracker(RemixAgent):
             self.current_entropy = float(info.get("value", 0.0))
             if self.current_entropy > self.entropy_threshold:
                 self.cosmic_nexus.hooks.fire_hooks(
-                    "entropy_divergence",
+                    events.ENTROPY_DIVERGENCE,
                     {"universe": id(self), "entropy": self.current_entropy},
                 )
         finally:

--- a/tests/test_audit_ui_hook.py
+++ b/tests/test_audit_ui_hook.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from audit.ui_hook import log_hypothesis_ui, attach_trace_ui
+from hooks import events
 from db_models import LogEntry, SystemState
 
 
@@ -25,7 +26,7 @@ async def test_log_hypothesis_ui_records_state_and_emits_event(test_db, monkeypa
     assert state is not None
 
     assert dummy.events == [
-        ("audit_log", ({"action": "log_hypothesis", "key": key},), {})
+        (events.AUDIT_LOG, ({"action": "log_hypothesis", "key": key},), {})
     ]
 
 
@@ -57,5 +58,5 @@ async def test_attach_trace_ui_updates_log_and_emits_event(test_db, monkeypatch)
     assert data["causal_commentary"] == "trace"
 
     assert dummy.events == [
-        ("audit_log", ({"action": "attach_trace", "log_id": log.id},), {})
+        (events.AUDIT_LOG, ({"action": "attach_trace", "log_id": log.id},), {})
     ]

--- a/tests/test_network_ui_hook.py
+++ b/tests/test_network_ui_hook.py
@@ -1,6 +1,7 @@
 import pytest
 
 from network.ui_hook import run_coordination_analysis
+from hooks import events
 
 
 class DummyHookManager:
@@ -33,7 +34,7 @@ async def test_run_coordination_analysis(monkeypatch):
     assert "overall_risk_score" in result  # nosec B101
     assert "flags" in result  # nosec B101
     assert "clusters" in result  # nosec B101
-    assert dummy.events == [("network_analysis", (result,), {})]  # nosec B101
+    assert dummy.events == [(events.NETWORK_ANALYSIS, (result,), {})]  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tests/ui_hooks/test_audit_hooks.py
+++ b/tests/ui_hooks/test_audit_hooks.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from audit.ui_hook import log_hypothesis_ui, attach_trace_ui
+from hooks import events
 from db_models import LogEntry, SystemState
 
 
@@ -24,7 +25,7 @@ async def test_log_hypothesis_ui(test_db, monkeypatch):
     state = test_db.query(SystemState).filter(SystemState.key == key).first()
     assert state is not None
     assert dummy.events == [
-        ("audit_log", ({"action": "log_hypothesis", "key": key},), {})
+        (events.AUDIT_LOG, ({"action": "log_hypothesis", "key": key},), {})
     ]
 
 
@@ -51,5 +52,5 @@ async def test_attach_trace_ui(test_db, monkeypatch):
     assert data["causal_node_ids"] == ["x"]
     assert data["causal_commentary"] == "trace"
     assert dummy.events == [
-        ("audit_log", ({"action": "attach_trace", "log_id": log.id},), {})
+        (events.AUDIT_LOG, ({"action": "attach_trace", "log_id": log.id},), {})
     ]

--- a/tests/ui_hooks/test_coordination.py
+++ b/tests/ui_hooks/test_coordination.py
@@ -2,6 +2,7 @@ import pytest
 
 from frontend_bridge import dispatch_route
 from network.ui_hook import ui_hook_manager
+from hooks import events
 
 
 @pytest.mark.asyncio
@@ -11,7 +12,7 @@ async def test_coordination_analysis_via_router():
     async def listener(data):
         calls.append(data)
 
-    ui_hook_manager.register_hook("coordination_analysis_run", listener)
+    ui_hook_manager.register_hook(events.COORDINATION_ANALYSIS_RUN, listener)
 
     payload = {
         "validations": [

--- a/tests/ui_hooks/test_cross_universe_bridge.py
+++ b/tests/ui_hooks/test_cross_universe_bridge.py
@@ -4,6 +4,7 @@ from frontend_bridge import dispatch_route
 from protocols.agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
 
 import protocols.ui_hook as ui_hook
+from hooks import events
 
 
 class DummyHookManager:
@@ -30,8 +31,8 @@ async def test_cross_universe_routes(monkeypatch):
     result = await dispatch_route("cross_universe_register_bridge", payload)
     assert result == {"valid": True}
     assert agent.get_provenance({"coin_id": "c123"}) == [payload]
-    assert dummy.events == [("bridge_registered", ({"valid": True},), {})]
+    assert dummy.events == [(events.BRIDGE_REGISTERED, ({"valid": True},), {})]
 
     result2 = await dispatch_route("cross_universe_get_provenance", {"coin_id": "c123"})
     assert result2 == [payload]
-    assert dummy.events[-1] == ("provenance_returned", ([payload],), {})
+    assert dummy.events[-1] == (events.PROVENANCE_RETURNED, ([payload],), {})

--- a/tests/ui_hooks/test_introspection.py
+++ b/tests/ui_hooks/test_introspection.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from introspection.ui_hook import trigger_full_audit_ui
+from hooks import events
 
 
 class DummyHookManager:
@@ -31,7 +32,7 @@ async def test_full_audit_ui_runs_pipeline_and_emits_event(monkeypatch):
 
     assert result == {"bundle": True}
     assert calls["run"] == ("H1", db)
-    assert dummy.events == [("full_audit_completed", ({"bundle": True},), {})]
+    assert dummy.events == [(events.FULL_AUDIT_COMPLETED, ({"bundle": True},), {})]
 
 
 @pytest.mark.asyncio

--- a/tests/ui_hooks/test_network_ui_bridge.py
+++ b/tests/ui_hooks/test_network_ui_bridge.py
@@ -1,16 +1,17 @@
 import pytest
 
 from network import ui_hook as net_ui_hook
+from hooks import events
 
 
 @pytest.mark.asyncio
 async def test_trigger_coordination_analysis_ui(monkeypatch):
-    events = []
+    captured = []
 
     async def listener(data):
-        events.append(data)
+        captured.append(data)
 
-    net_ui_hook.ui_hook_manager.register_hook("coordination_analysis_run", listener)
+    net_ui_hook.ui_hook_manager.register_hook(events.COORDINATION_ANALYSIS_RUN, listener)
 
     called = {}
 
@@ -29,5 +30,5 @@ async def test_trigger_coordination_analysis_ui(monkeypatch):
     result = await net_ui_hook.trigger_coordination_analysis_ui(payload)
 
     assert result == {"overall_risk_score": 0.5, "graph": {"nodes": [], "edges": []}}
-    assert events == [result]
+    assert captured == [result]
     assert called["validations"] == payload["validations"]

--- a/tests/ui_hooks/test_reputation.py
+++ b/tests/ui_hooks/test_reputation.py
@@ -2,6 +2,7 @@ import pytest
 
 from frontend_bridge import dispatch_route
 from validators.ui_hook import ui_hook_manager
+from hooks import events
 
 
 @pytest.mark.asyncio
@@ -11,7 +12,7 @@ async def test_reputation_analysis_via_router():
     async def listener(data):
         calls.append(data)
 
-    ui_hook_manager.register_hook("reputation_analysis_run", listener)
+    ui_hook_manager.register_hook(events.REPUTATION_ANALYSIS_RUN, listener)
 
     payload = {
         "validations": [

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from frontend_bridge import register_route
 from hook_manager import HookManager
+from hooks import events
 
 from .reputation_influence_tracker import compute_validator_reputations
 
@@ -33,7 +34,7 @@ async def compute_reputation_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stats": result.get("stats", {}),
     }
 
-    await ui_hook_manager.trigger("reputation_analysis_run", minimal)
+    await ui_hook_manager.trigger(events.REPUTATION_ANALYSIS_RUN, minimal)
     return minimal
 
 


### PR DESCRIPTION
## Summary
- centralize canonical event strings in `hooks/events.py`
- update hook usages to reference constants
- document available hook events
- adjust tests for new constants

## Testing
- `pytest -q` *(fails: 19 failed, 194 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887a9d66a18832097eb2f3e96942d0d