### PR TITLE
Align Streamlit ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,12 +22,12 @@
     "server": "streamlit run ui.py --server.enableCORS false --server.enableXsrfProtection false"
   },
   "portsAttributes": {
-    "8501": {
+    "8888": {
       "label": "Application",
       "onAutoForward": "openPreview"
     }
   },
   "forwardPorts": [
-    8501
+    8888
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Optional: leave blank to auto-generate a secure key
 SECRET_KEY=
 DATABASE_URL=postgresql+asyncpg://<username>:<password>@<hostname>/<database>
-BACKEND_URL=http://localhost:8501
+BACKEND_URL=http://localhost:8888

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.11', '3.12']
     env:
       PYTHONPATH: ${{ github.workspace }}/transcendental_resonance_frontend/src
-      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8501' }}
+      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8888' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          PORT=${STREAMLIT_PORT:-8501}
+          PORT=${STREAMLIT_PORT:-8888}
           streamlit run ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
           for i in {1..30}; do
             if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.11', '3.12']
     env:
       PYTHONPATH: ${{ github.workspace }}/transcendental_resonance_frontend/src
-      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8501' }}
+      STREAMLIT_PORT: ${{ env.STREAMLIT_PORT || '8888' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +48,7 @@ jobs:
       - run: pytest
       - name: Streamlit smoke test
         run: |
-          PORT=${STREAMLIT_PORT:-8501}
+          PORT=${STREAMLIT_PORT:-8888}
           streamlit run ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
           for i in {1..20}; do
             if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,4 +1,4 @@
 [server]
 headless = true
 enableCORS = false
-port = 8501
+port = 8888

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ The `vote_registry.py` module is under active development. Planned tasks include
 ## Troubleshooting
 
 If the Streamlit UI fails to start when running tests or the smoke test in the
-CI pipeline, inspect `streamlit.log` for errors and confirm that port `8501` is
+CI pipeline, inspect `streamlit.log` for errors and confirm that port `8888` is
 free. Both the `ci.yml` and `pr-tests.yml` workflows print this file on failure
 and upload it as a build artifact named `streamlit-log-python-<version>`. After
 any GitHub Actions run, download the artifact from the "Artifacts" section of

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN chown -R appuser:appuser /app
 USER appuser
 
 # Expose Streamlit port
-EXPOSE 8501
+EXPOSE 8888
 
 # Launch Streamlit UI explicitly
-CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8888", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
    # python setup_env.py --run-app    # launch API after install
    # python setup_env.py --locked     # install from requirements.lock
     # python setup_env.py --build-ui   # build Transcendental Resonance frontend assets
-    # python setup_env.py --launch-ui  # run the Streamlit UI on port 8501
+   # python setup_env.py --launch-ui  # run the Streamlit UI on port 8888
    ```
   You can also let `install.py` choose the appropriate installer for your
   platform:
@@ -259,7 +259,7 @@ docker build -t supernova-2177 .
 To build and run the Streamlit UI inside Docker:
 ```bash
 docker build -t supernova-ui .
-docker run -p 8501:8501 supernova-ui
+docker run -p 8888:8888 supernova-ui
 ```
 
 The build process installs required system libraries such as `libsnappy-dev`
@@ -273,7 +273,7 @@ docker-compose up
 
 
 The application will be available at [http://localhost:8000](http://localhost:8000),
-and the Streamlit UI at [http://localhost:8501](http://localhost:8501).
+and the Streamlit UI at [http://localhost:8888](http://localhost:8888).
 
 
 ## Authentication
@@ -563,7 +563,7 @@ is optional because a secure one will be generated if omitted:
 # optional
 export SECRET_KEY="your-secret"
 export DATABASE_URL="postgresql+asyncpg://<username>:<password>@<hostname>/<database>"
-export BACKEND_URL="http://localhost:8501"
+export BACKEND_URL="http://localhost:8888"
 ```
 
 To connect to a central database instead of the local file, pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   app:
     build: .
     ports:
-      - "8501:8501"
+      - "8888:8888"
     depends_on:
       - db
       - redis

--- a/setup_env.py
+++ b/setup_env.py
@@ -66,7 +66,7 @@ def run_ui() -> None:
             'run',
             'ui.py',
             '--server.port',
-            '8501',
+            '8888',
         ])
     except subprocess.CalledProcessError as exc:
         logging.error('Failed to launch the Streamlit UI: %s', exc)
@@ -101,7 +101,11 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(description='Set up the environment')
     parser.add_argument('--run-app', action='store_true', help='start the API after installation')
-    parser.add_argument('--build-ui', action='store_true', help='build the Transcendental Resonance frontend after installation')
+    parser.add_argument(
+        '--build-ui',
+        action='store_true',
+        help='build the Transcendental Resonance frontend after installation',
+    )
     parser.add_argument('--launch-ui', action='store_true', help='start the Streamlit UI after installation')
     parser.add_argument('--locked', action='store_true',
                         help='install dependencies from requirements.lock')

--- a/transcendental_resonance_frontend/README.md
+++ b/transcendental_resonance_frontend/README.md
@@ -20,7 +20,7 @@ python -m transcendental_resonance_frontend.demo
 
 This command starts the app using data from `src/utils/sample_data/`.
 
-Replace the backend URL with the `BACKEND_URL` environment variable if your API is not running on `http://localhost:8501`.
+Replace the backend URL with the `BACKEND_URL` environment variable if your API is not running on `http://localhost:8888`.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
- unify default Streamlit port to 8888
- update Dockerfile, docker-compose, CI workflows, and devcontainer
- document new port in README and example env files
- adjust setup_env to launch Streamlit on port 8888

## Testing
- `pre-commit run --files .devcontainer/devcontainer.json .env.example .github/workflows/ci.yml .github/workflows/pr-tests.yml .streamlit/config.toml DEVELOPMENT.md Dockerfile README.md docker-compose.yml setup_env.py transcendental_resonance_frontend/README.md` *(with SKIP=bandit,black,isort)*
- `pytest -q` *(fails: 46 failed, 278 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68881198a1fc832085e3b1b429fba17e