### PR TITLE
Add follower endpoints

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2582,6 +2582,14 @@ def read_users_me(current_user: Harmonizer = Depends(get_current_active_user)):
     return current_user
 
 
+@app.get("/users/{username}", response_model=HarmonizerOut, tags=["Harmonizers"])
+def read_user(username: str, db: Session = Depends(get_db)):
+    user = db.query(Harmonizer).filter(Harmonizer.username == username).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Harmonizer not found")
+    return user
+
+
 @app.get("/users/me/influence-score", tags=["Harmonizers"])
 def get_user_influence_score(
     db: Session = Depends(get_db),
@@ -2633,6 +2641,22 @@ def follow_unfollow_user(
         message = "Followed"
     db.commit()
     return {"message": message}
+
+
+@app.get("/users/{username}/followers", tags=["Harmonizers"])
+def get_follower_count(username: str, db: Session = Depends(get_db)):
+    user = db.query(Harmonizer).filter(Harmonizer.username == username).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Harmonizer not found")
+    return {"followers": len(user.followers)}
+
+
+@app.get("/users/{username}/following", tags=["Harmonizers"])
+def get_following_count(username: str, db: Session = Depends(get_db)):
+    user = db.query(Harmonizer).filter(Harmonizer.username == username).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Harmonizer not found")
+    return {"following": len(user.following)}
 
 
 @app.get("/status", tags=["System"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,6 +167,21 @@ async def test_follow_unfollow(client):
 
 
 @pytest.mark.asyncio
+async def test_follow_counts(client):
+    token = await register_and_get_token(client, "countfollower", "cf@example.com")
+    await register(client, "counttarget", "ct@example.com")
+    await client.post(
+        "/users/counttarget/follow", headers={"Authorization": f"Bearer {token}"}
+    )
+    r1 = await client.get("/users/counttarget/followers")
+    assert r1.status_code == 200
+    assert r1.json()["followers"] == 1
+    r2 = await client.get("/users/countfollower/following")
+    assert r2.status_code == 200
+    assert r2.json()["following"] == 1
+
+
+@pytest.mark.asyncio
 async def test_unknown_endpoint(client):
     r = await client.get("/does-not-exist")
     assert r.status_code == 404

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "login_page",
     "register_page",
     "profile_page",
+    "other_profile_page",
     "vibenodes_page",
     "groups_page",
     "events_page",

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -2,7 +2,13 @@
 
 from nicegui import ui
 
-from utils.api import api_call, TOKEN, clear_token
+from utils.api import (
+    api_call,
+    TOKEN,
+    clear_token,
+    get_followers,
+    get_following,
+)
 from utils.styles import (
     get_theme,
     set_theme,
@@ -97,3 +103,66 @@ async def profile_page():
                 value=THEME['accent'],
                 on_change=lambda e: set_accent(e.value),
             )
+
+
+@ui.page('/profile/{username}')
+async def other_profile_page(username: str):
+    """View another user's profile with follow option."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    me = await api_call('GET', '/users/me')
+    if not me:
+        clear_token()
+        ui.open(login_page)
+        return
+    if username == me.get('username'):
+        ui.open(profile_page)
+        return
+
+    user_data = await api_call('GET', f'/users/{username}')
+    if not user_data:
+        ui.notify('User not found', color='negative')
+        return
+
+    follower_data = await get_followers(username) or {"followers": 0}
+    following_data = await get_following(username) or {"following": 0}
+
+    THEME = get_theme()
+    with page_container(THEME):
+        ui.label(f"{user_data['username']}'s Profile").classes(
+            'text-2xl font-bold mb-4'
+        ).style(f'color: {THEME["accent"]};')
+
+        ui.label(f"Harmony Score: {user_data['harmony_score']}").classes('mb-2')
+        ui.label(f"Creative Spark: {user_data['creative_spark']}").classes('mb-2')
+        ui.label(f"Species: {user_data['species']}").classes('mb-2')
+        follow_count_label = ui.label(
+            f"Followers: {follower_data['followers']}"
+        ).classes('mb-2')
+        following_label = ui.label(
+            f"Following: {following_data['following']}"
+        ).classes('mb-4')
+
+        follow_btn = ui.button('Follow').classes('mb-4').style(
+            f'background: {THEME["primary"]}; color: {THEME["text"]};'
+        )
+
+        async def toggle_follow():
+            resp = await api_call('POST', f'/users/{username}/follow')
+            if resp:
+                follow_btn.text = 'Unfollow' if resp['message'] == 'Followed' else 'Follow'
+                new_counts = await get_followers(username)
+                if new_counts:
+                    follower_data['followers'] = new_counts['followers']
+                    follow_count_label.text = f"Followers: {follower_data['followers']}"
+
+        follow_btn.on('click', toggle_follow)
+
+        ui.button(
+            'Back to My Profile',
+            on_click=lambda: ui.open(profile_page)
+        ).classes('w-full').style(
+            f'background: {THEME["accent"]}; color: {THEME["background"]};'
+        )

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -82,3 +82,13 @@ def clear_token() -> None:
     """Clear the stored access token."""
     global TOKEN
     TOKEN = None
+
+
+async def get_followers(username: str) -> Optional[Dict[str, Any]]:
+    """Return follower count for ``username``."""
+    return await api_call("GET", f"/users/{username}/followers")
+
+
+async def get_following(username: str) -> Optional[Dict[str, Any]]:
+    """Return following count for ``username``."""
+    return await api_call("GET", f"/users/{username}/following")


### PR DESCRIPTION
## Summary
- support retrieving specific user's info
- support follower and following counts
- expose helpers to call new APIs from the frontend
- add Follow/Unfollow button when viewing other profiles
- ensure page list exports `other_profile_page`
- cover new API endpoints in tests

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q` *(fails: test_registry_classes_correct, test_mint_fails_for_low_karma, test_async_fallback_plugin, test_export_causal_path_handles_malformed_entries, test_export_causal_path_handles_non_dict_entries, test_federation_cli_db.py failures, test_prediction_manager.py failures, test_orm_consistency, test_ui_hooks/test_hypothesis.py)*

------
https://chatgpt.com/codex/tasks/task_e_6887ab403980832084af8e9e2dada10f