### PR TITLE
Fix Streamlit startup

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -34,7 +34,11 @@ def alert(message: str, level: Literal["warning", "error", "info"] = "info") -> 
 
 def header(title: str, *, layout: str = "centered") -> None:
     """Render a standard page header and apply base styling."""
-    st.set_page_config(page_title=title, layout=layout)
+    try:
+        st.set_page_config(page_title=title, layout=layout)
+    except Exception:
+        # set_page_config may have been called already in this session
+        pass
     st.markdown(
         "<style>.app-container{padding:1rem 2rem;}" "</style>",
         unsafe_allow_html=True,

--- a/ui.py
+++ b/ui.py
@@ -11,6 +11,11 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
+
+# Basic page setup so Streamlit responds immediately on load
+st.set_page_config(page_title="superNova_2177", layout="wide")
+st.title("superNova_2177")
+st.success("\u2705 Streamlit loaded!")
 from streamlit_helpers import (
     alert,
     header,


### PR DESCRIPTION
## Summary
- show the UI title and success message before any heavy work
- ignore duplicate set_page_config calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887f9d7d0748320bd531a96940eebb0