### PR TITLE
Ensure Streamlit frontend starts with a visible message

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -625,6 +625,8 @@ def render_logs_tab() -> None:
 def main() -> None:
     """Main entry point for the validation analysis UI."""
     header("superNova_2177 Validation Analyzer", layout="wide")
+    st.title("Welcome to superNova_2177")
+    st.success("\u2705 Streamlit loaded!")
 
     ts_placeholder = st.empty()
     if "session_start_ts" not in st.session_state:


### PR DESCRIPTION
## Summary
- tweak `ui.py` so the Streamlit page renders a header immediately
- show a title and success message when the frontend loads

## Testing
- `pytest -q` *(fails: AttributeError: <module 'requests'> has no attribute 'post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887f9d7d0748320bd531a96940eebb0