### PR TITLE
Refactor health check test URL logic

### DIFF
--- a/tests/test_ui_health.py
+++ b/tests/test_ui_health.py
@@ -32,9 +32,10 @@ def test_healthz_endpoint():
     proc = _start_server(port)
     try:
         # Wait for server to come up
+        url = f"http://localhost:{port}/?healthz=1"
         for _ in range(30):
             try:
-                res = requests.get(f"http://localhost:{port}/?healthz=1", timeout=1)
+                res = requests.get(url, timeout=1)
                 if res.status_code == 200:
                     break
             except Exception:
@@ -46,7 +47,7 @@ def test_healthz_endpoint():
             raise RuntimeError("Streamlit did not start in time")
 
         start = time.time()
-        resp = requests.get(f"http://localhost:{port}/?healthz=1", timeout=5)
+        resp = requests.get(url, timeout=5)
         elapsed = time.time() - start
         assert resp.status_code == 200
         assert "ok" in resp.text.lower()


### PR DESCRIPTION
## Summary
- remove duplication in `tests/test_ui_health.py` by storing the health check URL in a variable

## Testing
- `pip install -r requirements-minimal.txt`
- `pytest -q tests/test_ui_health.py` *(fails: Streamlit health check returns HTML)*

------
https://chatgpt.com/codex/tasks/task_e_688832c5e3a48320b566df463e45b498