### PR TITLE
Add ui hook imports and route listing test

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -31,7 +31,6 @@ async def dispatch_route(
     return result
 
 
-
 def _list_routes(_: Dict[str, Any]) -> Dict[str, Any]:
     """Return the names of all registered routes."""
     return {"routes": sorted(ROUTES.keys())}
@@ -90,3 +89,13 @@ register_route("temporal_consistency", analyze_temporal_ui)
 
 # Optimization-related route
 register_route("tune_parameters", tune_parameters_ui)
+
+# Import additional UI hooks for side effects (route registration)
+import network.ui_hook  # noqa: F401,E402 - registers network analysis routes
+import consensus.ui_hook  # noqa: F401,E402 - registers consensus forecast routes
+import validators.ui_hook  # noqa: F401,E402 - registers validator reputation routes
+import audit.ui_hook  # noqa: F401,E402 - exposes audit utilities
+import introspection.ui_hook  # noqa: F401,E402 - registers introspection routes
+import protocols.ui_hook  # noqa: F401,E402 - registers cross-universe bridge routes
+import protocols.agents.guardian_ui_hook  # noqa: F401,E402 - guardian agent routes
+import protocols.agents.harmony_ui_hook  # noqa: F401,E402 - harmony synth route

--- a/tests/ui_hooks/test_route_listing.py
+++ b/tests/ui_hooks/test_route_listing.py
@@ -1,0 +1,29 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+
+
+@pytest.mark.asyncio
+async def test_list_routes_contains_all_registered():
+    result = await dispatch_route("list_routes", {})
+    routes = set(result["routes"])
+    expected = {
+        "coordination_analysis",
+        "queue_coordination_analysis",
+        "poll_coordination_analysis",
+        "forecast_consensus",
+        "queue_consensus_forecast",
+        "poll_consensus_forecast",
+        "reputation_analysis",
+        "update_validator_reputations",
+        "reputation_update",
+        "compute_diversity",
+        "queue_full_audit",
+        "poll_full_audit",
+        "cross_universe_register_bridge",
+        "cross_universe_get_provenance",
+        "inspect_suggestion",
+        "propose_fix",
+        "generate_midi",
+    }
+    assert expected.issubset(routes)  # nosec B101


### PR DESCRIPTION
## Summary
- import several ui hooks in `frontend_bridge.py`
- ensure `dispatch_route` exposes those routes
- test available routes

## Testing
- `pre-commit` *(fails: isort modified files)*
- `pytest -q` *(fails: FastAPI object not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7e960b88320a8c197ac0c7e4a6c