### PR TITLE
Update Dockerfile to run Streamlit UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN chown -R appuser:appuser /app
 
 USER appuser
 
-# Expose FastAPI default port
-EXPOSE 8000
+# Expose Streamlit port
+EXPOSE 8501
 
-CMD ["uvicorn", "superNova_2177:app", "--host", "0.0.0.0", "--port", "8000"]
+# Launch the Streamlit UI
+CMD ["streamlit", "run", "ui.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
## Summary
- update Dockerfile to expose port 8501
- launch Streamlit UI when container starts

## Testing
- `pre-commit run --files Dockerfile`
- `pytest` *(fails: AttributeError: module 'superNova_2177' has no attribute 'app')*
- `streamlit run ui.py --server.port=8501 --server.address=0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_6887f39ca6b48320a0b9a21c03e1c0f2