### PR TITLE
Fix duplicate health check

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -24,31 +24,13 @@ Network = None  # imported lazily in run_analysis
 # Import Streamlit and register fallback health check
 import streamlit as st
 
-# Name of the query parameter used for the CI health check. Adjust here if the
-# health check endpoint ever changes.
-HEALTH_CHECK_PARAM = "healthz"
+try:
+    if st.query_params.get("healthz") == "1":
+        st.write("ok")
+        st.stop()
+except Exception:
+    pass
 
-# Fallback health check endpoint for CI (avoids internal monkey-patching)
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write("ok")
-    st.stop()
-
-# Fallback health check endpoint for CI (avoids internal monkey-patching)
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write("ok")
-    st.stop()
-
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    # Fallback health check endpoint for CI (avoids internal monkey-patching)
-    st.write("ok")
-    st.stop()
-
-# Fallback health check for CI environments
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write(
-        "ok"
-    )  # Fallback health check endpoint for CI (avoids internal monkey-patching)
-    st.stop()
 
 # Basic page setup so Streamlit responds immediately on load
 try:


### PR DESCRIPTION
## Summary
- remove duplicate `?healthz=1` checks from ui
- keep a single guarded block immediately after importing streamlit

## Testing
- `pytest tests/ui/test_ui_healthz.py::test_ui_healthz_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68882f1e3ba08320831afa0023e2d214