### PR TITLE
Add proposal engine with filtering and tests

### DIFF
--- a/proposals/engine.py
+++ b/proposals/engine.py
@@ -1,0 +1,80 @@
+"""Lightweight proposal generation engine."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+DEFAULT_PROPOSALS: List[Dict[str, str]] = [
+    {
+        "title": "Annual quantum audit",
+        "description": "Auto-propose annual audits via quantum simulations.",
+    },
+    {
+        "title": "Cross-universe remix bridge",
+        "description": "Enable cross-universe content with provenance tracking.",
+    },
+    {
+        "title": "Karma staking yields",
+        "description": "Implement karma staking for passive yields.",
+    },
+]
+
+
+class ProposalEngine:
+    """Generate governance proposals based on context."""
+
+    def __init__(
+        self,
+        min_karma: int = 0,
+        requires_certification: bool = False,
+        universe_metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.min_karma = min_karma
+        self.requires_certification = requires_certification
+        self.universe_metadata = universe_metadata or {}
+
+    # ------------------------------------------------------------------
+    def generate(self, user: Dict[str, Any], universe_state: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Return proposal suggestions for ``user`` given ``universe_state``."""
+
+        if user.get("karma", 0) < self.min_karma:
+            return []
+        if self.requires_certification and not user.get("is_certified"):
+            return []
+
+        proposals: List[Dict[str, Any]] = []
+        for base in DEFAULT_PROPOSALS:
+            p = dict(base)
+            entropy = universe_state.get("entropy", 0.0)
+            popularity = universe_state.get("popularity", 0.5)
+            p.update(
+                {
+                    "urgency": "high" if entropy > 1.0 else "low",
+                    "popularity": popularity,
+                    "entropy": entropy,
+                }
+            )
+            if self.universe_metadata:
+                p["universe"] = self.universe_metadata
+            proposals.append(p)
+        return proposals
+
+
+# Convenience function -------------------------------------------------
+
+def generate_proposals(
+    user: Dict[str, Any],
+    universe_state: Dict[str, Any],
+    *,
+    min_karma: int = 0,
+    requires_certification: bool = False,
+    universe_metadata: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Generate proposals filtered by ``user`` attributes."""
+
+    engine = ProposalEngine(
+        min_karma=min_karma,
+        requires_certification=requires_certification,
+        universe_metadata=universe_metadata,
+    )
+    return engine.generate(user, universe_state)

--- a/tests/proposals/test_engine.py
+++ b/tests/proposals/test_engine.py
@@ -1,0 +1,29 @@
+from proposals.engine import generate_proposals, DEFAULT_PROPOSALS
+
+
+def test_low_karma_filtered():
+    user = {"karma": 10, "is_certified": True}
+    universe_state = {"entropy": 0.5, "popularity": 0.8}
+
+    proposals = generate_proposals(user, universe_state, min_karma=50)
+
+    assert proposals == []
+
+
+def test_high_karma_receives_proposals():
+    user = {"karma": 100, "is_certified": True}
+    universe_state = {"entropy": 1.2, "popularity": 0.9}
+
+    proposals = generate_proposals(
+        user,
+        universe_state,
+        min_karma=50,
+        requires_certification=True,
+        universe_metadata={"id": "u1"},
+    )
+
+    assert len(proposals) == len(DEFAULT_PROPOSALS)
+    for p in proposals:
+        assert p["urgency"] in {"high", "low"}
+        assert "popularity" in p and "entropy" in p
+        assert p.get("universe") == {"id": "u1"}


### PR DESCRIPTION
## Summary
- add a simple proposal generation engine that filters on karma and certification
- auto-tag generated proposals with urgency, popularity and entropy
- expose `generate_proposals` helper
- test low- and high-karma scenarios

## Testing
- `pytest -q tests/proposals/test_engine.py`
- `pytest -q` *(fails: AttributeError: <module 'requests'> has no attribute 'get', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7c605a88320b291411c4fa5c9f6