### PR TITLE
docs: explain healthz endpoint

### DIFF
--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -15,3 +15,8 @@ with centered_container():
 
 Running this example will render a page with the standard header, a theme switcher
 radio button and a centered content area.
+
+The Streamlit app also supports a lightweight health check for CI or uptime
+monitors. Visiting `/?healthz=1` responds with `ok` and stops execution. This
+serves as a simple fallback when the built-in `/healthz` route isn't available,
+so monitoring systems can confirm the UI started successfully.


### PR DESCRIPTION
## Summary
- explain the `/?healthz=1` fallback in `streamlit_ui_extension_example.md`

## Testing
- `make test` *(fails: sqlalchemy & others missing)*

------
https://chatgpt.com/codex/tasks/task_e_688828469a2c8320826403d2ae56eac6