### PR TITLE
Fix streamlit port configuration

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,4 +1,4 @@
 [server]
 headless = true
 enableCORS = false
-port = 8888
+port = 8501


### PR DESCRIPTION
## Summary
- update `.streamlit/config.toml` so Streamlit listens on port 8501

## Testing
- `pytest -q` *(fails: 46 failed, 278 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68880efa50988320820fd4c3a0810b09