### PR TITLE
Remove outdated Streamlit health check

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -98,24 +98,6 @@ from protocols import AGENT_REGISTRY
 from social_tabs import render_social_tab
 from voting_ui import render_voting_tab
 
-# Register a lightweight health check endpoint for Streamlit Cloud
-try:
-    from streamlit.web.server.routes import HealthHandler  # type: ignore
-
-    _original_health_get = HealthHandler.get
-
-    async def _health_get(self):  # type: ignore[override]
-        if self.request.path.rstrip("/") == "/healthz":
-            ok, _ = await self._callback()
-            self.set_header("Content-Type", "application/json")
-            self.write({"status": "healthy" if ok else "unavailable"})
-            self.set_status(200 if ok else 503)
-        else:
-            await _original_health_get(self)
-
-    HealthHandler.get = _health_get  # type: ignore[assignment]
-except Exception:  # pragma: no cover - optional if Streamlit internals change
-    pass
 try:
     st_secrets = st.secrets
 except Exception:  # pragma: no cover - optional in dev/CI


### PR DESCRIPTION
## Summary
- drop custom health handler override from `ui.py`

## Testing
- `pytest -q` *(fails: AttributeError 'async_generator' object has no attribute 'post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688824fcbc0883208c2cd7a188247b6b