### PR TITLE
Fix UI startup error

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -9,7 +9,6 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
-import sys
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -858,14 +857,13 @@ if __name__ == "__main__":
     logger.info("\u2705 Streamlit UI started. Launching main()...")
     try:
         main()
-    try:
-        main()
-        st.success("✅ UI Booted")
-        print("UI Booted", file=sys.stderr)
     except Exception as exc:  # pragma: no cover - startup diagnostics
         logger.exception("UI startup failed")
         print(f"Startup failed: {exc}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         st.warning(f"UI startup failed — check logs for details: {exc}")
+    else:
+        st.success("✅ UI Booted")
+        print("UI Booted", file=sys.stderr)
 
 


### PR DESCRIPTION
## Summary
- remove duplicate `sys` import in ui.py
- fix `__main__` logic so the Streamlit UI can launch

## Testing
- `python -m py_compile ui.py`
- `pytest -q` *(fails: not found: /workspace/superNova_2177/tests/test_agent_registry.py::test_agent_registry)*

------
https://chatgpt.com/codex/tasks/task_e_688808380518832083b02e2def139e35