### PR TITLE
Enhance frontend bridge routing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,13 +357,15 @@ register themselves with `register_route(name, func)` and are invoked through
 `dispatch_route`.
 
 A convenient read-only route `"list_routes"` returns the currently available
-route names. This can help debug which backend callbacks are present:
+routes grouped by category along with each handler's description. This can help
+debug which backend callbacks are present:
 
 ```python
 from frontend_bridge import dispatch_route
 
 routes = await dispatch_route("list_routes", {})
-print(routes["routes"])
+for category, items in routes["routes"].items():
+    print(category, [r["name"] for r in items])
 ```
 
 ## 🧪 Running Tests

--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Dict, Union
+from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union
 
 Handler = Callable[..., Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
 
+# Flat lookup by route name
 ROUTES: Dict[str, Handler] = {}
+# Mapping of route name to docstring
+ROUTE_DESCRIPTIONS: Dict[str, str] = {}
+# Grouped mapping by category
+ROUTES_BY_CATEGORY: Dict[str, List[Tuple[str, Handler]]] = {}
 
 
-def register_route(name: str, func: Handler) -> None:
+def register_route(name: str, func: Handler, category: str = "general") -> None:
     """Register a handler for ``name`` events."""
+
     ROUTES[name] = func
+    ROUTE_DESCRIPTIONS[name] = (func.__doc__ or "").strip()
+    ROUTES_BY_CATEGORY.setdefault(category, []).append((name, func))
 
 
 async def dispatch_route(
@@ -33,11 +41,21 @@ async def dispatch_route(
 
 
 def _list_routes(_: Dict[str, Any]) -> Dict[str, Any]:
-    """Return the names of all registered routes."""
-    return {"routes": sorted(ROUTES.keys())}
+    """Return registered routes grouped by category with descriptions."""
+
+    grouped: Dict[str, List[Dict[str, str]]] = {}
+    for category, entries in ROUTES_BY_CATEGORY.items():
+        grouped[category] = [
+            {
+                "name": name,
+                "description": ROUTE_DESCRIPTIONS.get(name, ""),
+            }
+            for name, _ in entries
+        ]
+    return {"routes": grouped}
 
 
-register_route("list_routes", _list_routes)
+register_route("list_routes", _list_routes, category="core")
 
 # Built-in hypothesis-related routes
 from hypothesis.ui_hook import (
@@ -55,10 +73,18 @@ from validator_reputation_tracker_ui_hook import update_reputations_ui
 from consensus_forecaster_agent_ui_hook import forecast_consensus_ui
 
 
-register_route("rank_hypotheses_by_confidence", rank_hypotheses_by_confidence_ui)
-register_route("detect_conflicting_hypotheses", detect_conflicting_hypotheses_ui)
-register_route("register_hypothesis", register_hypothesis_ui)
-register_route("update_hypothesis_score", update_hypothesis_score_ui)
+register_route(
+    "rank_hypotheses_by_confidence",
+    rank_hypotheses_by_confidence_ui,
+    category="hypothesis",
+)
+register_route(
+    "detect_conflicting_hypotheses",
+    detect_conflicting_hypotheses_ui,
+    category="hypothesis",
+)
+register_route("register_hypothesis", register_hypothesis_ui, category="hypothesis")
+register_route("update_hypothesis_score", update_hypothesis_score_ui, category="hypothesis")
 
 # Prediction-related routes
 from predictions.ui_hook import (
@@ -69,9 +95,9 @@ from predictions.ui_hook import (
 
 from optimization.ui_hook import tune_parameters_ui
 
-register_route("store_prediction", store_prediction_ui)
-register_route("get_prediction", get_prediction_ui)
-register_route("update_prediction_status", update_prediction_status_ui)
+register_route("store_prediction", store_prediction_ui, category="prediction")
+register_route("get_prediction", get_prediction_ui, category="prediction")
+register_route("update_prediction_status", update_prediction_status_ui, category="prediction")
 
 # Protocol agent management routes
 from protocols.api_bridge import (
@@ -80,13 +106,13 @@ from protocols.api_bridge import (
     step_agents_api,
 )
 
-register_route("list_agents", list_agents_api)
-register_route("launch_agents", launch_agents_api)
-register_route("step_agents", step_agents_api)
+register_route("list_agents", list_agents_api, category="protocols")
+register_route("launch_agents", launch_agents_api, category="protocols")
+register_route("step_agents", step_agents_api, category="protocols")
 # Temporal analysis route
 from temporal.ui_hook import analyze_temporal_ui
 
-register_route("temporal_consistency", analyze_temporal_ui)
+register_route("temporal_consistency", analyze_temporal_ui, category="temporal")
 
 # Optimization-related route
-register_route("tune_parameters", tune_parameters_ui)
+register_route("tune_parameters", tune_parameters_ui, category="optimization")

--- a/tests/test_frontend_bridge.py
+++ b/tests/test_frontend_bridge.py
@@ -1,9 +1,21 @@
 import pytest
 
-from frontend_bridge import dispatch_route, ROUTES
+from frontend_bridge import dispatch_route, ROUTES_BY_CATEGORY
 
 
 @pytest.mark.asyncio
-async def test_list_routes_returns_registered_names():
+async def test_list_routes_groups_and_describes():
     result = await dispatch_route("list_routes", {})
-    assert set(result["routes"]) == set(ROUTES.keys())
+
+    returned = [
+        entry["name"]
+        for entries in result["routes"].values()
+        for entry in entries
+    ]
+    expected = [name for entries in ROUTES_BY_CATEGORY.values() for name, _ in entries]
+    assert set(returned) == set(expected)
+
+    for entries in result["routes"].values():
+        for entry in entries:
+            assert "description" in entry
+            assert isinstance(entry["description"], str)


### PR DESCRIPTION
## Summary
- keep docstrings and categories for UI routes
- return route metadata grouped by category in `list_routes`
- update docs and tests for new route info

## Testing
- `pytest tests/test_frontend_bridge.py::test_list_routes_groups_and_describes -q`
- `pytest -q` *(fails: 30 failed, 218 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887b952c21c83208c36eef074ba5d6d