### PR TITLE
Add follow_user route

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -42,6 +42,7 @@ backend handler.
 |`queue_full_audit`|Queue a full introspection audit job.|
 |`poll_full_audit`|Poll the status of an introspection audit.|
 |`explain_audit`|Create a textual explanation for an audit trace.|
+|`follow_user`|Follow or unfollow a user. Payload: `{"username": "<target>"}`|
 
 These routes are provided for research purposes only. STRICTLY A SOCIAL MEDIA PLATFORM.
 They incorporate Intellectual Property & Artistic Inspiration protections

--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -225,6 +225,7 @@ import optimization.ui_hook  # noqa: F401 - route registration
 import causal_graph.ui_hook  # noqa: F401 - route registration
 import predictions.ui_hook  # noqa: F401 - route registration
 import social.ui_hook  # noqa: F401 - route registration
+import social.follow_ui_hook  # noqa: F401 - route registration
 import quantum_sim.ui_hook  # noqa: F401 - route registration
 import virtual_diary.ui_hook  # noqa: F401 - route registration
 

--- a/social/follow_ui_hook.py
+++ b/social/follow_ui_hook.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict, TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from frontend_bridge import register_route_once
+
+try:  # pragma: no cover - optional when running tests
+    from superNova_2177 import follow_unfollow_user  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    follow_unfollow_user = None  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from db_models import Harmonizer
+
+
+async def follow_user_ui(
+    payload: Dict[str, Any], db: Session, current_user: "Harmonizer"
+) -> Dict[str, str]:
+    """Follow or unfollow ``payload['username']`` for ``current_user``."""
+    username = payload["username"]
+    if follow_unfollow_user is None:
+        raise RuntimeError("follow_unfollow_user unavailable")
+    return follow_unfollow_user(username, db=db, current_user=current_user)
+
+
+register_route_once(
+    "follow_user",
+    follow_user_ui,
+    "Follow or unfollow a user",
+    "social",
+)

--- a/tests/ui_hooks/test_social_follow.py
+++ b/tests/ui_hooks/test_social_follow.py
@@ -1,0 +1,31 @@
+import pytest
+
+from frontend_bridge import dispatch_route
+import social.follow_ui_hook as follow_hook
+
+
+class DummyUser:
+    pass
+
+
+class DummyDB:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_follow_user_route(monkeypatch):
+    called = {}
+
+    def fake_follow(username, db, current_user):
+        called['args'] = (username, db, current_user)
+        return {'message': 'Followed'}
+
+    monkeypatch.setattr(follow_hook, 'follow_unfollow_user', fake_follow)
+
+    db = DummyDB()
+    user = DummyUser()
+    payload = {'username': 'alice'}
+    result = await dispatch_route('follow_user', payload, db=db, current_user=user)
+
+    assert result == {'message': 'Followed'}
+    assert called['args'] == ('alice', db, user)


### PR DESCRIPTION
## Summary
- add new social.follow_ui_hook module to expose follow_user route
- load follow_user route in frontend_bridge
- document follow_user payload in docs
- test follow_user route

## Testing
- `pytest -q tests/ui_hooks/test_social_follow.py`
- `pytest -q` *(fails: `TypeError: object() takes no arguments` during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6887e913b9688320b18e058f73509b48