### PR TITLE
Update Docker instructions for UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ Build the image:
 docker build -t supernova-2177 .
 ```
 
+To build and run the Streamlit UI inside Docker:
+```bash
+docker build -t supernova-ui .
+docker run -p 8501:8501 supernova-ui
+```
+
 The build process installs required system libraries such as `libsnappy-dev`
 and SDL dependencies, so no manual setup is needed when using Docker.
 
@@ -265,7 +271,8 @@ cp .env.example .env  # set your own secrets
 docker-compose up
 ```
 
-The application will be available at [http://localhost:8000](http://localhost:8000).
+The application will be available at [http://localhost:8000](http://localhost:8000),
+and the Streamlit UI at [http://localhost:8501](http://localhost:8501).
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- document how to build and run the Streamlit UI via Docker
- note that `docker-compose up` now exposes the UI on port 8501

## Testing
- `pytest -q` *(fails: AttributeError: module 'superNova_2177' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6887f3c45aa483209f1399fb5b277ad9