### PR TITLE
Add caching for RFC entries

### DIFF
--- a/ui_utils.py
+++ b/ui_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for streamlit UIs."""
 from pathlib import Path
+import streamlit as st
 
 
 def summarize_text(text: str, max_len: int = 150) -> str:
@@ -23,6 +24,7 @@ def parse_summary(text: str) -> str:
     return " ".join(lines)
 
 
+@st.cache_data
 def load_rfc_entries(rfc_dir: Path):
     """Return list and index of RFC entries from a directory."""
     rfc_paths = sorted(rfc_dir.rglob("rfc-*.md"))


### PR DESCRIPTION
## Summary
- add `streamlit` import
- cache `load_rfc_entries` with `st.cache_data`

## Testing
- `pytest -q` *(fails: sqlalchemy exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68881106976c83209cfd7f9fba6be29a