### PR TITLE
Update UI port docs and compose config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Optional: leave blank to auto-generate a secure key
 SECRET_KEY=
 DATABASE_URL=postgresql+asyncpg://<username>:<password>@<hostname>/<database>
-BACKEND_URL=http://localhost:8000
+BACKEND_URL=http://localhost:8501

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ cp .env.example .env  # set your own secrets
 docker-compose up
 ```
 
-The application will be available at [http://localhost:8000](http://localhost:8000).
+The application will be available at [http://localhost:8501](http://localhost:8501).
 
 ## Authentication
 
@@ -554,7 +554,7 @@ is optional because a secure one will be generated if omitted:
 # optional
 export SECRET_KEY="your-secret"
 export DATABASE_URL="postgresql+asyncpg://<username>:<password>@<hostname>/<database>"
-export BACKEND_URL="http://localhost:8000"
+export BACKEND_URL="http://localhost:8501"
 ```
 
 To connect to a central database instead of the local file, pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
     ports:
-      - "8000:8000"
+      - "8501:8501"
     depends_on:
       - db
       - redis

--- a/transcendental_resonance_frontend/README.md
+++ b/transcendental_resonance_frontend/README.md
@@ -20,7 +20,7 @@ python -m transcendental_resonance_frontend.demo
 
 This command starts the app using data from `src/utils/sample_data/`.
 
-Replace the backend URL with the `BACKEND_URL` environment variable if your API is not running on `http://localhost:8000`.
+Replace the backend URL with the `BACKEND_URL` environment variable if your API is not running on `http://localhost:8501`.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
- expose port 8501 in docker-compose
- update README instructions to use port 8501
- change BACKEND_URL examples to 8501
- update frontend README with new port

## Testing
- `pytest -q` *(fails: AttributeError module 'superNova_2177')*

------
https://chatgpt.com/codex/tasks/task_e_6887f3be00dc8320881a45afbf7b9021