### PR TITLE
Add help route and route metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,17 +358,22 @@ After the build completes, you'll get a shareable URL to interact with the valid
 ## 🤝 UI Integration
 
 The `frontend_bridge` module exposes a lightweight router for the UI. Handlers
-register themselves with `register_route(name, func)` and are invoked through
-`dispatch_route`.
+register themselves with `register_route(name, func, description, category)` and
+are invoked through `dispatch_route`.
 
 A convenient read-only route `"list_routes"` returns the currently available
-route names. This can help debug which backend callbacks are present:
+route names. For more detail, the `"help"` route provides descriptions grouped
+by category. This can help debug which backend callbacks are present:
 
 ```python
 from frontend_bridge import dispatch_route
 
 routes = await dispatch_route("list_routes", {})
 print(routes["routes"])
+
+# Detailed route information
+help_data = await dispatch_route("help", {})
+print(help_data["routes"].keys())
 ```
 
 ### Frontend Bridge & Social Hooks

--- a/audit/explainer_ui_hook.py
+++ b/audit/explainer_ui_hook.py
@@ -39,4 +39,9 @@ async def _explain_audit_route(payload: Dict[str, Any]) -> str:
 
 
 # Register route with the central frontend bridge
-register_route("explain_audit", _explain_audit_route)
+register_route(
+    "explain_audit",
+    _explain_audit_route,
+    "Explain audit trace in text",
+    "audit",
+)

--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -141,8 +141,28 @@ async def causal_audit_ui(payload: Dict[str, Any], db: Session, **_: Any) -> Dic
 
 
 # Register routes with the frontend bridge
-register_route("causal_audit", causal_audit_ui)
-register_route("log_hypothesis", log_hypothesis_ui)
-register_route("attach_trace", attach_trace_ui)
-register_route("export_causal_path", export_causal_path_ui)
+register_route(
+    "causal_audit",
+    causal_audit_ui,
+    "Run causal audit on a trace",
+    "audit",
+)
+register_route(
+    "log_hypothesis",
+    log_hypothesis_ui,
+    "Log a new hypothesis",
+    "audit",
+)
+register_route(
+    "attach_trace",
+    attach_trace_ui,
+    "Attach trace to audit log",
+    "audit",
+)
+register_route(
+    "export_causal_path",
+    export_causal_path_ui,
+    "Export causal path for validation",
+    "audit",
+)
 

--- a/audit_explainer/ui_hook.py
+++ b/audit_explainer/ui_hook.py
@@ -24,4 +24,9 @@ async def _explain_validation_route(payload: Dict[str, Any], db: Session) -> Dic
     return await explain_validation_ui(payload, db)
 
 
-register_route("explain_validation_reasoning", _explain_validation_route)
+register_route(
+    "explain_validation_reasoning",
+    _explain_validation_route,
+    "Explain validation reasoning",
+    "audit",
+)

--- a/consensus/ui_hook.py
+++ b/consensus/ui_hook.py
@@ -61,6 +61,21 @@ async def poll_consensus_forecast_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the frontend bridge
-register_route("forecast_consensus", forecast_consensus_ui)
-register_route("queue_consensus_forecast", queue_consensus_forecast_ui)
-register_route("poll_consensus_forecast", poll_consensus_forecast_ui)
+register_route(
+    "forecast_consensus",
+    forecast_consensus_ui,
+    "Forecast consensus trend",
+    "consensus",
+)
+register_route(
+    "queue_consensus_forecast",
+    queue_consensus_forecast_ui,
+    "Queue consensus forecast job",
+    "consensus",
+)
+register_route(
+    "poll_consensus_forecast",
+    poll_consensus_forecast_ui,
+    "Poll forecast job status",
+    "consensus",
+)

--- a/diary/ui_hook.py
+++ b/diary/ui_hook.py
@@ -21,4 +21,9 @@ async def get_diary_entries_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {"entries": entries}
 
 
-register_route("get_diary_entries", get_diary_entries_ui)
+register_route(
+    "get_diary_entries",
+    get_diary_entries_ui,
+    "Retrieve diary entries",
+    "diary",
+)

--- a/diversity/ui_hook.py
+++ b/diversity/ui_hook.py
@@ -30,4 +30,9 @@ async def diversity_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route("diversity_certify", diversity_analysis_ui)
+register_route(
+    "diversity_certify",
+    diversity_analysis_ui,
+    "Compute diversity certification",
+    "diversity",
+)

--- a/diversity_analyzer/ui_hook.py
+++ b/diversity_analyzer/ui_hook.py
@@ -34,5 +34,15 @@ async def certify_validations_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route("diversity_score", compute_diversity_ui)
-register_route("certify_validations", certify_validations_ui)
+register_route(
+    "diversity_score",
+    compute_diversity_ui,
+    "Compute network diversity score",
+    "diversity",
+)
+register_route(
+    "certify_validations",
+    certify_validations_ui,
+    "Certify validation diversity",
+    "diversity",
+)

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -7,6 +7,7 @@ backend handler.
 | Route | Description |
 |-------|-------------|
 |`list_routes`|Return the names of all registered routes.|
+|`help`|Return routes grouped by category with descriptions.|
 |`describe_routes`|Return each route name with its handler docstring.|
 |`rank_hypotheses_by_confidence`|Rank hypotheses using the reasoning layer.|
 |`detect_conflicting_hypotheses`|Detect contradictions between hypotheses.|

--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -69,6 +69,21 @@ async def poll_full_audit_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return queue_agent.get_status(job_id)
 
 
-register_route("queue_full_audit", queue_full_audit_ui)
-register_route("poll_full_audit", poll_full_audit_ui)
-register_route("trigger_full_audit", trigger_full_audit_ui)
+register_route(
+    "queue_full_audit",
+    queue_full_audit_ui,
+    "Queue a full introspection audit",
+    "audit",
+)
+register_route(
+    "poll_full_audit",
+    poll_full_audit_ui,
+    "Poll introspection audit status",
+    "audit",
+)
+register_route(
+    "trigger_full_audit",
+    trigger_full_audit_ui,
+    "Run a full introspection audit",
+    "audit",
+)

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -69,9 +69,24 @@ async def poll_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, An
 
 
 # Register with the central frontend router
-register_route("coordination_analysis", trigger_coordination_analysis_ui)
-register_route("queue_coordination_analysis", queue_coordination_analysis_ui)
-register_route("poll_coordination_analysis", poll_coordination_analysis_ui)
+register_route(
+    "coordination_analysis",
+    trigger_coordination_analysis_ui,
+    "Run coordination risk analysis",
+    "network",
+)
+register_route(
+    "queue_coordination_analysis",
+    queue_coordination_analysis_ui,
+    "Queue coordination analysis job",
+    "network",
+)
+register_route(
+    "poll_coordination_analysis",
+    poll_coordination_analysis_ui,
+    "Poll coordination analysis status",
+    "network",
+)
 
 
 async def run_coordination_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/optimization/ui_hook.py
+++ b/optimization/ui_hook.py
@@ -19,4 +19,9 @@ async def tune_parameters_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route("tune_parameters", tune_parameters_ui)
+register_route(
+    "tune_parameters",
+    tune_parameters_ui,
+    "Tune system parameters",
+    "optimization",
+)

--- a/prediction/ui_hook.py
+++ b/prediction/ui_hook.py
@@ -53,6 +53,21 @@ async def schedule_audit_proposal_ui(
 
 
 # Register handlers with the frontend bridge
-register_route("store_prediction", store_prediction_ui)
-register_route("get_prediction", get_prediction_ui)
-register_route("schedule_audit_proposal", schedule_audit_proposal_ui)
+register_route(
+    "store_prediction",
+    store_prediction_ui,
+    "Persist prediction data",
+    "prediction",
+)
+register_route(
+    "get_prediction",
+    get_prediction_ui,
+    "Return a stored prediction",
+    "prediction",
+)
+register_route(
+    "schedule_audit_proposal",
+    schedule_audit_proposal_ui,
+    "Schedule annual audit proposal",
+    "prediction",
+)

--- a/prediction_manager/ui_hook.py
+++ b/prediction_manager/ui_hook.py
@@ -53,6 +53,21 @@ async def update_prediction_status_ui(payload: Dict[str, Any]) -> Dict[str, Any]
     return {"prediction_id": prediction_id, "status": new_status}
 
 
-register_route("store_prediction", store_prediction_ui)
-register_route("get_prediction", get_prediction_ui)
-register_route("update_prediction_status", update_prediction_status_ui)
+register_route(
+    "store_prediction",
+    store_prediction_ui,
+    "Persist prediction data",
+    "prediction",
+)
+register_route(
+    "get_prediction",
+    get_prediction_ui,
+    "Return minimal prediction info",
+    "prediction",
+)
+register_route(
+    "update_prediction_status",
+    update_prediction_status_ui,
+    "Update prediction status",
+    "prediction",
+)

--- a/protocols/agents/guardian_ui_hook.py
+++ b/protocols/agents/guardian_ui_hook.py
@@ -28,5 +28,15 @@ async def propose_fix_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route("inspect_suggestion", inspect_suggestion_ui)
-register_route("propose_fix", propose_fix_ui)
+register_route(
+    "inspect_suggestion",
+    inspect_suggestion_ui,
+    "Inspect a suggestion via Guardian agent",
+    "agents",
+)
+register_route(
+    "propose_fix",
+    propose_fix_ui,
+    "Propose a fix through Guardian agent",
+    "agents",
+)

--- a/protocols/agents/harmony_ui_hook.py
+++ b/protocols/agents/harmony_ui_hook.py
@@ -28,4 +28,9 @@ async def generate_midi_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the central frontend router
-register_route("generate_midi", generate_midi_ui)
+register_route(
+    "generate_midi",
+    generate_midi_ui,
+    "Generate a short MIDI snippet",
+    "agents",
+)

--- a/protocols/ui/api_bridge.py
+++ b/protocols/ui/api_bridge.py
@@ -64,6 +64,21 @@ async def step_agents_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register routes with the frontend bridge
-register_route("protocol_agents_list", list_agents_ui)
-register_route("protocol_agents_launch", launch_agents_ui)
-register_route("protocol_agents_step", step_agents_ui)
+register_route(
+    "protocol_agents_list",
+    list_agents_ui,
+    "List available protocol agent classes",
+    "protocol",
+)
+register_route(
+    "protocol_agents_launch",
+    launch_agents_ui,
+    "Launch protocol agents",
+    "protocol",
+)
+register_route(
+    "protocol_agents_step",
+    step_agents_ui,
+    "Trigger a single step on agents",
+    "protocol",
+)

--- a/protocols/ui_hook.py
+++ b/protocols/ui_hook.py
@@ -28,5 +28,15 @@ async def get_provenance_ui(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 # Register with the central frontend router
-register_route("cross_universe_register_bridge", register_bridge_ui)
-register_route("cross_universe_get_provenance", get_provenance_ui)
+register_route(
+    "cross_universe_register_bridge",
+    register_bridge_ui,
+    "Register cross-universe provenance data",
+    "protocol",
+)
+register_route(
+    "cross_universe_get_provenance",
+    get_provenance_ui,
+    "Retrieve provenance information for a coin",
+    "protocol",
+)

--- a/quantum_sim/ui_hook.py
+++ b/quantum_sim/ui_hook.py
@@ -42,4 +42,9 @@ async def simulate_entanglement_ui(
 
 
 # Register the route with the central router so UIs can invoke it
-register_route("simulate_entanglement", simulate_entanglement_ui)
+register_route(
+    "simulate_entanglement",
+    simulate_entanglement_ui,
+    "Simulate quantum entanglement",
+    "quantum",
+)

--- a/scientific_metrics/ui_hook.py
+++ b/scientific_metrics/ui_hook.py
@@ -50,5 +50,15 @@ async def calculate_influence_ui(
 
 
 # Register routes for the UI
-register_route("predict_user_interactions", predict_user_interactions_ui)
-register_route("calculate_influence", calculate_influence_ui)
+register_route(
+    "predict_user_interactions",
+    predict_user_interactions_ui,
+    "Predict user interactions",
+    "metrics",
+)
+register_route(
+    "calculate_influence",
+    calculate_influence_ui,
+    "Calculate user influence score",
+    "metrics",
+)

--- a/social/ui_hook.py
+++ b/social/ui_hook.py
@@ -32,4 +32,9 @@ async def simulate_entanglement_ui(
 
 
 # Register route with the frontend router
-register_route("simulate_entanglement", simulate_entanglement_ui)
+register_route(
+    "simulate_entanglement",
+    simulate_entanglement_ui,
+    "Simulate social entanglement",
+    "social",
+)

--- a/temporal/ui_hook.py
+++ b/temporal/ui_hook.py
@@ -26,4 +26,9 @@ async def analyze_temporal_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route("temporal_consistency", analyze_temporal_ui)
+register_route(
+    "temporal_consistency",
+    analyze_temporal_ui,
+    "Analyze temporal consistency",
+    "analysis",
+)

--- a/tests/test_frontend_bridge.py
+++ b/tests/test_frontend_bridge.py
@@ -11,6 +11,15 @@ async def test_list_routes_returns_registered_names():
     assert set(result["routes"]) == set(ROUTES.keys())
 
 
+@pytest.mark.asyncio
+async def test_help_returns_grouped_info():
+    result = await dispatch_route("help", {})
+    assert "hypothesis" in result["routes"]
+    assert any(
+        r["name"] == "register_hypothesis" for r in result["routes"]["hypothesis"]
+    )
+
+
 class DummyAgent:
     def __init__(self):
         self.jobs = {}
@@ -43,7 +52,7 @@ async def test_long_running_job_enqueued(monkeypatch):
     def handler(payload):
         return long_running(slow(payload))
 
-    register_route("slow_test", handler)
+    register_route("slow_test", handler, "slow test", "meta")
     try:
         job = await dispatch_route("slow_test", {"x": 5})
         assert job == {"job_id": "job1"}

--- a/ui_hooks/universe_ui.py
+++ b/ui_hooks/universe_ui.py
@@ -54,6 +54,21 @@ async def submit_universe_proposal(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {"proposal_id": proposal_id}
 
 
-register_route("get_universe_overview", get_universe_overview)
-register_route("list_available_proposals", list_available_proposals)
-register_route("submit_universe_proposal", submit_universe_proposal)
+register_route(
+    "get_universe_overview",
+    get_universe_overview,
+    "Get overview for a universe",
+    "universe",
+)
+register_route(
+    "list_available_proposals",
+    list_available_proposals,
+    "List proposals for a universe",
+    "universe",
+)
+register_route(
+    "submit_universe_proposal",
+    submit_universe_proposal,
+    "Submit a new universe proposal",
+    "universe",
+)

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -1,7 +1,7 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Universe lifecycle management utilities.
+"""Universe lifecycle management utilities."""
 
 from __future__ import annotations
 import uuid

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -105,7 +105,27 @@ async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any
 
 
 # Register with the central frontend router
-register_route("reputation_analysis", compute_reputation_ui)
-register_route("update_validator_reputations", update_reputations_ui)
-register_route("reputation_update", trigger_reputation_update_ui)
-register_route("compute_diversity", compute_diversity_ui)
+register_route(
+    "reputation_analysis",
+    compute_reputation_ui,
+    "Compute validator reputations",
+    "validators",
+)
+register_route(
+    "update_validator_reputations",
+    update_reputations_ui,
+    "Persist validator reputation updates",
+    "validators",
+)
+register_route(
+    "reputation_update",
+    trigger_reputation_update_ui,
+    "Run reputation update and return summary",
+    "validators",
+)
+register_route(
+    "compute_diversity",
+    compute_diversity_ui,
+    "Calculate network diversity metrics",
+    "validators",
+)

--- a/virtual_diary/ui_hook.py
+++ b/virtual_diary/ui_hook.py
@@ -29,5 +29,15 @@ async def add_entry_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register routes
-register_route("fetch_diary_entries", fetch_entries_ui)
-register_route("add_diary_entry", add_entry_ui)
+register_route(
+    "fetch_diary_entries",
+    fetch_entries_ui,
+    "Fetch diary entries",
+    "diary",
+)
+register_route(
+    "add_diary_entry",
+    add_entry_ui,
+    "Add a diary entry",
+    "diary",
+)

--- a/vote_registry/ui_hook.py
+++ b/vote_registry/ui_hook.py
@@ -26,5 +26,15 @@ async def load_votes_ui(_: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the frontend bridge
-register_route("record_vote", record_vote_ui)
-register_route("load_votes", load_votes_ui)
+register_route(
+    "record_vote",
+    record_vote_ui,
+    "Record a validator vote",
+    "prediction",
+)
+register_route(
+    "load_votes",
+    load_votes_ui,
+    "Load recorded votes",
+    "prediction",
+)


### PR DESCRIPTION
## Summary
- extend `register_route` to store description and category
- implement `/help` endpoint that groups routes by category
- update all route registrations with brief descriptions
- mention `/help` usage in docs and README
- fix missing docstring closing in `universe_manager`
- test new help endpoint

## Testing
- `pytest -q` *(fails: ImportError during test collection)*
- `pre-commit run --files ...` *(failed to install hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6887c2930eec83208f1da2a9840c0716