### PR TITLE
Remove duplicate Streamlit banner

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -454,9 +454,6 @@ def boot_diagnostic_ui():
 def render_validation_ui() -> None:
     """Main entry point for the validation analysis UI."""
     header("superNova_2177 Validation Analyzer", layout="wide")
-    st.title("Welcome to superNova_2177")
-    st.success("✅ Streamlit loaded!")
-
 
     ts_placeholder = st.empty()
     if "session_start_ts" not in st.session_state:


### PR DESCRIPTION
## Summary
- streamline validation UI startup by removing redundant success messages

## Testing
- `pytest -q` *(fails: sqlalchemy.exc.ArgumentError ...)*

------
https://chatgpt.com/codex/tasks/task_e_68880d137b588320b34fc6c1592f5e22