### PR TITLE
Use smaller streamlit build requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /install
-COPY requirements.txt ./
+COPY requirements-streamlit.txt ./
 # Install build tools and Python dependencies, including Streamlit
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN apt-get update \
         libsdl2-mixer-dev \
         libsdl2-ttf-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --prefix=/install -r requirements.txt
+    && pip install --no-cache-dir --prefix=/install -r requirements-streamlit.txt
 
 # Final stage
 FROM python:3.12-slim

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -1,0 +1,6 @@
+streamlit>=1.28
+streamlit-ace
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards


### PR DESCRIPTION
## Summary
- install `requirements-streamlit.txt` in Dockerfile builder stage
- create a minimal `requirements-streamlit.txt` with Streamlit packages

## Testing
- `pip install -r requirements-minimal.txt`
- `pytest -q` *(fails: 38 failed, 249 passed, 38 skipped)*

Docker was unavailable so the image could not be rebuilt.

------
https://chatgpt.com/codex/tasks/task_e_688811d80a348320ba8b97ee46094240