### PR TITLE
Add disclaimer and lazy optional imports for heavy modules

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1,3 +1,7 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import difflib
 import io
 import json
@@ -13,11 +17,10 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 logger.propagate = False
 
-try:
-    import matplotlib.pyplot as plt
-except Exception:  # pragma: no cover - optional dependency
-    plt = None
-import networkx as nx
+plt = None  # imported lazily in run_analysis
+nx = None  # imported lazily in run_analysis
+go = None  # imported lazily in run_analysis
+Network = None  # imported lazily in run_analysis
 import streamlit as st
 
 # Basic page setup so Streamlit responds immediately on load
@@ -78,15 +81,6 @@ except Exception:  # pragma: no cover - optional runtime globals
     agent = None  # type: ignore
     InMemoryStorage = None  # type: ignore
 
-try:
-    import plotly.graph_objects as go
-except Exception:  # pragma: no cover - optional dependency
-    go = None
-
-try:
-    from pyvis.network import Network
-except Exception:  # pragma: no cover - optional dependency
-    Network = None
 
 try:
     from network.network_coordination_detector import build_validation_graph
@@ -210,6 +204,27 @@ def generate_explanation(result: dict) -> str:
 
 def run_analysis(validations, *, layout: str = "force"):
     """Execute the validation integrity pipeline and display results."""
+    global nx, plt, go, Network
+    if nx is None:
+        try:
+            import networkx as nx  # type: ignore
+        except ImportError:
+            nx = None
+    if plt is None:
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except ImportError:
+            plt = None
+    if go is None:
+        try:
+            import plotly.graph_objects as go  # type: ignore
+        except ImportError:
+            go = None
+    if Network is None:
+        try:
+            from pyvis.network import Network  # type: ignore
+        except ImportError:
+            Network = None
     if analyze_validation_integrity is None or build_validation_graph is None:
         st.error(
             "Required analysis modules are missing. Please install optional dependencies."
@@ -258,7 +273,7 @@ def run_analysis(validations, *, layout: str = "force"):
 
     graph_data = build_validation_graph(validations)
     edges = graph_data.get("edges", [])
-    if edges:
+    if edges and nx is not None:
         G = nx.Graph()
 
         # Collect voter metadata from the validations
@@ -424,6 +439,8 @@ def run_analysis(validations, *, layout: str = "force"):
             st.pyplot(fig)
         else:
             st.info("Install matplotlib or pyvis for graph visualization")
+    elif edges:
+        st.info("Install networkx for graph visualization")
 
     if st.button("Explain This Score"):
         explanation = generate_explanation(result)


### PR DESCRIPTION
## Summary
- insert standard disclaimer block at top of `ui.py`
- move heavy imports (`matplotlib`, `networkx`, `plotly`, `pyvis`) into lazy `try/except` blocks within `run_analysis`
- warn if `networkx` is missing when visualizing graphs

## Testing
- `pytest -q` *(fails: AttributeError & others)*

------
https://chatgpt.com/codex/tasks/task_e_6888118e5a3c832090dd779a47fd3ed0