### PR TITLE
Update Streamlit startup logic

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -866,16 +866,18 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    logger.info("\u2705 Streamlit UI started. Launching main()...")
+    print("Starting Streamlit UI...", file=sys.stderr)
+    st.session_state.setdefault("diary", [])
+    st.session_state.setdefault("agent_output", {})
     try:
         main()
     except Exception as exc:  # pragma: no cover - startup diagnostics
         logger.exception("UI startup failed")
-        print(f"Startup failed: {exc}", file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
-        st.warning(f"UI startup failed — check logs for details: {exc}")
+        print(exc, file=sys.stderr)
+        traceback.print_exc()
+        st.error(f"UI startup failed: {exc}")
     else:
-        st.success("✅ UI Booted")
         print("UI Booted", file=sys.stderr)
+        st.success("✅ UI Booted")
 
 


### PR DESCRIPTION
## Summary
- streamline the Streamlit startup flow in `ui.py`
- prepopulate diary and agent output session state

## Testing
- `pytest -q` *(fails: sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_688810f82a608320a504f50afdce3723