### PR TITLE
Add UI route registrations

### DIFF
--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict
 
 from sqlalchemy.orm import Session
+from frontend_bridge import register_route
 
 # isort: off
 from audit_bridge import (
@@ -90,3 +91,9 @@ async def export_causal_path_ui(payload: Dict[str, Any], **_: Any) -> Dict[str, 
         },
     )
     return result
+
+
+# Register routes with the frontend bridge
+register_route("log_hypothesis", log_hypothesis_ui)
+register_route("attach_trace", attach_trace_ui)
+register_route("export_causal_path", export_causal_path_ui)

--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -71,3 +71,4 @@ async def poll_full_audit_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 register_route("queue_full_audit", queue_full_audit_ui)
 register_route("poll_full_audit", poll_full_audit_ui)
+register_route("trigger_full_audit", trigger_full_audit_ui)

--- a/tests/ui_hooks/test_audit_router.py
+++ b/tests/ui_hooks/test_audit_router.py
@@ -1,0 +1,86 @@
+import json
+import pytest
+from protocols.utils.messaging import MessageHub
+from frontend_bridge import dispatch_route
+import audit.ui_hook as ui_hook
+from audit_bridge import export_causal_path
+from causal_graph import InfluenceGraph
+from db_models import LogEntry, SystemState
+from hooks import events
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_log_hypothesis_route_dispatch(test_db, monkeypatch):
+    hub = MessageHub()
+    dummy = DummyHookManager()
+    monkeypatch.setattr(ui_hook, "message_hub", hub, raising=False)
+    monkeypatch.setattr(ui_hook, "hook_manager", dummy, raising=False)
+
+    payload = {"hypothesis_text": "foo", "causal_node_ids": ["a"]}
+    key = await dispatch_route("log_hypothesis", payload, db=test_db)
+
+    assert test_db.query(SystemState).filter(SystemState.key == key).first() is not None
+    msgs = hub.get_messages("audit_log")
+    assert len(msgs) == 1
+    assert msgs[0].data == {"action": "log_hypothesis", "key": key}
+    assert dummy.events == [(events.AUDIT_LOG, ({"action": "log_hypothesis", "key": key},), {})]
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_route_dispatch(test_db, monkeypatch):
+    hub = MessageHub()
+    dummy = DummyHookManager()
+    monkeypatch.setattr(ui_hook, "message_hub", hub, raising=False)
+    monkeypatch.setattr(ui_hook, "hook_manager", dummy, raising=False)
+
+    log = LogEntry(
+        timestamp=__import__("datetime").datetime.utcnow(),
+        event_type="test",
+        payload=json.dumps({"foo": "bar"}),
+        previous_hash="p",
+        current_hash="c",
+    )
+    test_db.add(log)
+    test_db.commit()
+
+    payload = {"log_id": log.id, "causal_node_ids": ["x"], "summary": "trace"}
+    await dispatch_route("attach_trace", payload, db=test_db)
+
+    refreshed = test_db.query(LogEntry).filter(LogEntry.id == log.id).first()
+    data = json.loads(refreshed.payload)
+    assert data["causal_node_ids"] == ["x"]
+    assert data["causal_commentary"] == "trace"
+
+    msgs = hub.get_messages("audit_log")
+    assert len(msgs) == 1
+    assert msgs[0].data == {"action": "attach_trace", "log_id": log.id}
+    assert dummy.events == [(events.AUDIT_LOG, ({"action": "attach_trace", "log_id": log.id},), {})]
+
+
+@pytest.mark.asyncio
+async def test_export_causal_path_route_dispatch(monkeypatch):
+    g = InfluenceGraph()
+    g.add_causal_node("A")
+    g.add_causal_node("B")
+    g.add_edge("A", "B")
+
+    hub = MessageHub()
+    monkeypatch.setattr(ui_hook, "message_hub", hub, raising=False)
+
+    payload = {"graph": g, "node_id": "B", "direction": "ancestors", "depth": 3}
+    result = await dispatch_route("export_causal_path", payload)
+
+    expected = export_causal_path(g, "B", direction="ancestors", depth=3)
+    assert result == expected
+
+    msgs = hub.get_messages("audit_log")
+    assert len(msgs) == 1
+    assert msgs[0].data == {"action": "export_causal_path", "node_id": "B", "direction": "ancestors"}

--- a/tests/ui_hooks/test_introspection_routes.py
+++ b/tests/ui_hooks/test_introspection_routes.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import MagicMock
+
+from frontend_bridge import dispatch_route
+import introspection.ui_hook as iuh
+from hooks import events
+
+
+class DummyHookManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_trigger_full_audit_route(monkeypatch):
+    dummy = DummyHookManager()
+    monkeypatch.setattr(iuh, "ui_hook_manager", dummy, raising=False)
+
+    calls = {}
+
+    def fake_run(hid, db):
+        calls["run"] = (hid, db)
+        return {"bundle": True}
+
+    monkeypatch.setattr(iuh, "run_full_audit", fake_run)
+
+    db = MagicMock()
+    payload = {"hypothesis_id": "H1"}
+    result = await dispatch_route("trigger_full_audit", payload, db=db)
+
+    assert result == {"bundle": True}
+    assert calls["run"] == ("H1", db)
+    assert dummy.events == [(events.FULL_AUDIT_COMPLETED, ({"bundle": True},), {})]


### PR DESCRIPTION
## Summary
- expose audit hooks via frontend_bridge
- add introspection route for full audits
- test audit routes through dispatch_route
- test trigger_full_audit via dispatch_route

## Testing
- `pytest tests/ui_hooks/test_audit_router.py tests/ui_hooks/test_introspection_routes.py -q`
- `pytest -q` *(fails: KeyError: 'trigger_meta_evaluation', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6887b7d547288320b7a9fb9b4556462c