### PR TITLE
Enable patch compliance check using existing disclaimers

### DIFF
--- a/governance/patch_monitor.py
+++ b/governance/patch_monitor.py
@@ -41,16 +41,52 @@ def check_file_compliance(
     return []
 
 
+def _check_patch_file(path: str | None, additions: List[str], phrases: Iterable[str]) -> List[str]:
+    """Return issues for a single file patch."""
+    if not additions:
+        return []
+    text = "\n".join(additions)
+    if _contains_disclaimers(text, phrases):
+        return []
+    if path:
+        p = Path(path)
+        if p.is_file() and _contains_disclaimers(p.read_text(errors="ignore"), phrases):
+            return []
+    return ["New additions missing required disclaimers"]
+
+
 def check_patch_compliance(
     patch: str, phrases: Iterable[str] = DEFAULT_DISCLAIMER_PHRASES
 ) -> List[str]:
-    """Inspect added lines in a diff patch for required disclaimers."""
-    additions = [
-        line[1:]
-        for line in patch.splitlines()
-        if line.startswith("+") and not line.startswith("+++")
-    ]
-    text = "\n".join(additions)
-    if additions and not _contains_disclaimers(text, phrases):
-        return ["New additions missing required disclaimers"]
-    return []
+    """Inspect added lines in a diff patch for required disclaimers.
+
+    If a modified file already contains the required phrases, the patch is
+    considered compliant even when the additions themselves omit the lines.
+    """
+    issues: List[str] = []
+    current_path: str | None = None
+    additions: List[str] = []
+
+    for line in patch.splitlines():
+        if line.startswith("diff --git"):
+            if current_path is not None:
+                issues.extend(_check_patch_file(current_path, additions, phrases))
+            current_path = None
+            additions = []
+            continue
+        if line.startswith("+++ "):
+            path = line[4:].strip()
+            if path != "/dev/null":
+                current_path = path[2:] if path.startswith("b/") else path
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            additions.append(line[1:])
+
+    if current_path is not None:
+        issues.extend(_check_patch_file(current_path, additions, phrases))
+
+    # Handle patches without path information
+    if not issues and additions:
+        issues.extend(_check_patch_file(None, additions, phrases))
+
+    return issues

--- a/scripts/check_disclaimers.py
+++ b/scripts/check_disclaimers.py
@@ -29,7 +29,7 @@ def main() -> int:
     if issues:
         print("\n".join(issues))
         return 1
-    print("Patch contains required disclaimers.")
+    print("Patch contains required disclaimers or they already exist in files.")
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import importlib.util
+import types
 
 _orig_find_spec = importlib.util.find_spec
 
@@ -469,7 +470,20 @@ for mod_name in [
             pass
         stub = types.ModuleType(mod_name)
         if mod_name == "fastapi":
-            stub.FastAPI = object
+            class FastAPI:
+                def __init__(self, *a, **kw):
+                    pass
+
+                def _decorator(self, *a, **kw):
+                    def wrapper(func):
+                        return func
+
+                    return wrapper
+
+                post = _decorator
+                get = _decorator
+
+            stub.FastAPI = FastAPI
             stub.Depends = lambda x=None: None
             stub.HTTPException = type("HTTPException", (), {})
             stub.Query = lambda *a, **kw: None

--- a/tests/test_patch_monitor.py
+++ b/tests/test_patch_monitor.py
@@ -39,3 +39,25 @@ def test_check_patch_compliance_missing():
     patch = "@@\n+print('hi')\n"
     issues = check_patch_compliance(patch)
     assert issues and "missing required disclaimers" in issues[0].lower()  # nosec B101
+
+
+def test_check_patch_compliance_existing_file(tmp_path, monkeypatch):
+    f = tmp_path / "module.py"
+    f.write_text(
+        (
+            "# STRICTLY A SOCIAL MEDIA PLATFORM\n"
+            "# Intellectual Property & Artistic Inspiration\n"
+            "# Legal & Ethical Safeguards\n"
+            "print('hello')\n"
+        )
+    )
+    patch = textwrap.dedent(
+        f"""diff --git a/{f.name} b/{f.name}
+        --- a/{f.name}
+        +++ b/{f.name}
+        @@
+        +print('world')
+        """
+    )
+    monkeypatch.chdir(tmp_path)
+    assert check_patch_compliance(patch) == []  # nosec B101


### PR DESCRIPTION
## Summary
- check if required phrases already exist in files before flagging patches
- update disclaimer check script message
- fix `tests/conftest` stub imports and add new compliance test

## Testing
- `pytest tests/test_patch_monitor.py tests/test_check_disclaimers_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ec06094c832080fa0bd05aee35fd