### PR TITLE
Add health check and smoke test for Streamlit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             exit 1
           fi
           curl -f http://localhost:"$PORT"
+          curl -f http://localhost:"$PORT"/healthz
           pkill streamlit
       - name: Print Streamlit logs on failure
         if: failure()

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,6 +63,7 @@ jobs:
             exit 1
           fi
           curl -f http://localhost:"$PORT"
+          curl -f http://localhost:"$PORT"/healthz
           pkill streamlit
       - name: Print Streamlit logs on failure
         if: failure()

--- a/ui.py
+++ b/ui.py
@@ -1,10 +1,10 @@
+import asyncio
 import difflib
 import io
 import json
 import logging
 import math
 import os
-import asyncio
 import sys
 import traceback
 from datetime import datetime
@@ -30,14 +30,9 @@ except Exception:
 else:
     st.title("superNova_2177")
     st.success("\u2705 Streamlit loaded!")
-from streamlit_helpers import (
-    alert,
-    header,
-    theme_selector,
-    centered_container,
-    apply_theme,
-)
-from ui_utils import summarize_text, parse_summary, load_rfc_entries
+from streamlit_helpers import (alert, apply_theme, centered_container, header,
+                               theme_selector)
+from ui_utils import load_rfc_entries, parse_summary, summarize_text
 
 try:
     from streamlit_app import _run_async
@@ -60,7 +55,7 @@ except Exception:  # pragma: no cover - optional dependency
     dispatch_route = None
 
 try:
-    from db_models import SessionLocal, Harmonizer, UniverseBranch
+    from db_models import Harmonizer, SessionLocal, UniverseBranch
 except Exception:  # pragma: no cover - missing ORM
     SessionLocal = None  # type: ignore
     Harmonizer = None  # type: ignore
@@ -72,7 +67,7 @@ except Exception:  # pragma: no cover - optional module
     run_full_audit = None  # type: ignore
 
 try:
-    from superNova_2177 import cosmic_nexus, agent, InMemoryStorage
+    from superNova_2177 import InMemoryStorage, agent, cosmic_nexus
 except Exception:  # pragma: no cover - optional runtime globals
     cosmic_nexus = None  # type: ignore
     agent = None  # type: ignore
@@ -103,13 +98,30 @@ except Exception:  # pragma: no cover - optional dependency
 
 from typing import Any, cast
 
-
+from agent_ui import render_agent_insights_tab
 from llm_backends import get_backend
 from protocols import AGENT_REGISTRY
-
 from social_tabs import render_social_tab
 from voting_ui import render_voting_tab
-from agent_ui import render_agent_insights_tab
+
+# Register a lightweight health check endpoint for Streamlit Cloud
+try:
+    from streamlit.web.server.routes import HealthHandler  # type: ignore
+
+    _original_health_get = HealthHandler.get
+
+    async def _health_get(self):  # type: ignore[override]
+        if self.request.path.rstrip("/") == "/healthz":
+            ok, _ = await self._callback()
+            self.set_header("Content-Type", "application/json")
+            self.write({"status": "healthy" if ok else "unavailable"})
+            self.set_status(200 if ok else 503)
+        else:
+            await _original_health_get(self)
+
+    HealthHandler.get = _health_get  # type: ignore[assignment]
+except Exception:  # pragma: no cover - optional if Streamlit internals change
+    pass
 try:
     st_secrets = st.secrets
 except Exception:  # pragma: no cover - optional in dev/CI
@@ -153,6 +165,8 @@ if HarmonyScanner is None:
 
         def scan(self, _data):
             return {"dummy": True}
+
+
 def clear_memory(state: dict) -> None:
     """Reset analysis tracking state."""
     state["analysis_diary"] = []
@@ -180,8 +194,6 @@ def diff_results(old: dict | None, new: dict) -> str:
         lineterm="",
     )
     return "\n".join(diff)
-
-
 
 
 def render_pyvis_to_html(net: Any) -> str:
@@ -460,6 +472,7 @@ def boot_diagnostic_ui():
 
     st.subheader("Validation Analysis")
     run_analysis([], layout="force")
+
 
 def render_validation_ui() -> None:
     """Main entry point for the validation analysis UI."""
@@ -877,5 +890,3 @@ if __name__ == "__main__":
     else:
         st.success("✅ UI Booted")
         print("UI Booted", file=sys.stderr)
-
-


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint to the Streamlit UI
- call the endpoint from CI smoke tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/pr-tests.yml ui.py` *(fails: black reformatted files, flake8 errors)*
- `mypy` *(passes)*
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6888125cc13083208b3ed0f5ed8a1dce