### PR TITLE
Add Streamlit UI health check test

### DIFF
--- a/tests/test_ui_launch.py
+++ b/tests/test_ui_launch.py
@@ -1,0 +1,54 @@
+import os
+import socket
+import subprocess
+import time
+
+import requests
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+def _start_server(port):
+    cmd = [
+        "streamlit",
+        "run",
+        "ui.py",
+        "--server.headless",
+        "true",
+        "--server.port",
+        str(port),
+    ]
+    env = os.environ.copy()
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+
+
+def test_ui_healthz_query():
+    port = _free_port()
+    proc = _start_server(port)
+    try:
+        for _ in range(30):
+            try:
+                resp = requests.get(f"http://localhost:{port}/?healthz=1", timeout=1)
+                if resp.status_code == 200:
+                    break
+            except Exception:
+                pass
+            if proc.poll() is not None:
+                raise RuntimeError("Streamlit failed to start")
+            time.sleep(1)
+        else:
+            raise RuntimeError("Streamlit did not start in time")
+
+        resp = requests.get(f"http://localhost:{port}/?healthz=1", timeout=5)
+        assert resp.status_code == 200
+        assert resp.text.strip() == "ok"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- add integration test to ensure `ui.py` starts and responds to `/?healthz=1`

## Testing
- `pytest tests/test_ui_launch.py -q` *(fails: assert response text == ok)*

------
https://chatgpt.com/codex/tasks/task_e_688828519a248320916f2854d1425016