### PR TITLE
Fix unsafe markdown in diary log

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -34,10 +34,8 @@ def render_agent_insights_tab() -> None:
             note = entry.get("note", "")
             rfc_list = entry.get("rfc_ids")
             extra = f" (RFCs: {', '.join(rfc_list)})" if rfc_list else ""
-            st.markdown(
-                f"<p id='{anchor}'><strong>{entry['timestamp']}</strong>: {note}{extra}</p>",
-                unsafe_allow_html=True,
-            )
+            with st.container():
+                st.markdown(f"**{entry['timestamp']}**: {note}{extra}")
         if st.download_button(
             "Export Diary as Markdown",
             "\n".join(


### PR DESCRIPTION
## Summary
- show diary entries using `st.container()` so Markdown doesn't need unsafe HTML

## Testing
- `pytest -q` *(fails: sqlalchemy errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_688811106bfc8320bf35272d648a7bff