### PR TITLE
Add streamlit entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /install
 COPY requirements.txt ./
+# Install build tools and Python dependencies, including Streamlit
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -45,4 +46,4 @@ USER appuser
 EXPOSE 8501
 
 # Launch Streamlit UI explicitly
-CMD ["streamlit", "run", "ui.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ lint:
 	mypy
 
 ui:
-	streamlit run ui.py
+	streamlit run streamlit_app.py

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ module falls back to a development setup equivalent to:
 The dashboard provides real-time integrity metrics and network graphs built with `streamlit`, `networkx`, and `matplotlib`. Upload your validations JSON or enable demo mode to populate the table. You can edit rows inline before re-running the analysis to see how scores change.
 
 ```bash
-streamlit run ui.py
+streamlit run streamlit_app.py
 ```
 
 Use the sidebar file uploader to select or update your dataset, then click **Run Analysis** to refresh the report.
@@ -354,7 +354,7 @@ Deploy the demo UI online with Streamlit Cloud:
 
 1. Fork this repository on GitHub.
 2. Sign in to [Streamlit Cloud](https://streamlit.io/cloud) and select **New app**.
-3. Choose the repo and set `ui.py` as the entry point.
+3. Choose the repo and set `streamlit_app.py` as the entry point.
 4. Add your `SECRET_KEY` and set a `DATABASE_URL` secret with your connection string under **Secrets** in the app settings.
 5. Streamlit will install dependencies from `requirements.txt` and launch the app.
 

--- a/launch_ui.sh
+++ b/launch_ui.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-streamlit run ui.py
+streamlit run streamlit_app.py


### PR DESCRIPTION
## Summary
- install Streamlit via requirements during build
- run `streamlit_app.py` by default in Docker and helper scripts
- document Streamlit dashboard command

## Testing
- `pytest -q` *(fails: module errors)*
- `docker build -t test-image .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f48871b88320aee9fd9ff3809a4e