### PR TITLE
Add script to block stray streamlit.py files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Ensure no stray streamlit.py
+        run: python scripts/check_no_streamlit_py.py
       # Continue even if the disclaimer check fails (e.g., missing git)
       - name: Check patch compliance
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Ensure no stray streamlit.py
+        run: python scripts/check_no_streamlit_py.py
       # Continue even if the disclaimer check fails (e.g., missing git)
       - name: Check patch compliance
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,8 @@ repos:
         language: python
         entry: python scripts/check_streamlit_shadow.py
         pass_filenames: false
+      - id: no-streamlit-py-check
+        name: no-streamlit-py-check
+        language: python
+        entry: python scripts/check_no_streamlit_py.py
+        pass_filenames: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,6 +67,11 @@ Most editors will also respect the formatting settings in `.editorconfig` at the
 repository root. It enforces UTF-8 encoding, LF newlines and four-space
 indentation.
 
+The pre-commit configuration runs `scripts/check_no_streamlit_py.py` to ensure
+no `streamlit.py` file exists anywhere in the repository. This prevents
+accidentally shadowing the real Streamlit package. The same check runs early in
+the CI workflows.
+
 ## Optional Frontend
 
 The `transcendental_resonance_frontend/` directory contains a NiceGUI-based UI. Follow its README to install `pip install -r transcendental_resonance_frontend/requirements.txt` and run the frontend if desired.

--- a/scripts/check_no_streamlit_py.py
+++ b/scripts/check_no_streamlit_py.py
@@ -1,0 +1,20 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    offending = [str(p) for p in Path(".").rglob("streamlit.py")]
+    if offending:
+        print("Found shadowing streamlit.py files:")
+        for path in offending:
+            print(path)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- check repo for accidental `streamlit.py` files
- run this check in CI workflows
- add pre-commit hook
- mention safeguard in DEVELOPMENT.md

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/pr-tests.yml .pre-commit-config.yaml DEVELOPMENT.md scripts/check_no_streamlit_py.py`
- `mypy`
- `pytest -q` *(fails: 54 failed, 274 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68882e4970ec8320bb4aa450e68af4c9