### PR TITLE
Install apt build deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /install
 COPY requirements.txt ./
-RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libsnappy-dev \
+        libsdl2-dev \
+        libsdl2-image-dev \
+        libsdl2-mixer-dev \
+        libsdl2-ttf-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # Final stage
 FROM python:3.12-slim

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Install these system dependencies if they're missing on your platform:
 sudo apt-get install build-essential libsnappy-dev libsdl2-dev …
 ```
 
+The Docker image installs these dependencies automatically, so you only
+need them locally when running without Docker.
+
 **macOS**
 
 ```bash
@@ -251,6 +254,9 @@ Build the image:
 ```bash
 docker build -t supernova-2177 .
 ```
+
+The build process installs required system libraries such as `libsnappy-dev`
+and SDL dependencies, so no manual setup is needed when using Docker.
 
 Or bring up the full stack:
 ```bash


### PR DESCRIPTION
## Summary
- install build tools and SDL/snappy libraries before pip install
- document that Docker automatically sets up the system dependencies

## Testing
- `pytest -q` *(fails: TypeError: object() takes no arguments)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887eb4bf15483208b05f44ef403a573