### PR TITLE
Update diary rendering in agent insights

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -29,15 +29,12 @@ def render_agent_insights_tab() -> None:
             if rfc_ids:
                 entry["rfc_ids"] = rfc_ids
             st.session_state.setdefault("diary", []).append(entry)
-        for i, entry in enumerate(st.session_state.get("diary", [])):
-            anchor = f"diary-{i}"
+        for entry in st.session_state.get("diary", []):
             note = entry.get("note", "")
             rfc_list = entry.get("rfc_ids")
             extra = f" (RFCs: {', '.join(rfc_list)})" if rfc_list else ""
-            st.markdown(
-                f"<p id='{anchor}'><strong>{entry['timestamp']}</strong>: {note}{extra}</p>",
-                unsafe_allow_html=True,
-            )
+            with st.container():
+                st.markdown(f"**{entry['timestamp']}**: {note}{extra}")
         if st.download_button(
             "Export Diary as Markdown",
             "\n".join(


### PR DESCRIPTION
## Summary
- simplify diary entry display container in `render_agent_insights_tab`
- keep diary export logic intact

## Testing
- `python -m compileall agent_ui.py`
- `pytest -q` *(fails: sqlalchemy connection and KeyError issues)*

------
https://chatgpt.com/codex/tasks/task_e_688810fa65fc832090cd0011bd87aadd