### PR TITLE
Update Streamlit smoke tests to use configurable port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         python-version: ['3.11', '3.12']
     env:
       PYTHONPATH: ${{ github.workspace }}/transcendental_resonance_frontend/src
+      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8501' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,18 +48,19 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          streamlit run ui.py --server.headless true --server.port 8501 &
+          PORT=${STREAMLIT_PORT:-8501}
+          streamlit run ui.py --server.headless true --server.port "$PORT" &
           for i in {1..30}; do
-            if curl -f http://localhost:8501 >/dev/null 2>&1; then
+            if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"
               break
             fi
             sleep 1
           done
-          if ! curl -f http://localhost:8501 >/dev/null 2>&1; then
+          if ! curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
             echo "Streamlit failed to start within timeout"
             pkill streamlit
             exit 1
           fi
-          curl -f http://localhost:8501
+          curl -f http://localhost:"$PORT"
           pkill streamlit

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,6 +15,7 @@ jobs:
         python-version: ['3.11', '3.12']
     env:
       PYTHONPATH: ${{ github.workspace }}/transcendental_resonance_frontend/src
+      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8501' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,20 +46,21 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          streamlit run ui.py --server.headless true --server.port 8501 >streamlit.log 2>&1 &
+          PORT=${STREAMLIT_PORT:-8501}
+          streamlit run ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
           for i in {1..20}; do
-            if curl -f http://localhost:8501 >/dev/null 2>&1; then
+            if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"
               break
             fi
             sleep 1
           done
-          if ! curl -f http://localhost:8501 >/dev/null 2>&1; then
+          if ! curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
             echo "Streamlit failed to start within timeout"
             pkill streamlit
             exit 1
           fi
-          curl -f http://localhost:8501
+          curl -f http://localhost:"$PORT"
           pkill streamlit
       - name: Print Streamlit logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- allow specifying `STREAMLIT_PORT` in CI workflows
- use the port variable when running Streamlit smoke tests

## Testing
- `mypy`
- `pytest` *(fails: OSError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac23e608832095d10f9451ef2cf9