### PR TITLE
Fix async run helper types

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,13 +1,25 @@
-import json
 import asyncio
+import json
+from typing import Any, Coroutine, TypeVar
+
 import streamlit as st
 
-from frontend_bridge import dispatch_route, ROUTES
+from frontend_bridge import ROUTES, dispatch_route
 from streamlit_helpers import apply_theme, header
 
+T = TypeVar("T")
 
-def _run_async(coro):
-    """Execute ``coro`` or schedule it if a loop is already running."""
+
+def _run_async(coro: Coroutine[Any, Any, T]) -> Any:
+    """Execute ``coro`` or schedule it if a loop is already running.
+
+    Example
+    -------
+    >>> async def greet():
+    ...     return "hi"
+    >>> _run_async(greet())
+    'hi'
+    """
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:


### PR DESCRIPTION
## Summary
- improve `_run_async` typing using `Coroutine` and `Any`
- add example usage to the docstring

## Testing
- `pre-commit run --files streamlit_app.py`
- `make lint`
- `make test` *(fails: AssertionError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888283d751883208b60263d0b72a043