### PR TITLE
Add universe UI routes

### DIFF
--- a/ui_hooks/universe_ui.py
+++ b/ui_hooks/universe_ui.py
@@ -1,0 +1,50 @@
+"""UI routes for universe interactions.
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+
+
+async def get_universe_overview(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a summary of the selected universe."""
+    universe_id = payload.get("universe_id")
+    return {
+        "universe_id": universe_id,
+        "population": 0,
+        "status": "stable",
+    }
+
+
+async def list_available_proposals(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return proposals available for the universe."""
+    universe_id = payload.get("universe_id")
+    return {
+        "universe_id": universe_id,
+        "proposals": [
+            {"id": 1, "title": "Mock Proposal A"},
+            {"id": 2, "title": "Mock Proposal B"},
+        ],
+    }
+
+
+async def submit_universe_proposal(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Submit a new proposal to the universe."""
+    universe_id = payload.get("universe_id")
+    proposal = payload.get("proposal")
+    return {
+        "universe_id": universe_id,
+        "proposal": proposal,
+        "status": "received",
+    }
+
+
+register_route("get_universe_overview", get_universe_overview)
+register_route("list_available_proposals", list_available_proposals)
+register_route("submit_universe_proposal", submit_universe_proposal)


### PR DESCRIPTION
## Summary
- create `ui_hooks/universe_ui.py` with placeholder universe UI routes
- register new UI routes with `frontend_bridge`

## Testing
- `pytest -q` *(fails: 25 failed, 221 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7ae12348320903580e2754eb623