### PR TITLE
Add plotly to requirements

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -78,6 +78,7 @@ pathspec==0.12.1
 patsy==1.0.1
 pillow==11.3.0
 platformdirs==4.3.8
+plotly==6.2.0
 pluggy==1.6.0
 prometheus_client==0.22.1
 protobuf==6.31.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ kaleido
 openai
 anthropic
 google-generativeai
+plotly


### PR DESCRIPTION
## Summary
- add `plotly` to `requirements.txt`
- pin `plotly==6.2.0` in `requirements.lock`

## Testing
- `pip install plotly==6.2.0`
- `pytest -q` *(fails: 46 failed, 278 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888111330a08320a11d31db479291ca