### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -63,6 +63,10 @@ Run all hooks manually with:
 pre-commit run --all-files
 ```
 
+Most editors will also respect the formatting settings in `.editorconfig` at the
+repository root. It enforces UTF-8 encoding, LF newlines and four-space
+indentation.
+
 ## Optional Frontend
 
 The `transcendental_resonance_frontend/` directory contains a NiceGUI-based UI. Follow its README to install `pip install -r transcendental_resonance_frontend/requirements.txt` and run the frontend if desired.


### PR DESCRIPTION
## Summary
- add a repo-wide `.editorconfig`
- mention `.editorconfig` usage in DEVELOPMENT docs

## Testing
- `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest -q` *(fails: sqlalchemy OperationalError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888283c3a0c8320a92c6f69bc5c39dc