### PR TITLE
Add reputation update route

### DIFF
--- a/tests/ui_hooks/test_reputation.py
+++ b/tests/ui_hooks/test_reputation.py
@@ -36,3 +36,29 @@ async def test_reputation_analysis_via_router():
     assert "validator_reputations" in result
     assert "stats" in result
     assert calls == [result]
+
+
+@pytest.mark.asyncio
+async def test_reputation_update_via_router(monkeypatch):
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("reputation_update_run", listener)
+
+    called = {}
+
+    def fake_update(vals):
+        called["vals"] = vals
+        return {"reputations": {"v1": 0.7}, "diversity": {"validator_count": 1}}
+
+    monkeypatch.setattr("validators.ui_hook.update_validator_reputations", fake_update)
+
+    payload = {"validations": [{"validator_id": "v1", "score": 0.5}]}
+
+    result = await dispatch_route("reputation_update", payload)
+
+    assert result == {"reputations": {"v1": 0.7}, "diversity": {"validator_count": 1}}
+    assert called["vals"] == payload["validations"]
+    assert events == [result]

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -54,6 +54,31 @@ async def update_reputations_ui(payload: Dict[str, Any], db) -> Dict[str, Any]:
     return result
 
 
+async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Update reputations from UI payload and notify listeners.
+
+    Parameters
+    ----------
+    payload : dict
+        Dictionary containing ``"validations"`` list.
+
+    Returns
+    -------
+    dict
+        Summary with ``reputations`` and ``diversity``.
+    """
+    validations = payload.get("validations", [])
+    result = update_validator_reputations(validations)
+    summary = {
+        "reputations": result.get("reputations", {}),
+        "diversity": result.get("diversity", {}),
+    }
+
+    await ui_hook_manager.trigger("reputation_update_run", summary)
+    return summary
+
+
 # Register with the central frontend router
 register_route("reputation_analysis", compute_reputation_ui)
 register_route("update_validator_reputations", update_reputations_ui)
+register_route("reputation_update", trigger_reputation_update_ui)


### PR DESCRIPTION
## Summary
- expose `trigger_reputation_update_ui` in validators/ui_hook
- register new `reputation_update` route
- test that the route emits hook events via HookManager

## Testing
- `pytest tests/ui_hooks/test_reputation.py -q`
- `pytest tests/ui_hooks/test_reputation.py::test_reputation_update_via_router -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ad3021b0832084be4e5bf23b8ed6