### PR TITLE
Fix async runner in streamlit_app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,7 +14,7 @@ def _run_async(coro):
         return asyncio.run(coro)
     else:
         if loop.is_running():
-            return asyncio.run(coro)
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
         return loop.run_until_complete(coro)
 
 

--- a/tests/test_streamlit_async.py
+++ b/tests/test_streamlit_async.py
@@ -1,0 +1,72 @@
+import sys
+import types
+import importlib
+import asyncio
+
+
+def load_app(monkeypatch):
+    """Reload ``streamlit_app`` with a stubbed ``streamlit`` module."""
+    stub = types.ModuleType("streamlit")
+    # provide minimal attributes used in ``streamlit_app``
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    if "streamlit_app" in sys.modules:
+        del sys.modules["streamlit_app"]
+    return importlib.import_module("streamlit_app")
+
+
+async def sample():
+    return "done"
+
+
+def test_run_async_without_running_loop(monkeypatch):
+    app = load_app(monkeypatch)
+    calls = {}
+
+    def fake_run(coro):
+        calls["coro"] = coro
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr(app.asyncio, "get_running_loop", lambda: (_ for _ in ()).throw(RuntimeError()))
+    monkeypatch.setattr(app.asyncio, "run", fake_run)
+
+    result = app._run_async(sample())
+    assert result == "done"
+    assert calls["coro"].__class__.__name__ == "coroutine"
+
+
+def test_run_async_with_running_loop(monkeypatch):
+    app = load_app(monkeypatch)
+
+    class DummyLoop:
+        def __init__(self):
+            self.coro = None
+        def is_running(self):
+            return True
+        def run_until_complete(self, coro):
+            self.coro = coro
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+
+    loop = DummyLoop()
+    fut_obj = types.SimpleNamespace()
+
+    def fake_run_coroutine_threadsafe(coro, l):
+        assert l is loop
+        loop.coro = coro
+        fut_obj.result = lambda: loop.run_until_complete(coro)
+        return fut_obj
+
+    monkeypatch.setattr(app.asyncio, "get_running_loop", lambda: loop)
+    monkeypatch.setattr(app.asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
+
+    result = app._run_async(sample())
+    assert result == "done"
+    assert loop.coro.__class__.__name__ == "coroutine"
+


### PR DESCRIPTION
## Summary
- improve `_run_async` to handle running loops
- add tests for `_run_async` covering running and non-running loop cases

## Testing
- `pytest tests/test_streamlit_helpers.py tests/test_streamlit_async.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: 'jose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887eac28f548320b262dc6281bad326