### PR TITLE
Update CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             exit 1
           fi
           curl -f http://localhost:"$PORT"
+          curl -f http://localhost:"$PORT"/healthz
           pkill streamlit
       - name: Print Streamlit logs on failure
         if: failure()

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,6 +63,7 @@ jobs:
             exit 1
           fi
           curl -f http://localhost:"$PORT"
+          curl -f http://localhost:"$PORT"/healthz
           pkill streamlit
       - name: Print Streamlit logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- verify `/healthz` is reachable in CI and PR workflows

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/pr-tests.yml`
- `pytest -q` *(fails: 46 failed, 278 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888124160288320976bcc2855f2ad1d