### PR TITLE
Binary validation scaffold

### DIFF
--- a/docs/tasks/validation_certifier_v5_plan.md
+++ b/docs/tasks/validation_certifier_v5_plan.md
@@ -53,3 +53,8 @@ The tasks below break down these features and suggest initial API endpoints or m
 ---
 
 These tasks should be created as GitHub issues or added to the project backlog. They can be addressed independently but share dependencies on the new v5 API namespace.
+
+### Future Work – Decentralized Ownership Verification
+* **Binary Trust Output**: Expand the new 100/0 scoring scaffold into a full ownership verification module.
+* **Distributed Ledger**: Store binary validation outcomes on-chain for transparent audit trails.
+* **Reputation Weighting**: Integrate validator reputation into binary approval decisions.

--- a/tests/test_validation_pipeline.py
+++ b/tests/test_validation_pipeline.py
@@ -13,6 +13,6 @@ def test_sample_data_analysis():
     result = analyze_validation_integrity(validations)
     
     assert "recommended_certification" in result
-    assert result["consensus_score"] > 0
+    assert result["consensus_score"] in (0, 100)
     assert result["validator_count"] == len(validations)
     assert isinstance(result["integrity_analysis"], dict)

--- a/validate_hypothesis.py
+++ b/validate_hypothesis.py
@@ -106,7 +106,7 @@ def format_analysis_output(result: Dict[str, Any]) -> str:
     }.get(certification, "❓")
     
     output.append(f"\n{status_emoji} CERTIFICATION: {certification.upper()}")
-    output.append(f"📊 Consensus Score: {consensus_score}/1.0")
+    output.append(f"📊 Consensus Score: {consensus_score}")
     output.append(f"👥 Validators: {validator_count}")
     
     # Integrity analysis (if available)

--- a/validation_certifier.py
+++ b/validation_certifier.py
@@ -271,6 +271,8 @@ def certify_validations_comprehensive(
     # Step 1: Basic validation scoring
     scores = [score_validation(v) for v in validations]
     avg_score = mean(scores)
+    # Binary trust scaffold for future decentralized ownership verification
+    binary_score = 100 if avg_score >= 0.5 else 0
 
     # Step 2: Check for contradictions
     contradictory = any(
@@ -324,7 +326,7 @@ def certify_validations_comprehensive(
 
     result = {
         "certified_validations": validations,
-        "consensus_score": round(avg_score, 3),
+        "consensus_score": binary_score,
         "recommended_certification": certification,
         "flags": flags,
         "integrity_analysis": integrity_analysis,

--- a/validation_certifier.py
+++ b/validation_certifier.py
@@ -271,8 +271,13 @@ def certify_validations_comprehensive(
     # Step 1: Basic validation scoring
     scores = [score_validation(v) for v in validations]
     avg_score = mean(scores)
+
+    # TODO: In future versions, upgrade to SUPERMAJORITY_THRESHOLD (e.g., 0.66 or 0.75 or anything else) instead of fixed 0.66
+    # SUPERMAJORITY_THRESHOLD = 0.75  # Placeholder for symbolic governance upgrade (currently unused)
+    
     # Binary trust scaffold for future decentralized ownership verification
-    binary_score = 100 if avg_score >= 0.5 else 0
+    binary_score = 100 if avg_score >= 0.75 else 0
+
 
     # Step 2: Check for contradictions
     contradictory = any(


### PR DESCRIPTION
## Summary
- return binary consensus score from validation pipeline
- remove /1.0 output in CLI formatter
- test the new binary scoring logic
- outline decentralized ownership verification tasks in docs

## Testing
- `pytest tests/test_validation_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e2c77600832098c4befa57bab737