### PR TITLE
Add Streamlit healthz UI test

### DIFF
--- a/tests/ui/test_ui_healthz.py
+++ b/tests/ui/test_ui_healthz.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import streamlit.testing.v1 as st_test
+
+
+def test_ui_healthz_endpoint():
+    """ui.py should respond to ?healthz=1 with plain 'ok'."""
+    app = st_test.AppTest.from_file(str(Path("ui.py").resolve()))
+    app.query_params["healthz"] = "1"
+    app.run()
+    assert not app.exception  # nosec B101
+    assert app.markdown[0].body.strip().lower() == "ok"  # nosec B101


### PR DESCRIPTION
## Summary
- add `test_ui_healthz_endpoint` to ensure `ui.py` handles the `?healthz=1` query

## Testing
- `pre-commit run --files tests/ui/test_ui_healthz.py`
- `pytest tests/ui/test_ui_healthz.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688828377d948320a6fdc7a564260b94