### PR TITLE
Implement hypothesis UI hooks

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -28,7 +28,11 @@ async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 from hypothesis.ui_hook import (
     rank_hypotheses_by_confidence_ui,
     detect_conflicting_hypotheses_ui,
+    rank_hypotheses_ui,
+    synthesize_consensus_ui,
 )
 
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
+register_route("rank_hypotheses", rank_hypotheses_ui)
+register_route("synthesize_consensus", synthesize_consensus_ui)

--- a/hypothesis/ui_hook.py
+++ b/hypothesis/ui_hook.py
@@ -7,6 +7,7 @@ from hook_manager import HookManager
 from hypothesis_reasoner import (
     rank_hypotheses_by_confidence as _rank_hypotheses_by_confidence,
     detect_conflicting_hypotheses as _detect_conflicting_hypotheses,
+    synthesize_consensus_hypothesis as _synthesize_consensus_hypothesis,
 )
 
 ui_hook_manager = HookManager()
@@ -33,3 +34,28 @@ async def detect_conflicting_hypotheses_ui(payload: Dict[str, Any]) -> Dict[str,
         db.close()
     await ui_hook_manager.trigger("hypothesis_conflicts", conflicts)
     return {"conflicts": conflicts}
+
+
+async def rank_hypotheses_ui(payload: Dict[str, Any], db) -> Dict[str, Any]:
+    """Rank hypotheses using provided DB session and emit an event."""
+    try:
+        top_k = int(payload.get("top_k", 5))
+    except (TypeError, ValueError):
+        top_k = 5
+    if top_k <= 0:
+        top_k = 5
+
+    ranking = _rank_hypotheses_by_confidence(db, top_k=top_k)
+    await ui_hook_manager.trigger("hypothesis_ranking", ranking)
+    return {"ranking": ranking}
+
+
+async def synthesize_consensus_ui(payload: Dict[str, Any], db) -> Dict[str, Any]:
+    """Create a consensus hypothesis from ``hypothesis_ids``."""
+    ids = payload.get("hypothesis_ids")
+    if not isinstance(ids, list) or not ids or not all(isinstance(i, str) for i in ids):
+        raise ValueError("'hypothesis_ids' must be a non-empty list of strings")
+
+    new_id = _synthesize_consensus_hypothesis(ids, db)
+    await ui_hook_manager.trigger("consensus_synthesized", new_id)
+    return {"hypothesis_id": new_id}

--- a/tests/test_hypothesis_ui_hook.py
+++ b/tests/test_hypothesis_ui_hook.py
@@ -1,0 +1,62 @@
+import pytest
+
+from hypothesis import ui_hook as hyp_ui_hook
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_rank_hypotheses_ui(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr(hyp_ui_hook, "ui_hook_manager", dummy, raising=False)
+
+    called = {}
+
+    def fake_rank(db, top_k=5):
+        called["args"] = (db, top_k)
+        return [{"id": "h1"}]
+
+    monkeypatch.setattr(
+        hyp_ui_hook, "_rank_hypotheses_by_confidence", fake_rank, raising=False
+    )
+
+    db = object()
+    payload = {"top_k": 3}
+
+    result = await hyp_ui_hook.rank_hypotheses_ui(payload, db)
+
+    assert result == {"ranking": [{"id": "h1"}]}
+    assert called["args"] == (db, 3)
+    assert dummy.events == [("hypothesis_ranking", ([{"id": "h1"}],), {})]
+
+
+@pytest.mark.asyncio
+async def test_synthesize_consensus_ui(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr(hyp_ui_hook, "ui_hook_manager", dummy, raising=False)
+
+    called = {}
+
+    def fake_synth(ids, db):
+        called["args"] = (ids, db)
+        return "H_NEW"
+
+    monkeypatch.setattr(
+        hyp_ui_hook, "_synthesize_consensus_hypothesis", fake_synth, raising=False
+    )
+
+    db = object()
+    payload = {"hypothesis_ids": ["h1", "h2"]}
+
+    result = await hyp_ui_hook.synthesize_consensus_ui(payload, db)
+
+    assert result == {"hypothesis_id": "H_NEW"}
+    assert called["args"] == (payload["hypothesis_ids"], db)
+    assert dummy.events == [("consensus_synthesized", ("H_NEW",), {})]
+


### PR DESCRIPTION
## Summary
- expand `hypothesis.ui_hook` with ranking/consensus helpers
- expose new hooks via `frontend_bridge`
- test `rank_hypotheses_ui` and `synthesize_consensus_ui`

## Testing
- `pytest tests/test_hypothesis_ui_hook.py -q`
- `pytest -q` *(fails: FastAPI object not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac745dd083209e52d376fb48d92f