### PR TITLE
Add UI hook for validator reputation updates

### DIFF
--- a/tests/ui_hooks/test_reputation.py
+++ b/tests/ui_hooks/test_reputation.py
@@ -33,6 +33,32 @@ async def test_reputation_analysis_via_router():
 
     result = await dispatch_route("reputation_analysis", payload)
 
-    assert "validator_reputations" in result
-    assert "stats" in result
-    assert calls == [result]
+    assert "validator_reputations" in result  # nosec B101
+    assert "stats" in result  # nosec B101
+    assert calls == [result]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_reputation_update_via_router():
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("reputation_update_run", listener)
+
+    payload = {
+        "validations": [
+            {"validator_id": "v1", "score": 0.6},
+            {"validator_id": "v1", "score": 0.7},
+            {"validator_id": "v2", "score": 0.4},
+            {"validator_id": "v2", "score": 0.5},
+        ]
+    }
+
+    result = await dispatch_route("reputation_update", payload)
+
+    assert "reputations" in result  # nosec B101
+    assert "diversity" in result  # nosec B101
+    assert "stats" in result  # nosec B101
+    assert events == [result]  # nosec B101

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from frontend_bridge import register_route
 from hook_manager import HookManager
+from validator_reputation_tracker import update_validator_reputations
 
 from .reputation_influence_tracker import compute_validator_reputations
 
@@ -39,3 +40,41 @@ async def compute_reputation_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 # Register with the central frontend router
 register_route("reputation_analysis", compute_reputation_ui)
+
+
+async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update validator reputations from UI-provided validations.
+
+    Parameters
+    ----------
+    payload : dict
+        Dictionary containing ``"validations"`` list.
+
+    Returns
+    -------
+    dict
+        Summary including ``reputations``, ``diversity`` and ``stats``.
+    """
+    validations = payload.get("validations", [])
+
+    result = update_validator_reputations(validations)
+    reputations = result.get("reputations", {})
+    summary = {
+        "reputations": reputations,
+        "diversity": result.get("diversity", {}),
+        "stats": {
+            "validator_count": len(reputations),
+            "avg_reputation": (
+                round(sum(reputations.values()) / len(reputations), 3)
+                if reputations
+                else 0.0
+            ),
+        },
+    }
+
+    await ui_hook_manager.trigger("reputation_update_run", summary)
+    return summary
+
+
+# Register with the central frontend router
+register_route("reputation_update", trigger_reputation_update_ui)


### PR DESCRIPTION
## Summary
- add `trigger_reputation_update_ui` to `validators/ui_hook.py`
- register `reputation_update` route
- verify with unit tests

## Testing
- `pre-commit run --files validators/ui_hook.py tests/ui_hooks/test_reputation.py`
- `pytest tests/ui_hooks/test_reputation.py::test_reputation_update_via_router -q`

------
https://chatgpt.com/codex/tasks/task_e_6887aa5a0f6483209e277ebb2d89cfb0