### PR TITLE
Implement prediction manager UI hooks

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -66,12 +66,18 @@ from predictions.ui_hook import (
     get_prediction_ui,
     update_prediction_status_ui,
 )
+from prediction_manager.ui_hook import (
+    save_prediction_ui,
+    get_prediction_ui as manager_get_prediction_ui,
+)
 
 from optimization.ui_hook import tune_parameters_ui
 
 register_route("store_prediction", store_prediction_ui)
 register_route("get_prediction", get_prediction_ui)
 register_route("update_prediction_status", update_prediction_status_ui)
+register_route("save_prediction", save_prediction_ui)
+register_route("get_saved_prediction", manager_get_prediction_ui)
 
 # Protocol agent management routes
 from protocols.api_bridge import (

--- a/prediction_manager/__init__.py
+++ b/prediction_manager/__init__.py
@@ -1,4 +1,6 @@
 """Management service for system predictions and experiments."""
+__all__ = ["PredictionManager"]
+
 
 import json
 import uuid

--- a/prediction_manager/ui_hook.py
+++ b/prediction_manager/ui_hook.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from hook_manager import HookManager
+from . import PredictionManager
+
+# Hook manager to allow observers to listen for prediction events
+ui_hook_manager = HookManager()
+
+# Global PredictionManager instance, configured by the application
+prediction_manager: Optional[PredictionManager] = None
+
+
+async def save_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist prediction data coming from the UI."""
+    if prediction_manager is None:
+        raise RuntimeError("prediction_manager not configured")
+
+    data = payload.get("prediction", payload)
+    prediction_id = prediction_manager.store_prediction(data)
+    await ui_hook_manager.trigger("prediction_saved", {"prediction_id": prediction_id})
+    return {"prediction_id": prediction_id}
+
+
+async def get_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return prediction data previously stored."""
+    if prediction_manager is None:
+        raise RuntimeError("prediction_manager not configured")
+
+    prediction_id = payload["prediction_id"]
+    record = prediction_manager.get_prediction(prediction_id)
+    await ui_hook_manager.trigger("prediction_loaded", record)
+    return record or {}

--- a/tests/ui_hooks/test_prediction_manager_ui.py
+++ b/tests/ui_hooks/test_prediction_manager_ui.py
@@ -1,0 +1,31 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+from prediction_manager import ui_hook as pm_ui_hook
+
+
+class DummyManager:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def store_prediction(self, data):
+        self.calls.append(("store", data))
+        return "pid42"
+
+    def get_prediction(self, pid):
+        self.calls.append(("get", pid))
+        return {"prediction_id": pid, "data": {"bar": 2}}
+
+
+@pytest.mark.asyncio
+async def test_prediction_manager_routes(monkeypatch):
+    mgr = DummyManager()
+    monkeypatch.setattr(pm_ui_hook, "prediction_manager", mgr, raising=False)
+
+    res1 = await dispatch_route("save_prediction", {"prediction": {"bar": 2}})
+    assert res1 == {"prediction_id": "pid42"}
+
+    res2 = await dispatch_route("get_saved_prediction", {"prediction_id": "pid42"})
+    assert res2 == {"prediction_id": "pid42", "data": {"bar": 2}}
+
+    assert mgr.calls == [("store", {"bar": 2}), ("get", "pid42")]


### PR DESCRIPTION
## Summary
- expose `save_prediction_ui` and `get_prediction_ui` in new package `prediction_manager`
- register the new prediction manager routes in `frontend_bridge`
- add tests for prediction manager UI routes
- move `prediction_manager.py` into a package to allow submodules

## Testing
- `pytest tests/test_prediction_manager.py tests/ui_hooks/test_predictions.py tests/ui_hooks/test_prediction_manager_ui.py -q`
- `pytest -q` *(fails: AttributeError: <module 'requests'> has no attribute 'get', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887b7fffac4832092a2d8cc55ad37bc