### PR TITLE
Add prediction UI hooks

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -32,3 +32,14 @@ from hypothesis.ui_hook import (
 
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
+
+# Prediction-related routes
+from predictions.ui_hook import (
+    store_prediction_ui,
+    get_prediction_ui,
+    update_prediction_status_ui,
+)
+
+register_route("store_prediction", store_prediction_ui)
+register_route("get_prediction", get_prediction_ui)
+register_route("update_prediction_status", update_prediction_status_ui)

--- a/predictions/ui_hook.py
+++ b/predictions/ui_hook.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from prediction_manager import PredictionManager
+
+# Exposed hook manager so external modules can listen for prediction events
+ui_hook_manager = HookManager()
+
+# Global manager instance. Real application should configure this on startup.
+prediction_manager: Optional[PredictionManager] = None
+
+
+async def store_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist prediction data coming from the UI."""
+    if prediction_manager is None:
+        raise RuntimeError("prediction_manager not configured")
+
+    prediction_data = payload.get("prediction", payload)
+    prediction_id = prediction_manager.store_prediction(prediction_data)
+    await ui_hook_manager.trigger(
+        "prediction_stored", {"prediction_id": prediction_id}
+    )
+    return {"prediction_id": prediction_id}
+
+
+async def get_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return prediction record identified by ``prediction_id``."""
+    if prediction_manager is None:
+        raise RuntimeError("prediction_manager not configured")
+
+    prediction_id = payload["prediction_id"]
+    record = prediction_manager.get_prediction(prediction_id)
+    await ui_hook_manager.trigger("prediction_returned", record)
+    return record or {}
+
+
+async def update_prediction_status_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update prediction status based on UI request."""
+    if prediction_manager is None:
+        raise RuntimeError("prediction_manager not configured")
+
+    prediction_id = payload["prediction_id"]
+    new_status = payload.get("status", "pending")
+    outcome = payload.get("actual_outcome")
+    prediction_manager.update_prediction_status(
+        prediction_id, new_status, actual_outcome=outcome
+    )
+    await ui_hook_manager.trigger(
+        "prediction_status_updated", {"prediction_id": prediction_id, "status": new_status}
+    )
+    return {"prediction_id": prediction_id, "status": new_status}
+
+
+# Register routes with the frontend bridge
+register_route("store_prediction", store_prediction_ui)
+register_route("get_prediction", get_prediction_ui)
+register_route("update_prediction_status", update_prediction_status_ui)

--- a/tests/ui_hooks/test_predictions.py
+++ b/tests/ui_hooks/test_predictions.py
@@ -1,0 +1,46 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+import predictions.ui_hook as pred_ui_hook
+
+
+class DummyManager:
+    def __init__(self):
+        self.calls = []
+
+    def store_prediction(self, data):
+        self.calls.append(("store", data))
+        return "pid123"
+
+    def get_prediction(self, pid):
+        self.calls.append(("get", pid))
+        return {"prediction_id": pid, "data": {"foo": 1}}
+
+    def update_prediction_status(self, pid, status, actual_outcome=None):
+        self.calls.append(("update", pid, status, actual_outcome))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_prediction_routes_dispatch(monkeypatch):
+    mgr = DummyManager()
+    monkeypatch.setattr(pred_ui_hook, "prediction_manager", mgr, raising=False)
+
+    # store
+    result = await dispatch_route("store_prediction", {"prediction": {"foo": 1}})
+    assert result == {"prediction_id": "pid123"}
+    # get
+    result2 = await dispatch_route("get_prediction", {"prediction_id": "pid123"})
+    assert result2 == {"prediction_id": "pid123", "data": {"foo": 1}}
+    # update
+    result3 = await dispatch_route(
+        "update_prediction_status",
+        {"prediction_id": "pid123", "status": "done", "actual_outcome": {"a": 1}},
+    )
+    assert result3 == {"prediction_id": "pid123", "status": "done"}
+
+    assert mgr.calls == [
+        ("store", {"foo": 1}),
+        ("get", "pid123"),
+        ("update", "pid123", "done", {"a": 1}),
+    ]


### PR DESCRIPTION
## Summary
- implement prediction UI hooks and register them with the frontend router
- expose hook manager and global prediction manager
- test router integration for prediction hooks

## Testing
- `pytest tests/ui_hooks/test_predictions.py -q`
- `pytest -k prediction_routes_dispatch -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ac4ad750832091a6442c491901c9