### PR TITLE
Add login router with universe init

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ docker-compose up
 
 The application will be available at [http://localhost:8000](http://localhost:8000).
 
+## Authentication
+
+Register first using `POST /users/register` then obtain a token with `POST /login`.
+The login route returns a JWT and a freshly initialized `universe_id` for your account.
+
 ## 🎛️ Local Streamlit UI
 
 To experiment with the validation analyzer locally, first build the NiceGUI

--- a/login_router.py
+++ b/login_router.py
@@ -1,0 +1,30 @@
+"""FastAPI router providing a login endpoint."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from superNova_2177 import get_db, login_for_access_token, Harmonizer
+from universe_manager import manager as universe_manager
+
+router = APIRouter()
+
+
+@router.post("/login")
+def login_endpoint(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    """Authenticate and create a universe for the user."""
+    token = login_for_access_token(form_data=form_data, db=db)
+    user = (
+        db.query(Harmonizer).filter(Harmonizer.username == form_data.username).first()
+    )
+    universe_id = universe_manager.initialize_for_entity(user.username)
+    return {**token, "universe_id": universe_id}
+
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2519,6 +2519,10 @@ def login_for_access_token(
     access_token = create_access_token({"sub": user.username})
     return {"access_token": access_token, "token_type": "bearer"}
 
+from login_router import router as login_router
+
+app.include_router(login_router)
+
 
 @app.get("/users/me", response_model=HarmonizerOut, tags=["Harmonizers"])
 def read_users_me(current_user: Harmonizer = Depends(get_current_active_user)):

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -1,0 +1,25 @@
+# Universe manager for creating user-specific universes
+from __future__ import annotations
+
+import uuid
+
+
+class UniverseManager:
+    """Simple universe initializer."""
+
+    def __init__(self) -> None:
+        self._universe_map: dict[str, str] = {}
+
+    def initialize_for_entity(self, entity: str) -> str:
+        """Initialize a universe for ``entity`` and return its id."""
+        universe_id = str(uuid.uuid4())
+        self._universe_map[entity] = universe_id
+        return universe_id
+
+
+# Shared default manager
+manager = UniverseManager()
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards


### PR DESCRIPTION
## Summary
- implement `login_router.py` exposing `/login`
- create simple `UniverseManager` for initializing universes
- include router in `superNova_2177.py`
- document new login endpoint in README

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q` *(fails: 25 failed, 221 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7aa748883209bfe2633d2163616