### PR TITLE
Fix UI health test startup path

### DIFF
--- a/tests/test_ui_health.py
+++ b/tests/test_ui_health.py
@@ -18,13 +18,13 @@ def _start_server(port):
     cmd = [
         "streamlit",
         "run",
-        "streamlit_app.py",
+        "ui.py",
         "--server.headless",
         "true",
         "--server.port",
         str(port),
     ]
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
 
 
 def test_healthz_endpoint():
@@ -34,7 +34,7 @@ def test_healthz_endpoint():
         # Wait for server to come up
         for _ in range(30):
             try:
-                res = requests.get(f"http://localhost:{port}/healthz", timeout=1)
+                res = requests.get(f"http://localhost:{port}/?healthz=1", timeout=1)
                 if res.status_code == 200:
                     break
             except Exception:
@@ -46,7 +46,7 @@ def test_healthz_endpoint():
             raise RuntimeError("Streamlit did not start in time")
 
         start = time.time()
-        resp = requests.get(f"http://localhost:{port}/healthz", timeout=5)
+        resp = requests.get(f"http://localhost:{port}/?healthz=1", timeout=5)
         elapsed = time.time() - start
         assert resp.status_code == 200
         assert "ok" in resp.text.lower()


### PR DESCRIPTION
## Summary
- launch the test UI via `ui.py`
- check `?healthz=1` during startup and in assertions
- pass the environment when spawning the UI

## Testing
- `pytest tests/test_ui_health.py -q` *(fails: assert 'ok' in HTML response)*

------
https://chatgpt.com/codex/tasks/task_e_68882f0bfef48320a24a3f3f14a7eac4