### PR TITLE
Add proposal listing support

### DIFF
--- a/proposals/engine.py
+++ b/proposals/engine.py
@@ -59,6 +59,30 @@ class ProposalEngine:
             proposals.append(p)
         return proposals
 
+    # ------------------------------------------------------------------
+    def list_proposals(self, karma: int, state: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Return proposals for a user with ``karma`` given ``state``."""
+
+        if karma < self.min_karma:
+            return []
+
+        proposals: List[Dict[str, Any]] = []
+        for base in DEFAULT_PROPOSALS:
+            p = dict(base)
+            entropy = state.get("entropy", 0.0)
+            popularity = state.get("popularity", 0.5)
+            p.update(
+                {
+                    "urgency": "high" if entropy > 1.0 else "low",
+                    "popularity": popularity,
+                    "entropy": entropy,
+                }
+            )
+            if self.universe_metadata:
+                p["universe"] = self.universe_metadata
+            proposals.append(p)
+        return proposals
+
 
 # Convenience function -------------------------------------------------
 
@@ -69,7 +93,7 @@ def generate_proposals(
     min_karma: int = 0,
     requires_certification: bool = False,
     universe_metadata: Optional[Dict[str, Any]] = None,
-) -> List[Dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
     """Generate proposals filtered by ``user`` attributes."""
 
     engine = ProposalEngine(
@@ -78,3 +102,21 @@ def generate_proposals(
         universe_metadata=universe_metadata,
     )
     return engine.generate(user, universe_state)
+
+
+def list_proposals(
+    user: Dict[str, Any],
+    universe_state: Dict[str, Any],
+    *,
+    min_karma: int = 0,
+    requires_certification: bool = False,
+    universe_metadata: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """List proposals for ``user`` using their karma and ``universe_state``."""
+
+    engine = ProposalEngine(
+        min_karma=min_karma,
+        requires_certification=requires_certification,
+        universe_metadata=universe_metadata,
+    )
+    return engine.list_proposals(user.get("karma", 0), universe_state)

--- a/tests/proposals/test_engine.py
+++ b/tests/proposals/test_engine.py
@@ -1,4 +1,4 @@
-from proposals.engine import generate_proposals, DEFAULT_PROPOSALS
+from proposals.engine import generate_proposals, list_proposals, DEFAULT_PROPOSALS
 
 
 def test_low_karma_filtered():
@@ -27,3 +27,28 @@ def test_high_karma_receives_proposals():
         assert p["urgency"] in {"high", "low"}
         assert "popularity" in p and "entropy" in p
         assert p.get("universe") == {"id": "u1"}
+
+
+def test_list_low_karma_filtered():
+    user = {"karma": 5}
+    state = {"entropy": 0.2, "popularity": 0.3}
+
+    assert list_proposals(user, state, min_karma=50) == []
+
+
+def test_list_high_karma_receives_proposals():
+    user = {"karma": 80}
+    state = {"entropy": 1.5, "popularity": 0.7}
+
+    proposals = list_proposals(
+        user,
+        state,
+        min_karma=50,
+        universe_metadata={"id": "u2"},
+    )
+
+    assert len(proposals) == len(DEFAULT_PROPOSALS)
+    for p in proposals:
+        assert p["urgency"] in {"high", "low"}
+        assert "popularity" in p and "entropy" in p
+        assert p.get("universe") == {"id": "u2"}


### PR DESCRIPTION
## Summary
- allow listing proposals via new ProposalEngine.list_proposals
- expose helper list_proposals for convenience
- test listing logic and ensure universe_ui uses the engine

## Testing
- `pytest tests/proposals/test_engine.py tests/ui_hooks/test_universe_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e917ef308320ba4d473df3ba7da4