### PR TITLE
Install build libs in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /install
 COPY requirements.txt ./
-RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libsnappy-dev \
+        libsdl2-dev \
+        libsdl2-image-dev \
+        libsdl2-mixer-dev \
+        libsdl2-ttf-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # Final stage
 FROM python:3.12-slim

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ This project depends on libraries such as `fastapi`, `pydantic-settings`, `struc
 
 ### System Packages
 
-Install these system dependencies if they're missing on your platform:
+Install these system dependencies if they're missing on your platform. If you
+build the project using Docker, these packages are installed automatically:
 
 **Ubuntu**
 


### PR DESCRIPTION
## Summary
- install SDL/snappy build dependencies in the Docker builder stage
- note that Docker installs these dependencies automatically in the docs

## Testing
- `pre-commit run --files Dockerfile README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ea6b62488320a06e8798f3ac77e0