### PR TITLE
Add reputation update UI hook

### DIFF
--- a/tests/test_validator_ui_hook.py
+++ b/tests/test_validator_ui_hook.py
@@ -1,0 +1,33 @@
+import pytest
+
+from validators.ui_hook import trigger_reputation_update_ui
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_trigger_reputation_update_ui(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr("validators.ui_hook.ui_hook_manager", dummy, raising=False)
+
+    called = {}
+
+    def fake_update(vals):
+        called["validations"] = vals
+        return {"reputations": {"v": 0.8}, "diversity": {"validator_count": 1}}
+
+    monkeypatch.setattr("validators.ui_hook.update_validator_reputations", fake_update)
+
+    payload = {"validations": [{"validator_id": "v", "score": 1.0}]}
+    result = await trigger_reputation_update_ui(payload)
+
+    assert result == {"reputations": {"v": 0.8}, "diversity": {"validator_count": 1}}
+    assert called["validations"] == payload["validations"]
+    assert dummy.events == [("reputation_update_run", (result,), {})]
+

--- a/tests/ui_hooks/test_reputation_update.py
+++ b/tests/ui_hooks/test_reputation_update.py
@@ -1,0 +1,27 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from validators.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_reputation_update_via_router():
+    calls = []
+
+    async def listener(data):
+        calls.append(data)
+
+    ui_hook_manager.register_hook("reputation_update_run", listener)
+
+    payload = {
+        "validations": [
+            {"validator_id": "v1", "score": 0.9, "certification": "strong"},
+            {"validator_id": "v2", "score": 0.7, "certification": "provisional"},
+        ]
+    }
+
+    result = await dispatch_route("reputation_update", payload)
+
+    assert "reputations" in result
+    assert "diversity" in result
+    assert calls == [result]

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -6,6 +6,7 @@ from frontend_bridge import register_route
 from hook_manager import HookManager
 
 from .reputation_influence_tracker import compute_validator_reputations
+from validator_reputation_tracker import update_validator_reputations
 
 # Exposed hook manager for observers
 ui_hook_manager = HookManager()
@@ -37,5 +38,31 @@ async def compute_reputation_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
+async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update validator reputations from validation payload.
+
+    Parameters
+    ----------
+    payload : dict
+        Input dictionary containing ``"validations"``.
+
+    Returns
+    -------
+    dict
+        Minimal result with ``reputations`` and ``diversity`` summary.
+    """
+    validations = payload.get("validations", [])
+
+    result = update_validator_reputations(validations)
+    minimal = {
+        "reputations": result.get("reputations", {}),
+        "diversity": result.get("diversity", {}),
+    }
+
+    await ui_hook_manager.trigger("reputation_update_run", minimal)
+    return minimal
+
+
 # Register with the central frontend router
 register_route("reputation_analysis", compute_reputation_ui)
+register_route("reputation_update", trigger_reputation_update_ui)


### PR DESCRIPTION
## Summary
- expose `trigger_reputation_update_ui` to update validator reputations
- route emits `reputation_update_run` via `HookManager`
- add unit tests for the hook and the router integration

## Testing
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'items')*

------
https://chatgpt.com/codex/tasks/task_e_6887aa5a0f6483209e277ebb2d89cfb0