### PR TITLE
Add route descriptions and help endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,17 +353,18 @@ After the build completes, you'll get a shareable URL to interact with the valid
 ## 🤝 UI Integration
 
 The `frontend_bridge` module exposes a lightweight router for the UI. Handlers
-register themselves with `register_route(name, func)` and are invoked through
-`dispatch_route`.
+register themselves with
+`register_route(name, func, description="", category="general")` and are invoked
+through `dispatch_route`.
 
-A convenient read-only route `"list_routes"` returns the currently available
-route names. This can help debug which backend callbacks are present:
+A convenient `"help"` (or legacy `"list_routes"`) endpoint returns the
+available routes grouped by category with short descriptions:
 
 ```python
 from frontend_bridge import dispatch_route
 
-routes = await dispatch_route("list_routes", {})
-print(routes["routes"])
+info = await dispatch_route("help", {})
+print(info["routes"]["prediction"])
 ```
 
 ## 🧪 Running Tests

--- a/audit/explainer_ui_hook.py
+++ b/audit/explainer_ui_hook.py
@@ -39,4 +39,9 @@ async def _explain_audit_route(payload: Dict[str, Any]) -> str:
 
 
 # Register route with the central frontend bridge
-register_route("explain_audit", _explain_audit_route)
+register_route(
+    "explain_audit",
+    _explain_audit_route,
+    description="Generate commentary for an audit trace",
+    category="audit",
+)

--- a/consensus/ui_hook.py
+++ b/consensus/ui_hook.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from consensus_forecaster_agent import forecast_consensus_trend
 from frontend_bridge import register_route
 from hook_manager import HookManager
 from hooks import events
 from protocols.core import JobQueueAgent
-from consensus_forecaster_agent import forecast_consensus_trend
 
 # Exposed hook manager for observers
 ui_hook_manager = HookManager()
@@ -61,6 +61,21 @@ async def poll_consensus_forecast_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the frontend bridge
-register_route("forecast_consensus", forecast_consensus_ui)
-register_route("queue_consensus_forecast", queue_consensus_forecast_ui)
-register_route("poll_consensus_forecast", poll_consensus_forecast_ui)
+register_route(
+    "forecast_consensus",
+    forecast_consensus_ui,
+    description="Forecast consensus trend",
+    category="consensus",
+)
+register_route(
+    "queue_consensus_forecast",
+    queue_consensus_forecast_ui,
+    description="Queue consensus forecast",
+    category="consensus",
+)
+register_route(
+    "poll_consensus_forecast",
+    poll_consensus_forecast_ui,
+    description="Check forecast job status",
+    category="consensus",
+)

--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Dict, Union
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Union
 
 Handler = Callable[..., Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
 
-ROUTES: Dict[str, Handler] = {}
+
+@dataclass
+class RouteInfo:
+    handler: Handler
+    description: str = ""
+    category: str = "general"
 
 
-def register_route(name: str, func: Handler) -> None:
+ROUTES: Dict[str, RouteInfo] = {}
+
+
+def register_route(
+    name: str,
+    func: Handler,
+    description: str | None = None,
+    category: str = "general",
+) -> None:
     """Register a handler for ``name`` events."""
-    ROUTES[name] = func
+    ROUTES[name] = RouteInfo(func, description or "", category)
 
 
 async def dispatch_route(
@@ -24,69 +38,139 @@ async def dispatch_route(
     """
     if name not in ROUTES:
         raise KeyError(name)
-    handler = ROUTES[name]
+    handler = ROUTES[name].handler
     result = handler(payload, **kwargs)
     if isinstance(result, Awaitable):
         result = await result
     return result
 
 
-
 def _list_routes(_: Dict[str, Any]) -> Dict[str, Any]:
-    """Return the names of all registered routes."""
-    return {"routes": sorted(ROUTES.keys())}
+    """Return registered routes grouped by category."""
+    grouped: Dict[str, List[Dict[str, str]]] = {}
+    for name, info in ROUTES.items():
+        entry = {
+            "name": name,
+            "description": info.description or (info.handler.__doc__ or ""),
+        }
+        grouped.setdefault(info.category, []).append(entry)
+
+    for routes in grouped.values():
+        routes.sort(key=lambda r: r["name"])
+
+    return {"routes": grouped}
 
 
-register_route("list_routes", _list_routes)
-
-# Built-in hypothesis-related routes
-from hypothesis.ui_hook import (
-    rank_hypotheses_by_confidence_ui,
-    detect_conflicting_hypotheses_ui,
-    register_hypothesis_ui,
-    update_hypothesis_score_ui,
-    rank_hypotheses_ui,
-    synthesize_consensus_ui,
+register_route(
+    "list_routes",
+    _list_routes,
+    description="List available routes",
+    category="meta",
 )
+register_route(
+    "help",
+    _list_routes,
+    description="List available routes",
+    category="meta",
+)
+
+from consensus_forecaster_agent_ui_hook import forecast_consensus_ui
+# Built-in hypothesis-related routes
+from hypothesis.ui_hook import (detect_conflicting_hypotheses_ui,
+                                rank_hypotheses_by_confidence_ui,
+                                rank_hypotheses_ui, register_hypothesis_ui,
+                                synthesize_consensus_ui,
+                                update_hypothesis_score_ui)
 from hypothesis_meta_evaluator_ui_hook import trigger_meta_evaluation_ui
 from hypothesis_reasoner_ui_hook import auto_flag_stale_ui
 from validation_certifier_ui_hook import run_integrity_analysis_ui
 from validator_reputation_tracker_ui_hook import update_reputations_ui
-from consensus_forecaster_agent_ui_hook import forecast_consensus_ui
 
-
-register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
-register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
-register_route("register_hypothesis", register_hypothesis_ui)
-register_route("update_hypothesis_score", update_hypothesis_score_ui)
-
-# Prediction-related routes
-from predictions.ui_hook import (
-    store_prediction_ui,
-    get_prediction_ui,
-    update_prediction_status_ui,
+register_route(
+    "rank_hypotheses_by_confidence",
+    rank_hypotheses_by_confidence_ui,
+    description="Rank hypotheses by confidence",
+    category="hypothesis",
+)
+register_route(
+    "detect_conflicting_hypotheses",
+    detect_conflicting_hypotheses_ui,
+    description="Find conflicting hypotheses",
+    category="hypothesis",
+)
+register_route(
+    "register_hypothesis",
+    register_hypothesis_ui,
+    description="Register a new hypothesis",
+    category="hypothesis",
+)
+register_route(
+    "update_hypothesis_score",
+    update_hypothesis_score_ui,
+    description="Update hypothesis score",
+    category="hypothesis",
 )
 
 from optimization.ui_hook import tune_parameters_ui
+# Prediction-related routes
+from predictions.ui_hook import (get_prediction_ui, store_prediction_ui,
+                                 update_prediction_status_ui)
 
-register_route("store_prediction", store_prediction_ui)
-register_route("get_prediction", get_prediction_ui)
-register_route("update_prediction_status", update_prediction_status_ui)
-
-# Protocol agent management routes
-from protocols.api_bridge import (
-    list_agents_api,
-    launch_agents_api,
-    step_agents_api,
+register_route(
+    "store_prediction",
+    store_prediction_ui,
+    description="Persist prediction data",
+    category="prediction",
+)
+register_route(
+    "get_prediction",
+    get_prediction_ui,
+    description="Fetch a prediction record",
+    category="prediction",
+)
+register_route(
+    "update_prediction_status",
+    update_prediction_status_ui,
+    description="Update prediction status",
+    category="prediction",
 )
 
-register_route("list_agents", list_agents_api)
-register_route("launch_agents", launch_agents_api)
-register_route("step_agents", step_agents_api)
+# Protocol agent management routes
+from protocols.api_bridge import (launch_agents_api, list_agents_api,
+                                  step_agents_api)
+
+register_route(
+    "list_agents",
+    list_agents_api,
+    description="Return available agent classes",
+    category="agents",
+)
+register_route(
+    "launch_agents",
+    launch_agents_api,
+    description="Instantiate and start agents",
+    category="agents",
+)
+register_route(
+    "step_agents",
+    step_agents_api,
+    description="Trigger one tick on active agents",
+    category="agents",
+)
 # Temporal analysis route
 from temporal.ui_hook import analyze_temporal_ui
 
-register_route("temporal_consistency", analyze_temporal_ui)
+register_route(
+    "temporal_consistency",
+    analyze_temporal_ui,
+    description="Analyze temporal consistency",
+    category="temporal",
+)
 
 # Optimization-related route
-register_route("tune_parameters", tune_parameters_ui)
+register_route(
+    "tune_parameters",
+    tune_parameters_ui,
+    description="Tune system parameters",
+    category="optimization",
+)

--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from frontend_bridge import register_route
-from db_models import SessionLocal
-from protocols.core import JobQueueAgent
-
 from sqlalchemy.orm import Session
 
+from db_models import SessionLocal
+from frontend_bridge import register_route
 from hook_manager import HookManager
 from hooks import events
+from protocols.core import JobQueueAgent
 
 from .introspection_pipeline import run_full_audit
 
@@ -69,5 +68,15 @@ async def poll_full_audit_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return queue_agent.get_status(job_id)
 
 
-register_route("queue_full_audit", queue_full_audit_ui)
-register_route("poll_full_audit", poll_full_audit_ui)
+register_route(
+    "queue_full_audit",
+    queue_full_audit_ui,
+    description="Queue a full introspection audit",
+    category="introspection",
+)
+register_route(
+    "poll_full_audit",
+    poll_full_audit_ui,
+    description="Check queued audit status",
+    category="introspection",
+)

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -69,9 +69,24 @@ async def poll_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, An
 
 
 # Register with the central frontend router
-register_route("coordination_analysis", trigger_coordination_analysis_ui)
-register_route("queue_coordination_analysis", queue_coordination_analysis_ui)
-register_route("poll_coordination_analysis", poll_coordination_analysis_ui)
+register_route(
+    "coordination_analysis",
+    trigger_coordination_analysis_ui,
+    description="Run coordination analysis",
+    category="network",
+)
+register_route(
+    "queue_coordination_analysis",
+    queue_coordination_analysis_ui,
+    description="Queue coordination analysis",
+    category="network",
+)
+register_route(
+    "poll_coordination_analysis",
+    poll_coordination_analysis_ui,
+    description="Check coordination job status",
+    category="network",
+)
 
 
 async def run_coordination_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/optimization/ui_hook.py
+++ b/optimization/ui_hook.py
@@ -19,4 +19,9 @@ async def tune_parameters_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route("tune_parameters", tune_parameters_ui)
+register_route(
+    "tune_parameters",
+    tune_parameters_ui,
+    description="Tune system parameters",
+    category="optimization",
+)

--- a/predictions/ui_hook.py
+++ b/predictions/ui_hook.py
@@ -20,9 +20,7 @@ async def store_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     prediction_data = payload.get("prediction", payload)
     prediction_id = prediction_manager.store_prediction(prediction_data)
-    await ui_hook_manager.trigger(
-        "prediction_stored", {"prediction_id": prediction_id}
-    )
+    await ui_hook_manager.trigger("prediction_stored", {"prediction_id": prediction_id})
     return {"prediction_id": prediction_id}
 
 
@@ -49,12 +47,28 @@ async def update_prediction_status_ui(payload: Dict[str, Any]) -> Dict[str, Any]
         prediction_id, new_status, actual_outcome=outcome
     )
     await ui_hook_manager.trigger(
-        "prediction_status_updated", {"prediction_id": prediction_id, "status": new_status}
+        "prediction_status_updated",
+        {"prediction_id": prediction_id, "status": new_status},
     )
     return {"prediction_id": prediction_id, "status": new_status}
 
 
 # Register routes with the frontend bridge
-register_route("store_prediction", store_prediction_ui)
-register_route("get_prediction", get_prediction_ui)
-register_route("update_prediction_status", update_prediction_status_ui)
+register_route(
+    "store_prediction",
+    store_prediction_ui,
+    description="Store a prediction record",
+    category="prediction",
+)
+register_route(
+    "get_prediction",
+    get_prediction_ui,
+    description="Retrieve a prediction record",
+    category="prediction",
+)
+register_route(
+    "update_prediction_status",
+    update_prediction_status_ui,
+    description="Update prediction status",
+    category="prediction",
+)

--- a/protocols/agents/guardian_ui_hook.py
+++ b/protocols/agents/guardian_ui_hook.py
@@ -28,5 +28,15 @@ async def propose_fix_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route("inspect_suggestion", inspect_suggestion_ui)
-register_route("propose_fix", propose_fix_ui)
+register_route(
+    "inspect_suggestion",
+    inspect_suggestion_ui,
+    description="Inspect a suggestion",
+    category="guardian",
+)
+register_route(
+    "propose_fix",
+    propose_fix_ui,
+    description="Propose a guardian fix",
+    category="guardian",
+)

--- a/protocols/agents/harmony_ui_hook.py
+++ b/protocols/agents/harmony_ui_hook.py
@@ -28,4 +28,9 @@ async def generate_midi_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the central frontend router
-register_route("generate_midi", generate_midi_ui)
+register_route(
+    "generate_midi",
+    generate_midi_ui,
+    description="Generate a MIDI snippet",
+    category="harmony",
+)

--- a/protocols/ui/api_bridge.py
+++ b/protocols/ui/api_bridge.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 from frontend_bridge import register_route
 from llm_backends import get_backend
 from protocols.core.runtime import set_provider_key
+
 from . import interface_server as server
 
 
@@ -64,6 +65,21 @@ async def step_agents_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register routes with the frontend bridge
-register_route("protocol_agents_list", list_agents_ui)
-register_route("protocol_agents_launch", launch_agents_ui)
-register_route("protocol_agents_step", step_agents_ui)
+register_route(
+    "protocol_agents_list",
+    list_agents_ui,
+    description="List available protocol agents",
+    category="protocols",
+)
+register_route(
+    "protocol_agents_launch",
+    launch_agents_ui,
+    description="Launch protocol agents",
+    category="protocols",
+)
+register_route(
+    "protocol_agents_step",
+    step_agents_ui,
+    description="Step active protocol agents",
+    category="protocols",
+)

--- a/protocols/ui_hook.py
+++ b/protocols/ui_hook.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List
 from frontend_bridge import register_route
 from hook_manager import HookManager
 from hooks import events
-
-from protocols.agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
+from protocols.agents.cross_universe_bridge_agent import \
+    CrossUniverseBridgeAgent
 
 # Exposed hook manager and agent instance
 bridge_hook_manager = HookManager()
@@ -28,5 +28,15 @@ async def get_provenance_ui(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 # Register with the central frontend router
-register_route("cross_universe_register_bridge", register_bridge_ui)
-register_route("cross_universe_get_provenance", get_provenance_ui)
+register_route(
+    "cross_universe_register_bridge",
+    register_bridge_ui,
+    description="Register cross-universe bridge data",
+    category="protocols",
+)
+register_route(
+    "cross_universe_get_provenance",
+    get_provenance_ui,
+    description="Retrieve cross-universe provenance",
+    category="protocols",
+)

--- a/temporal/ui_hook.py
+++ b/temporal/ui_hook.py
@@ -26,4 +26,9 @@ async def analyze_temporal_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route("temporal_consistency", analyze_temporal_ui)
+register_route(
+    "temporal_consistency",
+    analyze_temporal_ui,
+    description="Analyze temporal consistency",
+    category="temporal",
+)

--- a/tests/test_frontend_bridge.py
+++ b/tests/test_frontend_bridge.py
@@ -1,9 +1,10 @@
 import pytest
 
-from frontend_bridge import dispatch_route, ROUTES
+from frontend_bridge import ROUTES, dispatch_route
 
 
 @pytest.mark.asyncio
 async def test_list_routes_returns_registered_names():
     result = await dispatch_route("list_routes", {})
-    assert set(result["routes"]) == set(ROUTES.keys())
+    names = [r["name"] for grp in result["routes"].values() for r in grp]
+    assert set(names) == set(ROUTES.keys())

--- a/ui_hooks/universe_ui.py
+++ b/ui_hooks/universe_ui.py
@@ -45,6 +45,21 @@ async def submit_universe_proposal(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-register_route("get_universe_overview", get_universe_overview)
-register_route("list_available_proposals", list_available_proposals)
-register_route("submit_universe_proposal", submit_universe_proposal)
+register_route(
+    "get_universe_overview",
+    get_universe_overview,
+    description="Summarize a universe",
+    category="universe",
+)
+register_route(
+    "list_available_proposals",
+    list_available_proposals,
+    description="List proposals for a universe",
+    category="universe",
+)
+register_route(
+    "submit_universe_proposal",
+    submit_universe_proposal,
+    description="Submit a universe proposal",
+    category="universe",
+)

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
+from diversity_analyzer import compute_diversity_score
 from frontend_bridge import register_route
 from hook_manager import HookManager
 from hooks import events
 from validator_reputation_tracker import update_validator_reputations
-from diversity_analyzer import compute_diversity_score
 
 from .reputation_influence_tracker import compute_validator_reputations
 
@@ -105,7 +105,27 @@ async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any
 
 
 # Register with the central frontend router
-register_route("reputation_analysis", compute_reputation_ui)
-register_route("update_validator_reputations", update_reputations_ui)
-register_route("reputation_update", trigger_reputation_update_ui)
-register_route("compute_diversity", compute_diversity_ui)
+register_route(
+    "reputation_analysis",
+    compute_reputation_ui,
+    description="Compute validator reputations",
+    category="validation",
+)
+register_route(
+    "update_validator_reputations",
+    update_reputations_ui,
+    description="Update validator reputations in DB",
+    category="validation",
+)
+register_route(
+    "reputation_update",
+    trigger_reputation_update_ui,
+    description="Update reputations and compute diversity",
+    category="validation",
+)
+register_route(
+    "compute_diversity",
+    compute_diversity_ui,
+    description="Compute diversity score",
+    category="validation",
+)


### PR DESCRIPTION
## Summary
- enhance `frontend_bridge` routing with descriptions and categories
- expose new `/help` endpoint and return structured route info
- annotate route registrations with short descriptions
- update tests and README for new behaviour

## Testing
- `pre-commit run --files README.md audit/explainer_ui_hook.py consensus/ui_hook.py frontend_bridge.py introspection/ui_hook.py network/ui_hook.py optimization/ui_hook.py predictions/ui_hook.py protocols/agents/guardian_ui_hook.py protocols/agents/harmony_ui_hook.py protocols/ui/api_bridge.py protocols/ui_hook.py temporal/ui_hook.py tests/test_frontend_bridge.py ui_hooks/universe_ui.py validators/ui_hook.py`
- `pytest -q` *(fails: AttributeError: 'async_generator' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6887b95ad11c8320b3c7f3482480f959