### PR TITLE
Add UniverseManager for tracking universes

### DIFF
--- a/universe_manager.py
+++ b/universe_manager.py
@@ -1,0 +1,46 @@
+"""Universe lifecycle management utilities.
+
+This module exposes a :class:`UniverseManager` that tracks universe instances
+and their symbolic metrics (e.g., Harmony Score, Karma). Metadata persists in
+memory for now but can be hooked into the database models later.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+
+class UniverseManager:
+    """Create and retrieve universes with symbolic metrics."""
+
+    def __init__(self) -> None:
+        self._universes: Dict[str, Dict[str, Any]] = {}
+        self._owners: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    def create_universe(self, owner: str, **config: Any) -> str:
+        """Create a new universe and return its ID."""
+
+        universe_id = uuid.uuid4().hex
+        record = {
+            "id": universe_id,
+            "owner": owner,
+            "harmony_score": config.get("harmony_score", 0.0),
+            "karma": config.get("karma", 0.0),
+            "config": config,
+        }
+        self._universes[universe_id] = record
+        self._owners[universe_id] = owner
+        return universe_id
+
+    # ------------------------------------------------------------------
+    def get_universe(self, universe_id: str) -> Optional[Dict[str, Any]]:
+        """Return details for ``universe_id`` if known."""
+
+        return self._universes.get(universe_id)
+
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards


### PR DESCRIPTION
## Summary
- add `UniverseManager` utility class at repository root
- allow creation and retrieval of universes with symbolic metrics
- keep in-memory ownership metadata and note metrics are symbolic only

## Testing
- `pytest tests/test_patch_monitor.py::test_check_patch_compliance -q`
- `pytest -q` *(fails: test suite currently has multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7a794788320aeedcaa591d8d13f