### PR TITLE
Add plotly dependency

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -79,6 +79,7 @@ patsy==1.0.1
 pillow==11.3.0
 platformdirs==4.3.8
 pluggy==1.6.0
+plotly==6.2.0
 prometheus_client==0.22.1
 protobuf==6.31.1
 PuLP==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ email-validator
 httpx==0.27.0
 streamlit-ace
 kaleido
+plotly
 openai
 anthropic
 google-generativeai


### PR DESCRIPTION
## Summary
- include `plotly` in the main requirements
- pin `plotly` in `requirements.lock`

## Testing
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68881108cc748320aa07b9ceb3a594b6