### PR TITLE
Add virtual diary UI route

### DIFF
--- a/tests/ui_hooks/test_virtual_diary.py
+++ b/tests/ui_hooks/test_virtual_diary.py
@@ -1,0 +1,26 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+import virtual_diary.ui_hook as diary_hook
+
+
+class DummyManager:
+    def __init__(self):
+        self.events = []
+
+    async def trigger(self, name, *args, **kwargs):
+        self.events.append((name, args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_load_diary_entries_route(monkeypatch):
+    dummy = DummyManager()
+    monkeypatch.setattr(diary_hook, "ui_hook_manager", dummy, raising=False)
+    monkeypatch.setattr(diary_hook, "load_entries", lambda limit=20: [
+        {"note": "hello"}
+    ])
+
+    result = await dispatch_route("load_diary_entries", {"limit": 5})
+
+    assert result == {"entries": [{"note": "hello"}]}
+    assert dummy.events == [("diary_entries_loaded", ([{"note": "hello"}],), {})]

--- a/virtual_diary/__init__.py
+++ b/virtual_diary/__init__.py
@@ -32,3 +32,6 @@ def load_entries(limit: int = 20) -> List[Dict[str, Any]]:
     except Exception:
         logger.exception("Failed to load virtual diary")
     return []
+
+__all__ = ["load_entries"]
+

--- a/virtual_diary/ui_hook.py
+++ b/virtual_diary/ui_hook.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from frontend_bridge import register_route
+from hook_manager import HookManager
+
+from . import load_entries
+
+# Exposed hook manager so external listeners can react to diary events
+ui_hook_manager = HookManager()
+
+
+async def load_entries_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Load diary entries and emit a hook event."""
+    try:
+        limit = int(payload.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+
+    entries = load_entries(limit=limit)
+    await ui_hook_manager.trigger("diary_entries_loaded", entries)
+    return {"entries": entries}
+
+
+# Register route with the frontend router
+register_route("load_diary_entries", load_entries_ui)


### PR DESCRIPTION
## Summary
- convert `virtual_diary.py` into a package
- add `load_entries_ui` route that emits a hook
- test diary loading route

## Testing
- `pytest tests/ui_hooks/test_virtual_diary.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b803c3ac8320bf23b6481394a99a