### PR TITLE
Enhance route listing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,14 +356,16 @@ The `frontend_bridge` module exposes a lightweight router for the UI. Handlers
 register themselves with `register_route(name, func)` and are invoked through
 `dispatch_route`.
 
-A convenient read-only route `"list_routes"` returns the currently available
-route names. This can help debug which backend callbacks are present:
+A convenient read-only route `"list_routes"` now returns structured details
+about each registered route. This helps debug which backend callbacks are
+present and what they do:
 
 ```python
 from frontend_bridge import dispatch_route
 
 routes = await dispatch_route("list_routes", {})
-print(routes["routes"])
+for route in routes["routes"]:
+    print(route["category"], route["name"], "-", route["doc"])
 ```
 
 ## 🧪 Running Tests

--- a/tests/test_frontend_bridge.py
+++ b/tests/test_frontend_bridge.py
@@ -1,9 +1,12 @@
 import pytest
 
-from frontend_bridge import dispatch_route, ROUTES
+from frontend_bridge import ROUTES, dispatch_route
 
 
 @pytest.mark.asyncio
 async def test_list_routes_returns_registered_names():
     result = await dispatch_route("list_routes", {})
-    assert set(result["routes"]) == set(ROUTES.keys())
+    names = {r["name"] for r in result["routes"]}
+    assert names == set(ROUTES.keys())
+    for r in result["routes"]:
+        assert {"category", "name", "doc"} <= r.keys()


### PR DESCRIPTION
## Summary
- return structured route metadata from `list_routes`
- document new output format in README
- adjust tests for new structure

## Testing
- `pre-commit run --files frontend_bridge.py tests/test_frontend_bridge.py README.md` *(fails: black reformatted files earlier & flake8 issues)*
- `pytest tests/test_frontend_bridge.py -q`
- `pytest -q` *(fails: numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887b96f120c8320b5d57437fe0cb688