### PR TITLE
Add modular social and voting UI tabs

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -1,0 +1,136 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+from datetime import datetime
+import streamlit as st
+
+
+def summarize_text(text: str, max_len: int = 150) -> str:
+    """Basic text summarizer placeholder."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def render_agent_insights_tab() -> None:
+    """Display diary entries, RFC summaries and agent notes."""
+    st.subheader("Virtual Diary")
+    with st.expander("📘 Notes", expanded=False):
+        diary_note = st.text_input("Add note")
+        rfc_input = st.text_input("Referenced RFC IDs (comma separated)")
+        if st.button("Append Note"):
+            entry = {
+                "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+                "note": diary_note,
+            }
+            rfc_ids = [r.strip() for r in rfc_input.split(",") if r.strip()]
+            if rfc_ids:
+                entry["rfc_ids"] = rfc_ids
+            st.session_state.setdefault("diary", []).append(entry)
+        for i, entry in enumerate(st.session_state.get("diary", [])):
+            anchor = f"diary-{i}"
+            note = entry.get("note", "")
+            rfc_list = entry.get("rfc_ids")
+            extra = f" (RFCs: {', '.join(rfc_list)})" if rfc_list else ""
+            st.markdown(
+                f"<p id='{anchor}'><strong>{entry['timestamp']}</strong>: {note}{extra}</p>",
+                unsafe_allow_html=True,
+            )
+        if st.download_button(
+            "Export Diary as Markdown",
+            "\n".join(
+                [
+                    f"* {e['timestamp']}: {e.get('note', '')}" + (
+                        f" (RFCs: {', '.join(e['rfc_ids'])})" if e.get("rfc_ids") else ""
+                    )
+                    for e in st.session_state.get("diary", [])
+                ]
+            ),
+            file_name="diary.md",
+        ):
+            pass
+        st.download_button(
+            "Export Diary as JSON",
+            json.dumps(st.session_state.get("diary", []), indent=2),
+            file_name="diary.json",
+        )
+
+    st.subheader("RFCs and Agent Insights")
+    with st.expander("Proposed RFCs", expanded=False):
+        rfc_dir = Path("rfcs")
+        filter_text = st.text_input("Filter RFCs")
+        preview_all = st.checkbox("Preview full text")
+
+        def parse_summary(text: str) -> str:
+            if "## Summary" not in text:
+                return ""
+            part = text.split("## Summary", 1)[1]
+            lines = []
+            for line in part.splitlines()[1:]:
+                if line.startswith("##"):
+                    break
+                if line.strip():
+                    lines.append(line.strip())
+            return " ".join(lines)
+
+        rfc_paths = sorted(rfc_dir.rglob("rfc-*.md"))
+        rfc_entries: list[dict[str, Any]] = []
+        rfc_index: dict[str, dict[str, Any]] = {}
+        for path in rfc_paths:
+            text = path.read_text()
+            summary = parse_summary(text)
+            entry = {
+                "id": path.stem,
+                "summary": summary,
+                "text": text,
+                "path": path,
+            }
+            rfc_entries.append(entry)
+            rfc_index[path.stem.lower()] = entry
+
+        diary_mentions: dict[str, list[int]] = {str(e["id"]): [] for e in rfc_entries}
+        for i, entry in enumerate(st.session_state.get("diary", [])):
+            note_lower = entry.get("note", "").lower()
+            ids = {e.strip().lower() for e in entry.get("rfc_ids", []) if e}
+            for rfc in rfc_entries:
+                rid = str(rfc["id"]).lower()
+                if rid in note_lower or rid.replace("-", " ") in note_lower or rid in ids:
+                    diary_mentions.setdefault(str(rfc["id"]), []).append(i)
+                    continue
+                keywords = {w.strip(".,()[]{}:").lower() for w in str(rfc["summary"]).split() if len(w) > 4}
+                if any(k in note_lower for k in keywords):
+                    diary_mentions.setdefault(str(rfc["id"]), []).append(i)
+
+        for rfc in rfc_entries:
+            if (
+                filter_text
+                and filter_text.lower() not in rfc["summary"].lower()
+                and filter_text.lower() not in rfc["id"].lower()
+            ):
+                continue
+            mentions = diary_mentions.get(str(rfc["id"]), [])
+            heading = f"<mark>{rfc['id']}</mark>" if mentions else rfc["id"]
+            st.markdown(f"### {heading}", unsafe_allow_html=True)
+            st.write(summarize_text(str(rfc["summary"])))
+            if mentions:
+                links = ", ".join([f"[entry {idx + 1}](#diary-{idx})" for idx in mentions])
+                st.markdown(f"Referenced in: {links}", unsafe_allow_html=True)
+            st.markdown(f"[Read RFC]({cast(Path, rfc['path']).as_posix()})")
+            if preview_all or st.checkbox("Show details", key=f"show_{rfc['id']}"):
+                st.markdown(rfc["text"], unsafe_allow_html=True)
+
+    st.subheader("Protocols")
+    with st.expander("Repository Protocols", expanded=False):
+        proto_dir = Path("protocols")
+        files = sorted([p for p in proto_dir.glob("*.py") if p.is_file()])
+        for file in files:
+            st.markdown(f"- [{file.name}]({file.as_posix()})")
+
+    notes_path = Path("AgentNotes.md")
+    if notes_path.exists():
+        notes_content = notes_path.read_text()
+    else:
+        notes_content = "No notes found."
+
+    with st.expander("Agent’s Internal Thoughts"):
+        st.markdown(notes_content)

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -1,0 +1,46 @@
+import asyncio
+import streamlit as st
+
+from frontend_bridge import dispatch_route
+from streamlit_helpers import alert
+
+
+def _run_async(coro):
+    """Execute an async coroutine and return the result."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def render_social_tab() -> None:
+    """Display simple social network interactions."""
+    if dispatch_route is None:
+        alert("Social routes not enabled—enable them in config.", "warning")
+        return
+
+    st.subheader("Follow / Unfollow")
+    username = st.text_input("Target Username")
+    if st.button("Toggle Follow") and username:
+        try:
+            res = _run_async(dispatch_route("follow_user", {"username": username}))
+            st.write(res.get("message", res))
+        except Exception as exc:
+            alert(f"Action failed: {exc}", "error")
+
+    st.divider()
+    st.subheader("Simulate Social Entanglement")
+    col1, col2 = st.columns(2)
+    user1 = col1.number_input("User 1 ID", value=1, step=1)
+    user2 = col2.number_input("User 2 ID", value=2, step=1)
+    if st.button("Run Simulation"):
+        payload = {"user1_id": int(user1), "user2_id": int(user2)}
+        try:
+            result = _run_async(dispatch_route("simulate_entanglement", payload))
+            st.json(result)
+        except Exception as exc:
+            alert(f"Simulation failed: {exc}", "error")

--- a/ui.py
+++ b/ui.py
@@ -81,6 +81,9 @@ from frontend_bridge import dispatch_route, ROUTE_INFO
 
 from llm_backends import get_backend
 from protocols import AGENT_REGISTRY
+from social_tabs import render_social_tab
+from voting_ui import render_voting_tab
+from agent_ui import render_agent_insights_tab
 
 try:
     st_secrets = st.secrets
@@ -449,181 +452,8 @@ def boot_diagnostic_ui():
     run_analysis([], layout="force")
 
 
-def render_proposals_tab() -> None:
-    """Display proposal creation, listing and voting controls."""
-    if dispatch_route is None:
-        alert(
-            "Governance routes not enabled—enable them in config.",
-            "warning",
-        )
-        return
-    if st.button("Refresh Proposals"):
-        try:
-            res = _run_async(dispatch_route("list_proposals", {}))
-            st.session_state["proposals_cache"] = res.get("proposals", [])
-        except Exception as exc:
-            alert(f"Failed to load proposals: {exc}", "error")
 
-    proposals = st.session_state.get("proposals_cache", [])
-    if proposals:
-        simple = [
-            {
-                "id": p.get("id"),
-                "title": p.get("title"),
-                "status": p.get("status"),
-                "deadline": p.get("voting_deadline"),
-            }
-            for p in proposals
-        ]
-        st.table(simple)
-
-    with st.form("create_proposal_form"):
-        st.write("Create Proposal")
-        title = st.text_input("Title")
-        description = st.text_area("Description")
-        author_id = st.number_input("Author ID", value=1, step=1)
-        group_id = st.text_input("Group ID")
-        voting_deadline = st.date_input("Voting Deadline")
-        submitted = st.form_submit_button("Create")
-    if submitted:
-        payload = {
-            "title": title,
-            "description": description,
-            "author_id": int(author_id),
-            "group_id": group_id or None,
-            "voting_deadline": voting_deadline.isoformat(),
-        }
-        try:
-            res = _run_async(dispatch_route("create_proposal", payload))
-            alert(f"Proposal {res.get('proposal_id')} created", "info")
-        except Exception as exc:
-            alert(f"Create failed: {exc}", "error")
-
-    with st.form("vote_proposal_form"):
-        st.write("Vote on Proposal")
-        ids = [p.get("id") for p in proposals]
-        prop_id = st.selectbox("Proposal", ids) if ids else st.number_input("Proposal ID", value=1, step=1)
-        harmonizer_id = st.number_input("Harmonizer ID", value=1, step=1, key="harmonizer_id_vote")
-        vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
-        vote_sub = st.form_submit_button("Submit Vote")
-    if vote_sub:
-        payload = {
-            "proposal_id": prop_id,
-            "harmonizer_id": int(harmonizer_id),
-            "vote": vote_choice,
-        }
-        try:
-            res = _run_async(dispatch_route("vote_proposal", payload))
-            alert(f"Vote recorded id {res.get('vote_id')}", "info")
-        except Exception as exc:
-            alert(f"Vote failed: {exc}", "error")
-
-
-def render_governance_tab() -> None:
-    """Display generic vote registry operations."""
-    if dispatch_route is None:
-        alert(
-            "Governance routes not enabled—enable them in config.",
-            "warning",
-        )
-        return
-    if st.button("Refresh Votes"):
-        try:
-            res = _run_async(dispatch_route("load_votes", {}))
-            st.session_state["votes_cache"] = res.get("votes", [])
-        except Exception as exc:
-            alert(f"Failed to load votes: {exc}", "error")
-
-    votes = st.session_state.get("votes_cache", [])
-    if votes:
-        st.table(votes)
-
-    with st.form("record_vote_form"):
-        st.write("Record Vote")
-        species = st.selectbox("Species", ["human", "ai", "company"])
-        extra_json = st.text_input("Extra Fields (JSON)", value="{}")
-        submit = st.form_submit_button("Record")
-    if submit:
-        try:
-            extra = json.loads(extra_json or "{}")
-        except Exception as exc:
-            alert(f"Invalid JSON: {exc}", "error")
-        else:
-            payload = {"species": species, **extra}
-            try:
-                _run_async(dispatch_route("record_vote", payload))
-                alert("Vote recorded", "info")
-            except Exception as exc:
-                alert(f"Record failed: {exc}", "error")
-
-
-def render_agent_ops_tab() -> None:
-    """Expose protocol agent management routes."""
-    if dispatch_route is None:
-        alert(
-            "Governance routes not enabled—enable them in config.",
-            "warning",
-        )
-        return
-    if st.button("Reload Agent List"):
-        try:
-            res = _run_async(dispatch_route("list_agents", {}))
-            st.session_state["agent_list"] = res.get("agents", [])
-        except Exception as exc:
-            alert(f"Load failed: {exc}", "error")
-
-    agents = st.session_state.get("agent_list", [])
-    st.write("Available Agents", agents)
-
-    with st.form("launch_agents_form"):
-        launch_sel = st.multiselect("Agents to launch", agents)
-        llm_backend = st.selectbox("LLM Backend", ["", "dummy", "GPT-4o", "Claude-3", "Gemini"])
-        provider = st.text_input("Provider")
-        api_key = st.text_input("API Key", type="password")
-        launch = st.form_submit_button("Launch Agents")
-    if launch:
-        payload = {
-            "agents": launch_sel,
-            "llm_backend": llm_backend or None,
-            "provider": provider,
-            "api_key": api_key,
-        }
-        try:
-            res = _run_async(dispatch_route("launch_agents", payload))
-            st.json(res)
-        except Exception as exc:
-            alert(f"Launch failed: {exc}", "error")
-
-    if st.button("Step Agents"):
-        try:
-            res = _run_async(dispatch_route("step_agents", {}))
-            st.json(res)
-        except Exception as exc:
-            alert(f"Step failed: {exc}", "error")
-
-
-def render_logs_tab() -> None:
-    """Provide simple audit trace explanation."""
-    if dispatch_route is None:
-        alert(
-            "Governance routes not enabled—enable them in config.",
-            "warning",
-        )
-        return
-    trace_text = st.text_area("Audit Trace JSON", value="{}", height=200)
-    if st.button("Explain Trace"):
-        try:
-            trace = json.loads(trace_text or "{}")
-        except Exception as exc:
-            alert(f"Invalid JSON: {exc}", "error")
-        else:
-            try:
-                res = _run_async(dispatch_route("explain_audit", {"trace": trace}))
-                st.text_area("Explanation", value=res, height=150)
-            except Exception as exc:
-                alert(f"Explain failed: {exc}", "error")
-
-def main() -> None:
+def render_validation_ui() -> None:
     """Main entry point for the validation analysis UI."""
     header("superNova_2177 Validation Analyzer", layout="wide")
 
@@ -1115,20 +945,21 @@ def main() -> None:
     with st.expander("Agent’s Internal Thoughts"):
         st.markdown(notes_content)
 
-    tabs = st.tabs([
-        "Proposal Hub",
-        "Governance",
-        "Agent Ops",
-        "Logs",
-    ])
-    with tabs[0]:
-        render_proposals_tab()
-    with tabs[1]:
-        render_governance_tab()
-    with tabs[2]:
-        render_agent_ops_tab()
-    with tabs[3]:
-        render_logs_tab()
+
+def main() -> None:
+    """Entry point assembling all UI sections."""
+    tab1, tab2, tab3, tab4 = st.tabs(
+        ["Validation", "Friends", "Votes", "Agents"]
+    )
+    with tab1:
+        render_validation_ui()
+    with tab2:
+        render_social_tab()
+    with tab3:
+        render_voting_tab()
+    with tab4:
+        render_agent_insights_tab()
+
 
 
 if __name__ == "__main__":

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -1,0 +1,211 @@
+import asyncio
+import json
+import streamlit as st
+
+from frontend_bridge import dispatch_route
+from streamlit_helpers import alert
+
+
+def _run_async(coro):
+    """Execute an async coroutine and return the result."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def render_proposals_tab() -> None:
+    """Display proposal creation, listing and voting controls."""
+    if dispatch_route is None:
+        alert(
+            "Governance routes not enabled—enable them in config.",
+            "warning",
+        )
+        return
+    if st.button("Refresh Proposals"):
+        try:
+            res = _run_async(dispatch_route("list_proposals", {}))
+            st.session_state["proposals_cache"] = res.get("proposals", [])
+        except Exception as exc:
+            alert(f"Failed to load proposals: {exc}", "error")
+
+    proposals = st.session_state.get("proposals_cache", [])
+    if proposals:
+        simple = [
+            {
+                "id": p.get("id"),
+                "title": p.get("title"),
+                "status": p.get("status"),
+                "deadline": p.get("voting_deadline"),
+            }
+            for p in proposals
+        ]
+        st.table(simple)
+
+    with st.form("create_proposal_form"):
+        st.write("Create Proposal")
+        title = st.text_input("Title")
+        description = st.text_area("Description")
+        author_id = st.number_input("Author ID", value=1, step=1)
+        group_id = st.text_input("Group ID")
+        voting_deadline = st.date_input("Voting Deadline")
+        submitted = st.form_submit_button("Create")
+    if submitted:
+        payload = {
+            "title": title,
+            "description": description,
+            "author_id": int(author_id),
+            "group_id": group_id or None,
+            "voting_deadline": voting_deadline.isoformat(),
+        }
+        try:
+            res = _run_async(dispatch_route("create_proposal", payload))
+            alert(f"Proposal {res.get('proposal_id')} created", "info")
+        except Exception as exc:
+            alert(f"Create failed: {exc}", "error")
+
+    with st.form("vote_proposal_form"):
+        st.write("Vote on Proposal")
+        ids = [p.get("id") for p in proposals]
+        prop_id = st.selectbox("Proposal", ids) if ids else st.number_input("Proposal ID", value=1, step=1)
+        harmonizer_id = st.number_input("Harmonizer ID", value=1, step=1, key="harmonizer_id_vote")
+        vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
+        vote_sub = st.form_submit_button("Submit Vote")
+    if vote_sub:
+        payload = {
+            "proposal_id": prop_id,
+            "harmonizer_id": int(harmonizer_id),
+            "vote": vote_choice,
+        }
+        try:
+            res = _run_async(dispatch_route("vote_proposal", payload))
+            alert(f"Vote recorded id {res.get('vote_id')}", "info")
+        except Exception as exc:
+            alert(f"Vote failed: {exc}", "error")
+
+
+def render_governance_tab() -> None:
+    """Display generic vote registry operations."""
+    if dispatch_route is None:
+        alert(
+            "Governance routes not enabled—enable them in config.",
+            "warning",
+        )
+        return
+    if st.button("Refresh Votes"):
+        try:
+            res = _run_async(dispatch_route("load_votes", {}))
+            st.session_state["votes_cache"] = res.get("votes", [])
+        except Exception as exc:
+            alert(f"Failed to load votes: {exc}", "error")
+
+    votes = st.session_state.get("votes_cache", [])
+    if votes:
+        st.table(votes)
+
+    with st.form("record_vote_form"):
+        st.write("Record Vote")
+        species = st.selectbox("Species", ["human", "ai", "company"])
+        extra_json = st.text_input("Extra Fields (JSON)", value="{}")
+        submit = st.form_submit_button("Record")
+    if submit:
+        try:
+            extra = json.loads(extra_json or "{}")
+        except Exception as exc:
+            alert(f"Invalid JSON: {exc}", "error")
+        else:
+            payload = {"species": species, **extra}
+            try:
+                _run_async(dispatch_route("record_vote", payload))
+                alert("Vote recorded", "info")
+            except Exception as exc:
+                alert(f"Record failed: {exc}", "error")
+
+
+def render_agent_ops_tab() -> None:
+    """Expose protocol agent management routes."""
+    if dispatch_route is None:
+        alert(
+            "Governance routes not enabled—enable them in config.",
+            "warning",
+        )
+        return
+    if st.button("Reload Agent List"):
+        try:
+            res = _run_async(dispatch_route("list_agents", {}))
+            st.session_state["agent_list"] = res.get("agents", [])
+        except Exception as exc:
+            alert(f"Load failed: {exc}", "error")
+
+    agents = st.session_state.get("agent_list", [])
+    st.write("Available Agents", agents)
+
+    with st.form("launch_agents_form"):
+        launch_sel = st.multiselect("Agents to launch", agents)
+        llm_backend = st.selectbox("LLM Backend", ["", "dummy", "GPT-4o", "Claude-3", "Gemini"])
+        provider = st.text_input("Provider")
+        api_key = st.text_input("API Key", type="password")
+        launch = st.form_submit_button("Launch Agents")
+    if launch:
+        payload = {
+            "agents": launch_sel,
+            "llm_backend": llm_backend or None,
+            "provider": provider,
+            "api_key": api_key,
+        }
+        try:
+            res = _run_async(dispatch_route("launch_agents", payload))
+            st.json(res)
+        except Exception as exc:
+            alert(f"Launch failed: {exc}", "error")
+
+    if st.button("Step Agents"):
+        try:
+            res = _run_async(dispatch_route("step_agents", {}))
+            st.json(res)
+        except Exception as exc:
+            alert(f"Step failed: {exc}", "error")
+
+
+def render_logs_tab() -> None:
+    """Provide simple audit trace explanation."""
+    if dispatch_route is None:
+        alert(
+            "Governance routes not enabled—enable them in config.",
+            "warning",
+        )
+        return
+    trace_text = st.text_area("Audit Trace JSON", value="{}", height=200)
+    if st.button("Explain Trace"):
+        try:
+            trace = json.loads(trace_text or "{}")
+        except Exception as exc:
+            alert(f"Invalid JSON: {exc}", "error")
+        else:
+            try:
+                res = _run_async(dispatch_route("explain_audit", {"trace": trace}))
+                st.text_area("Explanation", value=res, height=150)
+            except Exception as exc:
+                alert(f"Explain failed: {exc}", "error")
+
+
+def render_voting_tab() -> None:
+    """Render governance and proposal interactions."""
+    tabs = st.tabs([
+        "Proposal Hub",
+        "Governance",
+        "Agent Ops",
+        "Logs",
+    ])
+    with tabs[0]:
+        render_proposals_tab()
+    with tabs[1]:
+        render_governance_tab()
+    with tabs[2]:
+        render_agent_ops_tab()
+    with tabs[3]:
+        render_logs_tab()


### PR DESCRIPTION
## Summary
- support following and entanglement simulation in new `social_tabs` module
- provide proposal and governance tabs via new `voting_ui` module
- expose agent notes and RFC browser via new `agent_ui` module
- simplify `ui.py` and assemble tabs for Validation, Friends, Votes and Agents

## Testing
- `pytest -q` *(fails: AttributeError importing superNova_2177)*

------
https://chatgpt.com/codex/tasks/task_e_6887f66e3aa8832093844d36805fb55a