### PR TITLE
Update Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 # Builder stage
 # Use slim Python image for smaller footprint
 FROM python:3.12-slim AS builder
@@ -37,7 +41,8 @@ RUN chown -R appuser:appuser /app
 
 USER appuser
 
-# Expose FastAPI default port
-EXPOSE 8000
+# Expose Streamlit default port
+EXPOSE 8501
 
-CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]
+# Launch Streamlit UI explicitly
+CMD ["streamlit", "run", "ui.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ cp .env.example .env  # set your own secrets
 docker-compose up
 ```
 
-The application will be available at [http://localhost:8000](http://localhost:8000).
+The Streamlit dashboard will be available at [http://localhost:8501](http://localhost:8501).
 
 ## Authentication
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
 version: "3.9"
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 services:
   app:
     build: .
     ports:
-      - "8000:8000"
+      - "8501:8501"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Summary
- run the Streamlit dashboard by default in Docker
- expose the Streamlit port in docker-compose and document the new URL

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml README.md`
- `pytest -q` *(fails: AttributeError in `superNova_2177`)*

------
https://chatgpt.com/codex/tasks/task_e_6887f29526448320b3d9d02e26164b69