### PR TITLE
Increase Streamlit startup wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true --server.port 8501 &
-          for i in {1..30}; do
+          for i in {1..60}; do
             if curl -f http://localhost:8501 >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"
               break

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Streamlit smoke test
         run: |
           streamlit run ui.py --server.headless true --server.port 8501 >streamlit.log 2>&1 &
-          for i in {1..20}; do
+          for i in {1..60}; do
             if curl -f http://localhost:8501 >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"
               break


### PR DESCRIPTION
## Summary
- give Streamlit up to 60s to start in CI and PR tests

## Testing
- `mypy`
- `pytest -q` *(fails: 19 failed, 199 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac31ad4c8320852e5c98c3cc3612