### PR TITLE
Add router documentation and introspection helper

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,47 @@
+# UI Routes
+
+This document lists the default routes registered with `frontend_bridge`.
+Each route name is dispatched via `dispatch_route` and maps to a
+backend handler.
+
+| Route | Description |
+|-------|-------------|
+|`list_routes`|Return the names of all registered routes.|
+|`describe_routes`|Return each route name with its handler docstring.|
+|`rank_hypotheses_by_confidence`|Rank hypotheses using the reasoning layer.|
+|`detect_conflicting_hypotheses`|Detect contradictions between hypotheses.|
+|`register_hypothesis`|Register a new hypothesis and emit an event.|
+|`update_hypothesis_score`|Update a hypothesis score.|
+|`store_prediction`|Persist prediction information.|
+|`get_prediction`|Retrieve a stored prediction.|
+|`update_prediction_status`|Modify prediction status and outcome.|
+|`list_agents`|List available protocol agent instances.|
+|`launch_agents`|Instantiate selected protocol agents.|
+|`step_agents`|Run a single tick on active agents.|
+|`temporal_consistency`|Analyze temporal consistency across validations.|
+|`tune_parameters`|Tune system parameters from metrics.|
+|`forecast_consensus`|Forecast consensus trend from validations.|
+|`queue_consensus_forecast`|Start an asynchronous consensus forecast.|
+|`poll_consensus_forecast`|Check the status of a forecast job.|
+|`coordination_analysis`|Run a network coordination risk analysis.|
+|`queue_coordination_analysis`|Queue coordination analysis as a job.|
+|`poll_coordination_analysis`|Poll the status of a coordination job.|
+|`reputation_analysis`|Compute validator reputations from data.|
+|`update_validator_reputations`|Persist validator reputation updates.|
+|`reputation_update`|Update reputations and return summary.|
+|`compute_diversity`|Calculate network diversity metrics.|
+|`cross_universe_register_bridge`|Register cross-universe provenance data.|
+|`cross_universe_get_provenance`|Retrieve provenance information for a coin.|
+|`inspect_suggestion`|Inspect a suggestion using the Guardian agent.|
+|`propose_fix`|Propose a fix through the Guardian agent.|
+|`generate_midi`|Generate a short MIDI snippet.|
+|`protocol_agents_list`|Return names of available protocol agent classes.|
+|`protocol_agents_launch`|Launch protocol agents with optional backend.|
+|`protocol_agents_step`|Trigger a single step on running protocol agents.|
+|`queue_full_audit`|Queue a full introspection audit job.|
+|`poll_full_audit`|Poll the status of an introspection audit.|
+|`explain_audit`|Create a textual explanation for an audit trace.|
+
+These routes are provided for research purposes only. STRICTLY A SOCIAL MEDIA PLATFORM.
+They incorporate Intellectual Property & Artistic Inspiration protections
+and follow Legal & Ethical Safeguards for community use.

--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -1,8 +1,30 @@
-"""Lightweight router for UI callbacks."""
+"""Lightweight router for UI callbacks.
+
+This module exposes a simple registry mapping route names to callables.
+Handlers register themselves with :func:`register_route` and can be
+executed using :func:`dispatch_route`. The built-in handlers cover
+hypothesis management, prediction storage and protocol operations.
+
+The :data:`ROUTES` dictionary holds the active mapping. Debug helpers
+``list_routes`` and ``describe_routes`` reveal the currently registered
+names and their docstrings. See ``docs/routes.md`` for a reference table
+of default routes.
+"""
 
 from __future__ import annotations
 
 from typing import Any, Awaitable, Callable, Dict, Union
+
+from hypothesis.ui_hook import (detect_conflicting_hypotheses_ui,
+                                rank_hypotheses_by_confidence_ui,
+                                register_hypothesis_ui,
+                                update_hypothesis_score_ui)
+from optimization.ui_hook import tune_parameters_ui
+from predictions.ui_hook import (get_prediction_ui, store_prediction_ui,
+                                 update_prediction_status_ui)
+from protocols.api_bridge import (launch_agents_api, list_agents_api,
+                                  step_agents_api)
+from temporal.ui_hook import analyze_temporal_ui
 
 Handler = Callable[..., Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
 
@@ -17,11 +39,7 @@ def register_route(name: str, func: Handler) -> None:
 async def dispatch_route(
     name: str, payload: Dict[str, Any], **kwargs: Any
 ) -> Dict[str, Any]:
-    """Dispatch ``payload`` to the registered handler.
-
-    Additional keyword arguments are forwarded to the handler. This allows
-    callers to provide context objects like database sessions.
-    """
+    """Dispatch ``payload`` to the registered handler."""
     if name not in ROUTES:
         raise KeyError(name)
     handler = ROUTES[name]
@@ -31,62 +49,42 @@ async def dispatch_route(
     return result
 
 
-
 def _list_routes(_: Dict[str, Any]) -> Dict[str, Any]:
     """Return the names of all registered routes."""
     return {"routes": sorted(ROUTES.keys())}
 
 
-register_route("list_routes", _list_routes)
-
-# Built-in hypothesis-related routes
-from hypothesis.ui_hook import (
-    rank_hypotheses_by_confidence_ui,
-    detect_conflicting_hypotheses_ui,
-    register_hypothesis_ui,
-    update_hypothesis_score_ui,
-    rank_hypotheses_ui,
-    synthesize_consensus_ui,
-)
-from hypothesis_meta_evaluator_ui_hook import trigger_meta_evaluation_ui
-from hypothesis_reasoner_ui_hook import auto_flag_stale_ui
-from validation_certifier_ui_hook import run_integrity_analysis_ui
-from validator_reputation_tracker_ui_hook import update_reputations_ui
-from consensus_forecaster_agent_ui_hook import forecast_consensus_ui
+def describe_routes(_: Dict[str, Any]) -> Dict[str, Any]:
+    """Return each route name mapped to the handler's docstring."""
+    descriptions = {
+        name: (getattr(func, "__doc__", "") or "").strip()
+        for name, func in ROUTES.items()
+    }
+    return {"routes": descriptions}
 
 
+# Hypothesis related routes
 register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
 register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
 register_route("register_hypothesis", register_hypothesis_ui)
 register_route("update_hypothesis_score", update_hypothesis_score_ui)
 
-# Prediction-related routes
-from predictions.ui_hook import (
-    store_prediction_ui,
-    get_prediction_ui,
-    update_prediction_status_ui,
-)
-
-from optimization.ui_hook import tune_parameters_ui
-
+# Prediction routes
 register_route("store_prediction", store_prediction_ui)
 register_route("get_prediction", get_prediction_ui)
 register_route("update_prediction_status", update_prediction_status_ui)
 
 # Protocol agent management routes
-from protocols.api_bridge import (
-    list_agents_api,
-    launch_agents_api,
-    step_agents_api,
-)
-
 register_route("list_agents", list_agents_api)
 register_route("launch_agents", launch_agents_api)
 register_route("step_agents", step_agents_api)
-# Temporal analysis route
-from temporal.ui_hook import analyze_temporal_ui
 
+# Temporal analysis route
 register_route("temporal_consistency", analyze_temporal_ui)
 
-# Optimization-related route
+# Optimization route
 register_route("tune_parameters", tune_parameters_ui)
+
+# Debugging helpers
+register_route("list_routes", _list_routes)
+register_route("describe_routes", describe_routes)


### PR DESCRIPTION
## Summary
- expand `frontend_bridge` module docstring
- add `describe_routes` helper and register all routes after imports
- document available routes in `docs/routes.md`

## Testing
- `pre-commit run --files frontend_bridge.py docs/routes.md`

------
https://chatgpt.com/codex/tasks/task_e_6887b7ddb1488320bce4429fd496f7f1