### PR TITLE
Add Streamlit name clash CI check

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Check patch compliance
         run: |
           python scripts/check_disclaimers.py origin/${{ github.event.pull_request.base.ref }} || echo 'Patch compliance check failed (missing git?)'
+      - name: Fail if stray streamlit.py exists
+        run: |
+          if find . -name "streamlit.py" | grep -q "."; then
+            echo "streamlit.py found. Please remove conflicting file." >&2
+            find . -name "streamlit.py"
+            exit 1
+          fi
       - name: Install dependencies with fallback mirror
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- check for stray `streamlit.py` files in PR tests

## Testing
- `pre-commit run --files .github/workflows/pr-tests.yml`
- `pytest -q` *(fails: AttributeError / FileNotFoundError)*
- `streamlit run ui.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68882b988c3c83208dd8593be1d25ebd