### PR TITLE
Add Streamlit shadow file check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 repos:
   - repo: https://github.com/psf/black
     rev: 24.4.2
@@ -30,3 +33,8 @@ repos:
         name: patch-monitor
         language: python
         entry: python scripts/patch_monitor_hook.py
+      - id: streamlit-shadow-check
+        name: streamlit-shadow-check
+        language: python
+        entry: python scripts/check_streamlit_shadow.py
+        pass_filenames: false

--- a/scripts/check_streamlit_shadow.py
+++ b/scripts/check_streamlit_shadow.py
@@ -1,0 +1,22 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    offending = [str(p) for p in repo_root.rglob("streamlit.py")]
+    if offending:
+        print("Found shadowing streamlit.py files:")
+        for path in offending:
+            print(path)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- prevent accidental shadowing of the streamlit package
- add `check_streamlit_shadow.py` and hook into pre-commit

## Testing
- `pre-commit run --files scripts/check_streamlit_shadow.py .pre-commit-config.yaml`
- `pytest` *(fails: sqlalchemy errors)*
- `PORT=8888 streamlit run ui.py --server.headless true --server.port 8888`

------
https://chatgpt.com/codex/tasks/task_e_68882b8ca5588320bd4f5908e82f4bc8