### PR TITLE
Add protocol agent API bridge

### DIFF
--- a/protocols/ui/api_bridge.py
+++ b/protocols/ui/api_bridge.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from frontend_bridge import register_route
+from llm_backends import get_backend
+from protocols.core.runtime import set_provider_key
+from . import interface_server as server
+
+
+async def list_agents_ui(payload: Dict[str, Any]) -> List[str]:
+    """Return available protocol agent class names."""
+    return list(server.available_agents.keys())
+
+
+async def launch_agents_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Instantiate and launch selected agents."""
+    provider = payload.get("provider")
+    api_key = payload.get("api_key")
+    agents: List[str] = payload.get("agents", [])
+    llm_backend = payload.get("llm_backend")
+
+    if provider and api_key:
+        set_provider_key(provider, api_key)
+
+    backend_fn = None
+    if llm_backend:
+        backend_fn = get_backend(llm_backend)
+        if backend_fn is None:
+            raise ValueError(f"Backend {llm_backend} not found")
+
+    launched = []
+    for name in agents:
+        cls = server.available_agents.get(name)
+        if cls is None:
+            raise ValueError(f"Agent {name} not found")
+        try:
+            if backend_fn is not None:
+                try:
+                    instance = cls(backend_fn)
+                except TypeError:
+                    instance = cls()
+            else:
+                instance = cls()
+            server.active_agents[name] = instance
+            if hasattr(instance, "start") and callable(getattr(instance, "start")):
+                instance.start()
+            launched.append(name)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"Failed to launch {name}: {exc}") from exc
+
+    return {"launched": launched, "provider": provider}
+
+
+async def step_agents_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Trigger one tick on all active agents if they implement ``tick``."""
+    stepped = []
+    for name, agent in server.active_agents.items():
+        tick = getattr(agent, "tick", None)
+        if callable(tick):
+            tick()
+            stepped.append(name)
+    return {"stepped": stepped, "active_agents": list(server.active_agents.keys())}
+
+
+# Register routes with the frontend bridge
+register_route("protocol_agents_list", list_agents_ui)
+register_route("protocol_agents_launch", launch_agents_ui)
+register_route("protocol_agents_step", step_agents_ui)

--- a/tests/ui_hooks/test_protocols.py
+++ b/tests/ui_hooks/test_protocols.py
@@ -1,0 +1,34 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from protocols.ui import api_bridge
+from protocols.ui import interface_server
+
+
+class DummyAgent:
+    def __init__(self):
+        self.ticks = 0
+
+    def tick(self):
+        self.ticks += 1
+
+
+@pytest.mark.asyncio
+async def test_list_agents_via_router(monkeypatch):
+    monkeypatch.setattr(interface_server, "available_agents", {"DummyAgent": DummyAgent}, raising=False)
+    result = await dispatch_route("protocol_agents_list", {})
+    assert result == ["DummyAgent"]
+
+
+@pytest.mark.asyncio
+async def test_launch_and_step_agents_via_router(monkeypatch):
+    monkeypatch.setattr(interface_server, "available_agents", {"DummyAgent": DummyAgent}, raising=False)
+    monkeypatch.setattr(interface_server, "active_agents", {}, raising=False)
+
+    payload = {"provider": "test", "api_key": "k", "agents": ["DummyAgent"]}
+    launch = await dispatch_route("protocol_agents_launch", payload)
+    assert launch == {"launched": ["DummyAgent"], "provider": "test"}
+
+    step = await dispatch_route("protocol_agents_step", {})
+    assert step == {"stepped": ["DummyAgent"], "active_agents": ["DummyAgent"]}
+    assert interface_server.active_agents["DummyAgent"].ticks == 1


### PR DESCRIPTION
## Summary
- add `api_bridge.py` with simple agent APIs and register them with the router
- test listing, launching and stepping agents through the router

## Testing
- `pytest tests/ui_hooks/test_protocols.py -q`
- `pytest -q` *(fails: AttributeError/TypeError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac6dc11c8320bdbba9e4f07d705e