### PR TITLE
Centralize disclaimers

### DIFF
--- a/disclaimers.py
+++ b/disclaimers.py
@@ -1,0 +1,11 @@
+"""Common disclaimer phrases used across the project."""
+
+STRICTLY_SOCIAL_MEDIA = "STRICTLY A SOCIAL MEDIA PLATFORM"
+INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION = "Intellectual Property & Artistic Inspiration"
+LEGAL_ETHICAL_SAFEGUARDS = "Legal & Ethical Safeguards"
+
+__all__ = [
+    "STRICTLY_SOCIAL_MEDIA",
+    "INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION",
+    "LEGAL_ETHICAL_SAFEGUARDS",
+]

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -44,9 +44,9 @@ backend handler.
 |`explain_audit`|Create a textual explanation for an audit trace.|
 |`follow_user`|Follow or unfollow a user. Payload: `{"username": "<target>"}`|
 
-These routes are provided for research purposes only. STRICTLY A SOCIAL MEDIA PLATFORM.
-They incorporate Intellectual Property & Artistic Inspiration protections
-and follow Legal & Ethical Safeguards for community use.
+These routes are provided for research purposes only. `disclaimers.STRICTLY_SOCIAL_MEDIA`.
+They incorporate `disclaimers.INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION` protections
+and follow `disclaimers.LEGAL_ETHICAL_SAFEGUARDS` for community use.
 
 ## proposals
 

--- a/governance/patch_monitor.py
+++ b/governance/patch_monitor.py
@@ -14,10 +14,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, List
 
+from disclaimers import (
+    STRICTLY_SOCIAL_MEDIA,
+    INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
+    LEGAL_ETHICAL_SAFEGUARDS,
+)
+
 DEFAULT_DISCLAIMER_PHRASES = [
-    "STRICTLY A SOCIAL MEDIA PLATFORM",
-    "Intellectual Property & Artistic Inspiration",
-    "Legal & Ethical Safeguards",
+    STRICTLY_SOCIAL_MEDIA,
+    INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
+    LEGAL_ETHICAL_SAFEGUARDS,
 ]
 
 

--- a/tests/test_patch_monitor.py
+++ b/tests/test_patch_monitor.py
@@ -1,16 +1,23 @@
 import textwrap
 
-from governance.patch_monitor import (check_file_compliance,
-                                      check_patch_compliance)
+from governance.patch_monitor import (
+    check_file_compliance,
+    check_patch_compliance,
+)
+from disclaimers import (
+    STRICTLY_SOCIAL_MEDIA,
+    INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
+    LEGAL_ETHICAL_SAFEGUARDS,
+)
 
 
 def test_check_file_compliance(tmp_path):
     f = tmp_path / "module.py"
     f.write_text(
         (
-            "# STRICTLY A SOCIAL MEDIA PLATFORM\n"
-            "# Intellectual Property & Artistic Inspiration\n"
-            "# Legal & Ethical Safeguards\n"
+            f"# {STRICTLY_SOCIAL_MEDIA}\n"
+            f"# {INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION}\n"
+            f"# {LEGAL_ETHICAL_SAFEGUARDS}\n"
             "print('hello')\n"
         )
     )
@@ -27,9 +34,9 @@ def test_check_file_compliance_missing(tmp_path):
 def test_check_patch_compliance():
     patch = textwrap.dedent(
         """@@\n"
-        "+ # STRICTLY A SOCIAL MEDIA PLATFORM\n"
-        "+ # Intellectual Property & Artistic Inspiration\n"
-        "+ # Legal & Ethical Safeguards\n"
+        f"+ # {STRICTLY_SOCIAL_MEDIA}\n"
+        f"+ # {INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION}\n"
+        f"+ # {LEGAL_ETHICAL_SAFEGUARDS}\n"
         "+ pass\n"""
     )
     assert check_patch_compliance(patch) == []  # nosec B101
@@ -45,9 +52,9 @@ def test_check_patch_compliance_existing_file(tmp_path, monkeypatch):
     f = tmp_path / "module.py"
     f.write_text(
         (
-            "# STRICTLY A SOCIAL MEDIA PLATFORM\n"
-            "# Intellectual Property & Artistic Inspiration\n"
-            "# Legal & Ethical Safeguards\n"
+            f"# {STRICTLY_SOCIAL_MEDIA}\n"
+            f"# {INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION}\n"
+            f"# {LEGAL_ETHICAL_SAFEGUARDS}\n"
             "print('hello')\n"
         )
     )


### PR DESCRIPTION
## Summary
- add a `disclaimers.py` module with constants for the three phrases
- reference the constants in the patch monitor
- update docs to mention the constant names
- update patch monitor tests to use the constants

## Testing
- `pytest tests/test_patch_monitor.py tests/test_check_disclaimers_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6888283ae05083208a21134b56407730