### PR TITLE
Add UI routes for hypothesis ranking and consensus

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -28,10 +28,14 @@ async def dispatch_route(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 from hypothesis.ui_hook import (
     rank_hypotheses_by_confidence_ui,
     detect_conflicting_hypotheses_ui,
+    rank_hypotheses_route,
+    synthesize_consensus_route,
 )
 
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
+register_route("rank_hypotheses", rank_hypotheses_route)
+register_route("synthesize_consensus", synthesize_consensus_route)
 
 # Prediction-related routes
 from predictions.ui_hook import (

--- a/hypothesis/ui_hook.py
+++ b/hypothesis/ui_hook.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from sqlalchemy.orm import Session
+
 from db_models import SessionLocal
 from hook_manager import HookManager
 from hypothesis_reasoner import (
     rank_hypotheses_by_confidence as _rank_hypotheses_by_confidence,
     detect_conflicting_hypotheses as _detect_conflicting_hypotheses,
+    synthesize_consensus_hypothesis as _synthesize_consensus_hypothesis,
 )
 
 ui_hook_manager = HookManager()
@@ -33,3 +36,45 @@ async def detect_conflicting_hypotheses_ui(payload: Dict[str, Any]) -> Dict[str,
         db.close()
     await ui_hook_manager.trigger("hypothesis_conflicts", conflicts)
     return {"conflicts": conflicts}
+
+
+async def rank_hypotheses_ui(payload: Dict[str, Any], db: Session) -> Dict[str, Any]:
+    """Return ranked hypotheses using an existing session."""
+    top_k = payload.get("top_k", 5)
+    try:
+        top_k = int(top_k)
+    except (TypeError, ValueError):
+        top_k = 5
+
+    ranking = _rank_hypotheses_by_confidence(db, top_k=top_k)
+    await ui_hook_manager.trigger("hypothesis_ranking", ranking)
+    return {"ranking": ranking}
+
+
+async def synthesize_consensus_ui(payload: Dict[str, Any], db: Session) -> Dict[str, Any]:
+    """Create a consensus hypothesis from ``hypothesis_ids``."""
+    ids = payload.get("hypothesis_ids")
+    if not isinstance(ids, list) or not ids or not all(isinstance(i, str) for i in ids):
+        raise ValueError("'hypothesis_ids' must be a non-empty list of strings")
+
+    new_id = _synthesize_consensus_hypothesis(ids, db)
+    await ui_hook_manager.trigger("consensus_synthesized", {"hypothesis_id": new_id})
+    return {"hypothesis_id": new_id}
+
+
+async def rank_hypotheses_route(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Route helper for :func:`rank_hypotheses_ui` using ``SessionLocal``."""
+    db = SessionLocal()
+    try:
+        return await rank_hypotheses_ui(payload, db)
+    finally:
+        db.close()
+
+
+async def synthesize_consensus_route(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Route helper for :func:`synthesize_consensus_ui` using ``SessionLocal``."""
+    db = SessionLocal()
+    try:
+        return await synthesize_consensus_ui(payload, db)
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add `rank_hypotheses_ui` and `synthesize_consensus_ui` helpers
- expose route helpers for frontend dispatch
- register `rank_hypotheses` and `synthesize_consensus` in the frontend bridge
- test new routes via `dispatch_route`

## Testing
- `pytest tests/ui_hooks/test_hypothesis.py -q`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'get', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887afe2129c8320978547f63db88138