### PR TITLE
Add help endpoint and route metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,13 @@ routes = await dispatch_route("list_routes", {})
 print(routes["routes"])
 ```
 
+For more detail, dispatch the `"help"` route to get descriptions grouped by
+category:
+
+```python
+info = await dispatch_route("help", {})
+``` 
+
 During development, you can also open `/ui/debug_panel` in the NiceGUI
 frontend to interactively invoke these routes. The panel lists every
 registered name with a JSON payload editor and uses `dispatch_route` under

--- a/audit/explainer_ui_hook.py
+++ b/audit/explainer_ui_hook.py
@@ -39,4 +39,9 @@ async def _explain_audit_route(payload: Dict[str, Any]) -> str:
 
 
 # Register route with the central frontend bridge
-register_route_once("explain_audit", _explain_audit_route)
+register_route_once(
+    "explain_audit",
+    _explain_audit_route,
+    "Explain an audit trace",
+    "audit",
+)

--- a/audit/ui_hook.py
+++ b/audit/ui_hook.py
@@ -95,7 +95,9 @@ async def export_causal_path_ui(payload: Dict[str, Any], **_: Any) -> Dict[str, 
 
 
 # Register causal audit route
-async def causal_audit_ui(payload: Dict[str, Any], db: Session, **_: Any) -> Dict[str, Any]:
+async def causal_audit_ui(
+    payload: Dict[str, Any], db: Session, **_: Any
+) -> Dict[str, Any]:
     """Run :func:`trigger_causal_audit` from UI payload.
 
     Parameters
@@ -133,15 +135,32 @@ async def causal_audit_ui(payload: Dict[str, Any], db: Session, **_: Any) -> Dic
     await hook_manager.trigger(
         events.AUDIT_LOG, {"action": "causal_audit", "log_id": log_id}
     )
-    message_hub.publish(
-        "audit_log", {"action": "causal_audit", "log_id": log_id}
-    )
+    message_hub.publish("audit_log", {"action": "causal_audit", "log_id": log_id})
     return minimal
 
 
 # Register routes with the frontend bridge
-register_route_once("causal_audit", causal_audit_ui)
-register_route_once("log_hypothesis", log_hypothesis_ui)
-register_route_once("attach_trace", attach_trace_ui)
-register_route_once("export_causal_path", export_causal_path_ui)
-
+register_route_once(
+    "causal_audit",
+    causal_audit_ui,
+    "Run a causal audit",
+    "audit",
+)
+register_route_once(
+    "log_hypothesis",
+    log_hypothesis_ui,
+    "Log a hypothesis for auditing",
+    "audit",
+)
+register_route_once(
+    "attach_trace",
+    attach_trace_ui,
+    "Attach audit trace data",
+    "audit",
+)
+register_route_once(
+    "export_causal_path",
+    export_causal_path_ui,
+    "Export causal path information",
+    "audit",
+)

--- a/audit_explainer/ui_hook.py
+++ b/audit_explainer/ui_hook.py
@@ -20,8 +20,15 @@ async def explain_validation_ui(payload: Dict[str, Any], db: Session) -> Dict[st
     return result
 
 
-async def _explain_validation_route(payload: Dict[str, Any], db: Session) -> Dict[str, Any]:
+async def _explain_validation_route(
+    payload: Dict[str, Any], db: Session
+) -> Dict[str, Any]:
     return await explain_validation_ui(payload, db)
 
 
-register_route_once("explain_validation_reasoning", _explain_validation_route)
+register_route_once(
+    "explain_validation_reasoning",
+    _explain_validation_route,
+    "Explain validation reasoning",
+    "audit",
+)

--- a/causal_graph/ui_hook.py
+++ b/causal_graph/ui_hook.py
@@ -7,11 +7,14 @@ from sqlalchemy.orm import Session
 from hook_manager import HookManager
 from frontend_bridge import register_route_once
 from . import build_causal_graph
+
 try:  # pragma: no cover - optional dependency during tests
     from superNova_2177 import simulate_social_entanglement
 except Exception:  # pragma: no cover - fallback stub
+
     def simulate_social_entanglement(*_a: Any, **_k: Any) -> Dict[str, Any]:
         return {"source": None, "target": None, "probabilistic_influence": 0.0}
+
 
 ui_hook_manager = HookManager()
 
@@ -20,19 +23,18 @@ async def build_graph_ui(_: Dict[str, Any], db: Session, **__: Any) -> Dict[str,
     """Return the causal graph structure for the current database."""
     graph = build_causal_graph(db)
     data = {
-        "nodes": [
-            {"id": n, **graph.graph.nodes.get(n, {})} for n in graph.graph.nodes
-        ],
+        "nodes": [{"id": n, **graph.graph.nodes.get(n, {})} for n in graph.graph.nodes],
         "edges": [
-            {"source": u, "target": v, **d}
-            for u, v, d in graph.graph.edges(data=True)
+            {"source": u, "target": v, **d} for u, v, d in graph.graph.edges(data=True)
         ],
     }
     await ui_hook_manager.trigger("graph_built", data)
     return data
 
 
-async def simulate_entanglement_ui(payload: Dict[str, Any], db: Session, **__: Any) -> Dict[str, Any]:
+async def simulate_entanglement_ui(
+    payload: Dict[str, Any], db: Session, **__: Any
+) -> Dict[str, Any]:
     """Run :func:`simulate_social_entanglement` and return its result."""
     user1 = int(payload["user1_id"])
     user2 = int(payload["user2_id"])
@@ -40,5 +42,16 @@ async def simulate_entanglement_ui(payload: Dict[str, Any], db: Session, **__: A
     await ui_hook_manager.trigger("entanglement_simulated", result)
     return result
 
-register_route_once("build_causal_graph", build_graph_ui)
-register_route_once("simulate_entanglement_causal", simulate_entanglement_ui)
+
+register_route_once(
+    "build_causal_graph",
+    build_graph_ui,
+    "Return the causal graph structure",
+    "causal",
+)
+register_route_once(
+    "simulate_entanglement_causal",
+    simulate_entanglement_ui,
+    "Simulate entanglement on the causal graph",
+    "causal",
+)

--- a/consensus/ui_hook.py
+++ b/consensus/ui_hook.py
@@ -61,6 +61,21 @@ async def poll_consensus_forecast_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the frontend bridge
-register_route_once("forecast_consensus", forecast_consensus_ui)
-register_route_once("queue_consensus_forecast", queue_consensus_forecast_ui)
-register_route_once("poll_consensus_forecast", poll_consensus_forecast_ui)
+register_route_once(
+    "forecast_consensus",
+    forecast_consensus_ui,
+    "Forecast consensus trend",
+    "consensus",
+)
+register_route_once(
+    "queue_consensus_forecast",
+    queue_consensus_forecast_ui,
+    "Queue consensus forecast job",
+    "consensus",
+)
+register_route_once(
+    "poll_consensus_forecast",
+    poll_consensus_forecast_ui,
+    "Poll status of a consensus forecast job",
+    "consensus",
+)

--- a/diary/ui_hook.py
+++ b/diary/ui_hook.py
@@ -21,4 +21,9 @@ async def get_diary_entries_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {"entries": entries}
 
 
-register_route_once("get_diary_entries", get_diary_entries_ui)
+register_route_once(
+    "get_diary_entries",
+    get_diary_entries_ui,
+    "Retrieve diary entries",
+    "diary",
+)

--- a/diversity/ui_hook.py
+++ b/diversity/ui_hook.py
@@ -30,4 +30,9 @@ async def diversity_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route_once("diversity_certify", diversity_analysis_ui)
+register_route_once(
+    "diversity_certify",
+    diversity_analysis_ui,
+    "Certify validations and emit diversity event",
+    "diversity",
+)

--- a/diversity_analyzer/ui_hook.py
+++ b/diversity_analyzer/ui_hook.py
@@ -34,5 +34,15 @@ async def certify_validations_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route_once("diversity_score", compute_diversity_ui)
-register_route_once("certify_validations", certify_validations_ui)
+register_route_once(
+    "diversity_score",
+    compute_diversity_ui,
+    "Compute diversity score",
+    "diversity",
+)
+register_route_once(
+    "certify_validations",
+    certify_validations_ui,
+    "Certify validations",
+    "diversity",
+)

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -7,6 +7,7 @@ backend handler.
 | Route | Description |
 |-------|-------------|
 |`list_routes`|Return the names of all registered routes.|
+|`help`|Return structured route details grouped by category.|
 |`describe_routes`|Return each route name with its handler docstring.|
 |`rank_hypotheses_by_confidence`|Rank hypotheses using the reasoning layer.|
 |`detect_conflicting_hypotheses`|Detect contradictions between hypotheses.|

--- a/hypothesis_meta_evaluator_ui_hook.py
+++ b/hypothesis_meta_evaluator_ui_hook.py
@@ -22,6 +22,9 @@ async def trigger_meta_evaluation_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-register_route_once("trigger_meta_evaluation", trigger_meta_evaluation_ui)
-
-
+register_route_once(
+    "trigger_meta_evaluation",
+    trigger_meta_evaluation_ui,
+    "Run meta evaluation",
+    "hypothesis",
+)

--- a/hypothesis_reasoner_ui_hook.py
+++ b/hypothesis_reasoner_ui_hook.py
@@ -22,6 +22,9 @@ async def auto_flag_stale_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-register_route_once("auto_flag_stale", auto_flag_stale_ui)
-
-
+register_route_once(
+    "auto_flag_stale",
+    auto_flag_stale_ui,
+    "Auto-flag stale hypotheses",
+    "hypothesis",
+)

--- a/introspection/ui_hook.py
+++ b/introspection/ui_hook.py
@@ -69,6 +69,21 @@ async def poll_full_audit_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return queue_agent.get_status(job_id)
 
 
-register_route_once("queue_full_audit", queue_full_audit_ui)
-register_route_once("poll_full_audit", poll_full_audit_ui)
-register_route_once("trigger_full_audit", trigger_full_audit_ui)
+register_route_once(
+    "queue_full_audit",
+    queue_full_audit_ui,
+    "Queue a full audit job",
+    "introspection",
+)
+register_route_once(
+    "poll_full_audit",
+    poll_full_audit_ui,
+    "Poll status of a full audit job",
+    "introspection",
+)
+register_route_once(
+    "trigger_full_audit",
+    trigger_full_audit_ui,
+    "Run a full introspection audit",
+    "introspection",
+)

--- a/network/ui_hook.py
+++ b/network/ui_hook.py
@@ -69,9 +69,24 @@ async def poll_coordination_analysis_ui(payload: Dict[str, Any]) -> Dict[str, An
 
 
 # Register with the central frontend router
-register_route_once("coordination_analysis", trigger_coordination_analysis_ui)
-register_route_once("queue_coordination_analysis", queue_coordination_analysis_ui)
-register_route_once("poll_coordination_analysis", poll_coordination_analysis_ui)
+register_route_once(
+    "coordination_analysis",
+    trigger_coordination_analysis_ui,
+    "Run network coordination analysis",
+    "network",
+)
+register_route_once(
+    "queue_coordination_analysis",
+    queue_coordination_analysis_ui,
+    "Queue coordination analysis job",
+    "network",
+)
+register_route_once(
+    "poll_coordination_analysis",
+    poll_coordination_analysis_ui,
+    "Poll status of a coordination job",
+    "network",
+)
 
 
 async def run_coordination_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/optimization/ui_hook.py
+++ b/optimization/ui_hook.py
@@ -19,4 +19,9 @@ async def tune_parameters_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route_once("tune_parameters", tune_parameters_ui)
+register_route_once(
+    "tune_parameters",
+    tune_parameters_ui,
+    "Tune system parameters",
+    "optimization",
+)

--- a/prediction/ui_hook.py
+++ b/prediction/ui_hook.py
@@ -53,6 +53,21 @@ async def schedule_audit_proposal_ui(
 
 
 # Register handlers with the frontend bridge
-register_route_once("store_prediction", store_prediction_ui)
-register_route_once("get_prediction", get_prediction_ui)
-register_route_once("schedule_audit_proposal", schedule_audit_proposal_ui)
+register_route_once(
+    "store_prediction",
+    store_prediction_ui,
+    "Persist prediction data",
+    "prediction",
+)
+register_route_once(
+    "get_prediction",
+    get_prediction_ui,
+    "Retrieve a stored prediction",
+    "prediction",
+)
+register_route_once(
+    "schedule_audit_proposal",
+    schedule_audit_proposal_ui,
+    "Schedule an annual audit proposal",
+    "prediction",
+)

--- a/prediction_manager/ui_hook.py
+++ b/prediction_manager/ui_hook.py
@@ -48,11 +48,27 @@ async def update_prediction_status_ui(payload: Dict[str, Any]) -> Dict[str, Any]
         prediction_id, new_status, actual_outcome=outcome
     )
     await ui_hook_manager.trigger(
-        "prediction_status_updated", {"prediction_id": prediction_id, "status": new_status}
+        "prediction_status_updated",
+        {"prediction_id": prediction_id, "status": new_status},
     )
     return {"prediction_id": prediction_id, "status": new_status}
 
 
-register_route_once("store_prediction", store_prediction_ui)
-register_route_once("get_prediction", get_prediction_ui)
-register_route_once("update_prediction_status", update_prediction_status_ui)
+register_route_once(
+    "store_prediction",
+    store_prediction_ui,
+    "Persist prediction data",
+    "prediction",
+)
+register_route_once(
+    "get_prediction",
+    get_prediction_ui,
+    "Retrieve a stored prediction",
+    "prediction",
+)
+register_route_once(
+    "update_prediction_status",
+    update_prediction_status_ui,
+    "Update prediction status",
+    "prediction",
+)

--- a/protocols/agents/guardian_ui_hook.py
+++ b/protocols/agents/guardian_ui_hook.py
@@ -28,5 +28,15 @@ async def propose_fix_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the central frontend router
-register_route_once("inspect_suggestion", inspect_suggestion_ui)
-register_route_once("propose_fix", propose_fix_ui)
+register_route_once(
+    "inspect_suggestion",
+    inspect_suggestion_ui,
+    "Inspect a suggestion via the Guardian agent",
+    "protocols",
+)
+register_route_once(
+    "propose_fix",
+    propose_fix_ui,
+    "Propose a fix via the Guardian agent",
+    "protocols",
+)

--- a/protocols/agents/harmony_ui_hook.py
+++ b/protocols/agents/harmony_ui_hook.py
@@ -28,4 +28,9 @@ async def generate_midi_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register route with the central frontend router
-register_route_once("generate_midi", generate_midi_ui)
+register_route_once(
+    "generate_midi",
+    generate_midi_ui,
+    "Generate a MIDI snippet",
+    "protocols",
+)

--- a/protocols/ui/api_bridge.py
+++ b/protocols/ui/api_bridge.py
@@ -64,6 +64,21 @@ async def step_agents_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register routes with the frontend bridge
-register_route_once("protocol_agents_list", list_agents_ui)
-register_route_once("protocol_agents_launch", launch_agents_ui)
-register_route_once("protocol_agents_step", step_agents_ui)
+register_route_once(
+    "protocol_agents_list",
+    list_agents_ui,
+    "List protocol agent classes",
+    "protocols",
+)
+register_route_once(
+    "protocol_agents_launch",
+    launch_agents_ui,
+    "Launch protocol agents",
+    "protocols",
+)
+register_route_once(
+    "protocol_agents_step",
+    step_agents_ui,
+    "Step running protocol agents",
+    "protocols",
+)

--- a/protocols/ui_hook.py
+++ b/protocols/ui_hook.py
@@ -28,5 +28,15 @@ async def get_provenance_ui(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 # Register with the central frontend router
-register_route_once("cross_universe_register_bridge", register_bridge_ui)
-register_route_once("cross_universe_get_provenance", get_provenance_ui)
+register_route_once(
+    "cross_universe_register_bridge",
+    register_bridge_ui,
+    "Register cross-universe provenance",
+    "protocols",
+)
+register_route_once(
+    "cross_universe_get_provenance",
+    get_provenance_ui,
+    "Retrieve cross-universe provenance",
+    "protocols",
+)

--- a/quantum_sim/ui_hook.py
+++ b/quantum_sim/ui_hook.py
@@ -44,5 +44,15 @@ async def simulate_entanglement_ui(
 
 
 # Register routes with frontend
-register_route_once("quantum_prediction", quantum_prediction_ui)
-register_route_once("simulate_entanglement", simulate_entanglement_ui)
+register_route_once(
+    "quantum_prediction",
+    quantum_prediction_ui,
+    "Run a quantum prediction",
+    "quantum",
+)
+register_route_once(
+    "simulate_entanglement",
+    simulate_entanglement_ui,
+    "Simulate quantum entanglement",
+    "quantum",
+)

--- a/scientific_metrics/ui_hook.py
+++ b/scientific_metrics/ui_hook.py
@@ -50,5 +50,15 @@ async def calculate_influence_ui(
 
 
 # Register routes for the UI
-register_route_once("predict_user_interactions", predict_user_interactions_ui)
-register_route_once("calculate_influence", calculate_influence_ui)
+register_route_once(
+    "predict_user_interactions",
+    predict_user_interactions_ui,
+    "Predict user interactions",
+    "metrics",
+)
+register_route_once(
+    "calculate_influence",
+    calculate_influence_ui,
+    "Calculate user influence score",
+    "metrics",
+)

--- a/social/ui_hook.py
+++ b/social/ui_hook.py
@@ -32,4 +32,9 @@ async def simulate_entanglement_ui(
 
 
 # Register route with the frontend router
-register_route_once("simulate_entanglement", simulate_entanglement_ui)
+register_route_once(
+    "simulate_entanglement",
+    simulate_entanglement_ui,
+    "Simulate social entanglement",
+    "social",
+)

--- a/system_state_utils/ui_hook.py
+++ b/system_state_utils/ui_hook.py
@@ -10,7 +10,9 @@ from . import log_event
 ui_hook_manager = HookManager()
 
 
-async def log_event_ui(payload: Dict[str, Any], db: Session, **_: Any) -> Dict[str, Any]:
+async def log_event_ui(
+    payload: Dict[str, Any], db: Session, **_: Any
+) -> Dict[str, Any]:
     """Persist an event triggered via the UI and emit a hook."""
     category = payload.get("category")
     if not isinstance(category, str) or not category:
@@ -29,4 +31,9 @@ async def log_event_ui(payload: Dict[str, Any], db: Session, **_: Any) -> Dict[s
     return {"category": category, **event_payload}
 
 
-register_route_once("log_event", log_event_ui)
+register_route_once(
+    "log_event",
+    log_event_ui,
+    "Log a system state event",
+    "system",
+)

--- a/temporal/ui_hook.py
+++ b/temporal/ui_hook.py
@@ -26,4 +26,9 @@ async def analyze_temporal_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route_once("temporal_consistency", analyze_temporal_ui)
+register_route_once(
+    "temporal_consistency",
+    analyze_temporal_ui,
+    "Analyze temporal consistency",
+    "temporal",
+)

--- a/tests/test_frontend_bridge.py
+++ b/tests/test_frontend_bridge.py
@@ -29,6 +29,14 @@ async def test_new_routes_exposed():
         assert name in result["routes"]
 
 
+@pytest.mark.asyncio
+async def test_help_lists_routes_by_category():
+    result = await dispatch_route("help", {})
+    categories = result["categories"]
+    names = {entry["name"] for routes in categories.values() for entry in routes}
+    assert names == set(ROUTES.keys())
+
+
 class DummyAgent:
     def __init__(self):
         self.jobs = {}
@@ -71,4 +79,3 @@ async def test_long_running_job_enqueued(monkeypatch):
         assert status == {"status": "done", "result": {"value": 5}}
     finally:
         ROUTES.pop("slow_test", None)
-

--- a/ui_hooks/universe_ui.py
+++ b/ui_hooks/universe_ui.py
@@ -48,12 +48,25 @@ async def submit_universe_proposal(payload: Dict[str, Any]) -> Dict[str, Any]:
     universe_id = payload.get("universe_id")
     proposal = payload.get("proposal", {})
     proposal_id = universe_manager.submit_proposal(universe_id, proposal)
-    await ui_hook_manager.trigger(
-        "proposal_submitted", {"proposal_id": proposal_id}
-    )
+    await ui_hook_manager.trigger("proposal_submitted", {"proposal_id": proposal_id})
     return {"proposal_id": proposal_id}
 
 
-register_route_once("get_universe_overview", get_universe_overview)
-register_route_once("list_available_proposals", list_available_proposals)
-register_route_once("submit_universe_proposal", submit_universe_proposal)
+register_route_once(
+    "get_universe_overview",
+    get_universe_overview,
+    "Get an overview of the universe",
+    "universe",
+)
+register_route_once(
+    "list_available_proposals",
+    list_available_proposals,
+    "List available proposals",
+    "universe",
+)
+register_route_once(
+    "submit_universe_proposal",
+    submit_universe_proposal,
+    "Submit a universe proposal",
+    "universe",
+)

--- a/validation_certifier_ui_hook.py
+++ b/validation_certifier_ui_hook.py
@@ -16,13 +16,18 @@ async def run_integrity_analysis_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     minimal = {
         "consensus_score": result.get("consensus_score"),
         "recommended_certification": result.get("recommended_certification"),
-        "integrity_score": result.get("integrity_analysis", {}).get("overall_integrity_score"),
+        "integrity_score": result.get("integrity_analysis", {}).get(
+            "overall_integrity_score"
+        ),
         "risk_level": result.get("integrity_analysis", {}).get("risk_level"),
     }
     await ui_hook_manager.trigger("integrity_analysis_run", minimal)
     return minimal
 
 
-register_route_once("run_integrity_analysis", run_integrity_analysis_ui)
-
-
+register_route_once(
+    "run_integrity_analysis",
+    run_integrity_analysis_ui,
+    "Analyze validation integrity",
+    "audit",
+)

--- a/validator_reputation_tracker_ui_hook.py
+++ b/validator_reputation_tracker_ui_hook.py
@@ -18,6 +18,9 @@ async def update_reputations_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     return minimal
 
 
-register_route_once("update_reputations", update_reputations_ui)
-
-
+register_route_once(
+    "update_reputations",
+    update_reputations_ui,
+    "Update validator reputations",
+    "validators",
+)

--- a/validators/ui_hook.py
+++ b/validators/ui_hook.py
@@ -105,7 +105,27 @@ async def trigger_reputation_update_ui(payload: Dict[str, Any]) -> Dict[str, Any
 
 
 # Register with the central frontend router
-register_route_once("reputation_analysis", compute_reputation_ui)
-register_route_once("update_validator_reputations", update_reputations_ui)
-register_route_once("reputation_update", trigger_reputation_update_ui)
-register_route_once("compute_diversity", compute_diversity_ui)
+register_route_once(
+    "reputation_analysis",
+    compute_reputation_ui,
+    "Compute validator reputations",
+    "validators",
+)
+register_route_once(
+    "update_validator_reputations",
+    update_reputations_ui,
+    "Persist validator reputation updates",
+    "validators",
+)
+register_route_once(
+    "reputation_update",
+    trigger_reputation_update_ui,
+    "Update reputations from payload",
+    "validators",
+)
+register_route_once(
+    "compute_diversity",
+    compute_diversity_ui,
+    "Compute diversity metrics",
+    "validators",
+)

--- a/virtual_diary/ui_hook.py
+++ b/virtual_diary/ui_hook.py
@@ -32,6 +32,15 @@ async def add_entry_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register routes
-register_route_once("load_diary_entries", load_entries_ui)
-register_route_once("add_diary_entry", add_entry_ui)
-
+register_route_once(
+    "load_diary_entries",
+    load_entries_ui,
+    "Load diary entries",
+    "diary",
+)
+register_route_once(
+    "add_diary_entry",
+    add_entry_ui,
+    "Add a diary entry",
+    "diary",
+)

--- a/vote_registry/ui_hook.py
+++ b/vote_registry/ui_hook.py
@@ -26,5 +26,15 @@ async def load_votes_ui(_: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Register with the frontend bridge
-register_route_once("record_vote", record_vote_ui)
-register_route_once("load_votes", load_votes_ui)
+register_route_once(
+    "record_vote",
+    record_vote_ui,
+    "Record a new vote",
+    "vote",
+)
+register_route_once(
+    "load_votes",
+    load_votes_ui,
+    "Load recorded votes",
+    "vote",
+)


### PR DESCRIPTION
## Summary
- extend `register_route` to store description and category
- add a `help` route to list grouped route info
- document new endpoint in the README and docs
- annotate route registrations with short descriptions
- test help endpoint

## Testing
- `pytest tests/test_frontend_bridge.py tests/ui_hooks/test_route_listing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d83069cc8320b95665aa0c66b260