### PR TITLE
Add API bridge for agent management

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -43,3 +43,14 @@ from predictions.ui_hook import (
 register_route("store_prediction", store_prediction_ui)
 register_route("get_prediction", get_prediction_ui)
 register_route("update_prediction_status", update_prediction_status_ui)
+
+# Protocol agent management routes
+from protocols.api_bridge import (
+    list_agents_api,
+    launch_agents_api,
+    step_agents_api,
+)
+
+register_route("list_agents", list_agents_api)
+register_route("launch_agents", launch_agents_api)
+register_route("step_agents", step_agents_api)

--- a/protocols/api_bridge.py
+++ b/protocols/api_bridge.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type check only
+    from protocols._registry import AGENT_REGISTRY  # noqa: F401
+
+
+def _registry() -> Dict[str, Dict[str, Any]]:
+    from protocols._registry import AGENT_REGISTRY
+    return AGENT_REGISTRY
+
+from protocols.core.runtime import set_provider_key
+from llm_backends import get_backend
+
+# Active agent instances keyed by name
+active_agents: Dict[str, Any] = {}
+
+
+async def list_agents_api(_: Dict[str, Any] | None = None) -> Dict[str, List[str]]:
+    """Return available agent class names."""
+    return {"agents": list(_registry().keys())}
+
+
+async def launch_agents_api(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Instantiate and start selected agents."""
+    provider = payload.get("provider", "")
+    api_key = payload.get("api_key", "")
+    if provider:
+        set_provider_key(provider, api_key)
+
+    backend_fn = None
+    llm_backend = payload.get("llm_backend")
+    if llm_backend:
+        backend_fn = get_backend(llm_backend)
+        if backend_fn is None:
+            raise ValueError(f"Backend {llm_backend} not found")
+
+    launched: List[str] = []
+    for name in payload.get("agents", []):
+        info = _registry().get(name)
+        if info is None:
+            raise ValueError(f"Agent {name} not found")
+        cls = info["class"]
+        try:
+            if backend_fn is not None:
+                try:
+                    instance = cls(backend_fn)
+                except TypeError:
+                    instance = cls()
+            else:
+                instance = cls()
+        except Exception as exc:  # pragma: no cover - initialization failure
+            raise RuntimeError(f"Failed to launch {name}: {exc}") from exc
+        active_agents[name] = instance
+        start = getattr(instance, "start", None)
+        if callable(start):
+            try:
+                start()
+            except Exception:  # pragma: no cover - best effort
+                pass
+        launched.append(name)
+
+    return {"launched": launched, "active_agents": list(active_agents.keys())}
+
+
+async def step_agents_api(_: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Trigger a single ``tick`` on all active agents."""
+    stepped: List[str] = []
+    for name, agent in active_agents.items():
+        tick = getattr(agent, "tick", None)
+        if callable(tick):
+            try:
+                tick()
+            except Exception:  # pragma: no cover - step errors ignored
+                continue
+            stepped.append(name)
+    return {"stepped": stepped, "active_agents": list(active_agents.keys())}

--- a/tests/test_api_bridge.py
+++ b/tests/test_api_bridge.py
@@ -1,0 +1,50 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+import protocols.api_bridge as api_bridge
+
+
+class DummyAgent:
+    def __init__(self):
+        self.started = False
+        self.ticks = 0
+
+    def start(self):
+        self.started = True
+
+    def tick(self):
+        self.ticks += 1
+
+
+@pytest.mark.asyncio
+async def test_agent_lifecycle(monkeypatch):
+    registry = {"DummyAgent": {"class": DummyAgent}}
+    monkeypatch.setattr(api_bridge, "_registry", lambda: registry, raising=False)
+    api_bridge.active_agents.clear()
+
+    agents = await dispatch_route("list_agents", {})
+    assert agents == {"agents": ["DummyAgent"]}
+
+    launch_result = await dispatch_route(
+        "launch_agents",
+        {"agents": ["DummyAgent"], "provider": "p", "api_key": "k"},
+    )
+    assert launch_result["launched"] == ["DummyAgent"]
+    assert "DummyAgent" in api_bridge.active_agents
+    assert api_bridge.active_agents["DummyAgent"].started
+
+    step_result = await dispatch_route("step_agents", {})
+    assert step_result["stepped"] == ["DummyAgent"]
+    assert api_bridge.active_agents["DummyAgent"].ticks == 1
+
+
+@pytest.mark.asyncio
+async def test_launch_unknown_agent(monkeypatch):
+    monkeypatch.setattr(api_bridge, "_registry", lambda: {}, raising=False)
+    api_bridge.active_agents.clear()
+
+    with pytest.raises(ValueError):
+        await dispatch_route(
+            "launch_agents",
+            {"agents": ["Missing"], "provider": "p", "api_key": "k"},
+        )


### PR DESCRIPTION
## Summary
- implement `protocols.api_bridge` with asynchronous agent lifecycle helpers
- expose `list_agents`, `launch_agents`, and `step_agents` via `frontend_bridge`
- track active agent instances in `api_bridge`
- test route dispatch and agent lifecycle behavior

## Testing
- `pytest tests/test_api_bridge.py -q`
- `pytest -q` *(fails: test_agent_registry.py::test_registry_classes_correct, test_app.py::test_mint_fails_for_low_karma, test_async_fallback_plugin.py::test_async_fallback_plugin, test_audit_bridge.py::test_export_causal_path_handles_malformed_entries, test_audit_bridge.py::test_export_causal_path_handles_non_dict_entries, test_federation_cli.py::test_list_forks_serializes_decimal_config, test_federation_cli.py::test_fork_info_serializes_decimal_config, test_federation_cli_db.py::test_create_fork_success, test_federation_cli_db.py::test_create_fork_invalid_creator, test_federation_cli_db.py::test_create_fork_invalid_config, test_federation_cli_db.py::test_create_fork_cooldown, test_federation_cli_db.py::test_list_forks_and_info, test_federation_cli_db.py::test_fork_info_not_found, test_federation_cli_db.py::test_vote_fork_success_and_duplicate, test_federation_cli_db.py::test_vote_fork_missing_records, test_orm_consistency.py::test_orm_consistency, test_prediction_manager.py::test_prediction_lifecycle, test_prediction_manager.py::test_annual_audit_scheduler, tests/ui_hooks/test_hypothesis.py::test_hypothesis_ui_routes)*

------
https://chatgpt.com/codex/tasks/task_e_6887b098c6bc832095c62c933cc0d756