### PR TITLE
Fix Streamlit UI startup block

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -9,7 +9,6 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
-import sys
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -858,14 +857,13 @@ if __name__ == "__main__":
     logger.info("\u2705 Streamlit UI started. Launching main()...")
     try:
         main()
-    try:
-        main()
-        st.success("✅ UI Booted")
-        print("UI Booted", file=sys.stderr)
     except Exception as exc:  # pragma: no cover - startup diagnostics
         logger.exception("UI startup failed")
         print(f"Startup failed: {exc}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         st.warning(f"UI startup failed — check logs for details: {exc}")
+    else:
+        st.success("✅ UI Booted")
+        print("UI Booted", file=sys.stderr)
 
 


### PR DESCRIPTION
## Summary
- remove duplicate sys import in `ui.py`
- fix the `__main__` startup handler so the UI loads and logs errors correctly

## Testing
- `pytest tests/test_ui_fallback.py tests/test_ui_pyvis_helper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688808380518832083b02e2def139e35