### PR TITLE
Add optimization UI hook

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -29,6 +29,8 @@ from hypothesis.ui_hook import (
     rank_hypotheses_by_confidence_ui,
     detect_conflicting_hypotheses_ui,
 )
+from optimization.ui_hook import tune_parameters_ui
 
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
+register_route("tune_parameters", tune_parameters_ui)

--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -1,0 +1,1 @@
+# Optimization utilities

--- a/optimization/ui_hook.py
+++ b/optimization/ui_hook.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from optimization_engine import tune_system_parameters
+
+# Exposed hook manager for observers
+ui_hook_manager = HookManager()
+
+
+async def tune_parameters_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Tune system parameters from UI-provided metrics.
+
+    Parameters
+    ----------
+    payload : dict
+        Dictionary containing ``"performance_metrics"``.
+
+    Returns
+    -------
+    dict
+        Suggested parameter overrides from :func:`tune_system_parameters`.
+    """
+    metrics = payload["performance_metrics"]
+    overrides = tune_system_parameters(metrics)
+    await ui_hook_manager.trigger("system_parameters_tuned", overrides)
+    return overrides
+
+
+# Register route with the frontend bridge
+register_route("tune_parameters", tune_parameters_ui)

--- a/tests/ui_hooks/test_optimization_ui_hook.py
+++ b/tests/ui_hooks/test_optimization_ui_hook.py
@@ -1,0 +1,51 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from optimization import ui_hook
+
+
+@pytest.mark.asyncio
+async def test_tune_parameters_ui(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook.ui_hook_manager.register_hook("system_parameters_tuned", listener)
+
+    called = {}
+
+    def fake_tune(metrics):
+        called["metrics"] = metrics
+        return {"A": 1}
+
+    monkeypatch.setattr(ui_hook, "tune_system_parameters", fake_tune)
+
+    payload = {"performance_metrics": {"m": 0.5}}
+
+    result = await ui_hook.tune_parameters_ui(payload)
+
+    assert result == {"A": 1}
+    assert events == [result]
+    assert called["metrics"] == payload["performance_metrics"]
+
+
+@pytest.mark.asyncio
+async def test_tune_parameters_via_router(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook.ui_hook_manager.register_hook("system_parameters_tuned", listener)
+
+    def fake_tune(metrics):
+        return {"B": 2}
+
+    monkeypatch.setattr(ui_hook, "tune_system_parameters", fake_tune)
+
+    payload = {"performance_metrics": {"x": 0.1}}
+    result = await dispatch_route("tune_parameters", payload)
+
+    assert result == {"B": 2}
+    assert events == [result]


### PR DESCRIPTION
## Summary
- expose `optimization.ui_hook.tune_parameters_ui` to tune system parameters
- register `tune_parameters` route in `frontend_bridge`
- test optimization UI hook and router integration

## Testing
- `pytest tests/ui_hooks/test_optimization_ui_hook.py tests/test_optimization_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ac4cb1c08320aa0f7a0906c071f0