### PR TITLE
Add API bridge for protocol agent management

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -29,6 +29,10 @@ from hypothesis.ui_hook import (
     rank_hypotheses_by_confidence_ui,
     detect_conflicting_hypotheses_ui,
 )
+from protocols.api_bridge import list_agents, launch_agents, step_agents
 
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
+register_route("list_agents", list_agents)
+register_route("launch_agents", launch_agents)
+register_route("step_agents", step_agents)

--- a/protocols/api_bridge.py
+++ b/protocols/api_bridge.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from llm_backends import get_backend
+
+# Active agent instances keyed by name
+ACTIVE_AGENTS: Dict[str, Any] = {}
+
+
+async def list_agents(_payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Return available agent names from ``AGENT_REGISTRY``."""
+    from ._registry import AGENT_REGISTRY
+
+    return {"agents": list(AGENT_REGISTRY.keys())}
+
+
+async def launch_agents(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Instantiate and store selected agents.
+
+    Parameters
+    ----------
+    payload : dict
+        Expected to contain ``"agents"`` list and optional ``"llm_backend"`` name.
+    """
+    names = payload.get("agents", [])
+    if not isinstance(names, list):
+        raise ValueError("payload['agents'] must be a list")
+
+    from ._registry import AGENT_REGISTRY
+
+    backend_name = payload.get("llm_backend")
+    backend_fn = None
+    if backend_name:
+        backend_fn = get_backend(backend_name)
+        if backend_fn is None:
+            raise ValueError(f"Unknown backend {backend_name}")
+
+    launched: List[str] = []
+    for name in names:
+        meta = AGENT_REGISTRY.get(name)
+        if meta is None:
+            continue
+        cls = meta["class"]
+        try:
+            if backend_fn is not None:
+                try:
+                    agent = cls(backend_fn)
+                except TypeError:
+                    agent = cls()
+            else:
+                agent = cls()
+        except Exception:
+            continue
+        ACTIVE_AGENTS[name] = agent
+        start = getattr(agent, "start", None)
+        if callable(start):
+            try:
+                start()
+            except Exception:
+                pass
+        launched.append(name)
+
+    return {"launched": launched}
+
+
+async def step_agents(_payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Trigger ``tick`` on active agents if available."""
+    stepped: List[str] = []
+    for name, agent in list(ACTIVE_AGENTS.items()):
+        tick = getattr(agent, "tick", None)
+        if callable(tick):
+            try:
+                tick()
+                stepped.append(name)
+            except Exception:
+                pass
+    return {"stepped": stepped, "active_agents": list(ACTIVE_AGENTS.keys())}
+
+
+def _reset() -> None:
+    """Clear all active agents (for tests)."""
+    ACTIVE_AGENTS.clear()

--- a/tests/test_api_bridge.py
+++ b/tests/test_api_bridge.py
@@ -1,0 +1,39 @@
+import pytest
+
+from frontend_bridge import dispatch_route, ROUTES
+import protocols.api_bridge as api_bridge
+
+
+class DummyAgent:
+    def __init__(self) -> None:
+        self.started = False
+        self.ticks = 0
+
+    def start(self) -> None:
+        self.started = True
+
+    def tick(self) -> None:
+        self.ticks += 1
+
+
+@pytest.mark.asyncio
+async def test_api_bridge_routes(monkeypatch):
+    import protocols._registry as reg
+    monkeypatch.setattr(reg, "AGENT_REGISTRY", {"DummyAgent": {"class": DummyAgent}})
+    api_bridge._reset()
+
+    assert "list_agents" in ROUTES
+    assert "launch_agents" in ROUTES
+    assert "step_agents" in ROUTES
+
+    listing = await dispatch_route("list_agents", {})
+    assert listing == {"agents": ["DummyAgent"]}
+
+    launch = await dispatch_route("launch_agents", {"agents": ["DummyAgent"]})
+    assert launch == {"launched": ["DummyAgent"]}
+    assert isinstance(api_bridge.ACTIVE_AGENTS.get("DummyAgent"), DummyAgent)
+    assert api_bridge.ACTIVE_AGENTS["DummyAgent"].started is True
+
+    stepped = await dispatch_route("step_agents", {})
+    assert stepped["stepped"] == ["DummyAgent"]
+    assert api_bridge.ACTIVE_AGENTS["DummyAgent"].ticks == 1


### PR DESCRIPTION
## Summary
- implement `protocols/api_bridge.py` with async agent management helpers
- register `list_agents`, `launch_agents`, and `step_agents` routes in `frontend_bridge`
- test new route dispatch and lifecycle handling

## Testing
- `pytest -k test_api_bridge.py -q`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac5c1c7883209263da348167bee9