### PR TITLE
Add temporal consistency UI hook

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -43,3 +43,8 @@ from predictions.ui_hook import (
 register_route("store_prediction", store_prediction_ui)
 register_route("get_prediction", get_prediction_ui)
 register_route("update_prediction_status", update_prediction_status_ui)
+
+# Temporal analysis route
+from temporal.ui_hook import analyze_temporal_ui
+
+register_route("temporal_consistency", analyze_temporal_ui)

--- a/temporal/__init__.py
+++ b/temporal/__init__.py
@@ -1,0 +1,1 @@
+# Package for temporal analysis hooks

--- a/temporal/ui_hook.py
+++ b/temporal/ui_hook.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+from temporal_consistency_checker import analyze_temporal_consistency
+
+# Exposed hook manager for observers
+ui_hook_manager = HookManager()
+
+
+async def analyze_temporal_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run temporal consistency analysis from a UI payload."""
+    validations = payload.get("validations", [])
+    reputations = payload.get("reputations")
+
+    result = analyze_temporal_consistency(validations, reputations)
+    minimal = {
+        "avg_delay_hours": result.get("avg_delay_hours", 0.0),
+        "consensus_volatility": result.get("consensus_volatility", 0.0),
+        "flags": result.get("flags", []),
+    }
+
+    await ui_hook_manager.trigger("temporal_analysis_run", minimal)
+    return minimal
+
+
+register_route("temporal_consistency", analyze_temporal_ui)

--- a/tests/ui_hooks/test_temporal.py
+++ b/tests/ui_hooks/test_temporal.py
@@ -1,0 +1,26 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from temporal.ui_hook import ui_hook_manager
+
+
+@pytest.mark.asyncio
+async def test_temporal_analysis_via_router():
+    events = []
+
+    async def listener(data):
+        events.append(data)
+
+    ui_hook_manager.register_hook("temporal_analysis_run", listener)
+
+    payload = {
+        "validations": [
+            {"timestamp": "2025-01-01T00:00:00Z", "score": 0.5}
+        ]
+    }
+
+    result = await dispatch_route("temporal_consistency", payload)
+
+    assert "avg_delay_hours" in result
+    assert "consensus_volatility" in result
+    assert events == [result]


### PR DESCRIPTION
## Summary
- add `temporal/ui_hook.py` exposing `analyze_temporal_ui`
- register `temporal_consistency` route in `frontend_bridge`
- emit `temporal_analysis_run` events
- test temporal UI hook through `frontend_bridge`

## Testing
- `pytest tests/ui_hooks/test_temporal.py -q`
- `pytest -q` *(fails: AttributeError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887b06699c8832081f8786765c45c9e