### PR TITLE
Create slim requirements for Streamlit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /install
-COPY requirements.txt ./
+COPY requirements-streamlit.txt requirements-minimal.txt ./
 # Install build tools and Python dependencies, including Streamlit
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN apt-get update \
         libsdl2-mixer-dev \
         libsdl2-ttf-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --prefix=/install -r requirements.txt
+    && pip install --no-cache-dir --prefix=/install -r requirements-streamlit.txt
 
 # Final stage
 FROM python:3.12-slim

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Run these commands from the repository root. **Do not** execute `python ui.py`
 directly as that bypasses Streamlit's runtime.
 
 Exporting plots as static images requires the `kaleido` package. Install it
-using `pip install -r requirements.txt` if it isn't already available.
+using `pip install -r requirements-streamlit.txt` if it isn't already available.
 
 Open [http://localhost:8888](http://localhost:8888) in your browser to interact with the demo. Use the **Reset to Demo** button below the editor to reload `sample_validations.json` at any time.
 
@@ -333,7 +333,7 @@ Missing packages such as `tqdm` are installed automatically when you run `one_cl
 ### Troubleshooting the UI
 
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run
-  `pip install -r requirements.txt` to ensure all packages are available.
+  `pip install -r requirements-streamlit.txt` to ensure all packages are available.
 - **Port already in use**: Pass `--server.port` to Streamlit or set the
   `STREAMLIT_SERVER_PORT` environment variable to use a different port.
 - **Browser does not open**: Navigate manually to
@@ -365,9 +365,9 @@ Deploy the demo UI online with Streamlit Cloud:
 2. Sign in to [Streamlit Cloud](https://streamlit.io/cloud) and select **New app**.
 3. Choose the repo and set `streamlit_app.py` as the entry point.
 4. Add your `SECRET_KEY` and set a `DATABASE_URL` secret with your connection string under **Secrets** in the app settings.
-5. Streamlit will install dependencies from `requirements.txt` and launch the app.
+5. Streamlit will install dependencies from `requirements-streamlit.txt` and launch the app.
 
-`kaleido` is bundled in `requirements.txt` so image export features work on Streamlit Cloud.
+`kaleido` is bundled in this file so image export features work on Streamlit Cloud.
 
 After the build completes, you'll get a shareable URL to interact with the validation demo in your browser.
 

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -1,0 +1,23 @@
+-r requirements-minimal.txt
+uvicorn
+python-dotenv
+sympy
+scipy
+tqdm
+statsmodels
+pulp
+matplotlib
+python-snappy
+qutip
+pandas
+pygame
+mido
+midiutil
+qrcode
+asyncpg
+streamlit-ace
+kaleido
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ types-requests
 types-networkx
 numpy
 sympy
-sentence-transformers
 scipy
 tqdm
 statsmodels
@@ -32,8 +31,6 @@ pandas
 pygame
 mido
 midiutil
-torch
-scikit-learn
 streamlit>=1.28
 qrcode
 asyncpg
@@ -41,6 +38,3 @@ email-validator
 httpx==0.27.0
 streamlit-ace
 kaleido
-openai
-anthropic
-google-generativeai


### PR DESCRIPTION
## Summary
- lighten `requirements.txt` by removing heavy ML libs
- add a `requirements-streamlit.txt` file for Streamlit deployments
- update Dockerfile to install from the new Streamlit requirements
- document Streamlit Cloud setup with the new file

## Testing
- `pre-commit run --files requirements.txt requirements-streamlit.txt README.md Dockerfile`
- `pytest -k 'nothing' -q` *(tests skipped)*


------
https://chatgpt.com/codex/tasks/task_e_6888118cfb9c83208597f07c9d79a51e