### PR TITLE
Add query param health check

### DIFF
--- a/tests/test_ui_health.py
+++ b/tests/test_ui_health.py
@@ -1,6 +1,6 @@
 import os
-import subprocess
 import socket
+import subprocess
 import time
 
 import requests
@@ -18,13 +18,15 @@ def _start_server(port):
     cmd = [
         "streamlit",
         "run",
-        "streamlit_app.py",
+        "ui.py",
         "--server.headless",
         "true",
         "--server.port",
         str(port),
     ]
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+    )
 
 
 def test_healthz_endpoint():
@@ -34,7 +36,7 @@ def test_healthz_endpoint():
         # Wait for server to come up
         for _ in range(30):
             try:
-                res = requests.get(f"http://localhost:{port}/healthz", timeout=1)
+                res = requests.get(f"http://localhost:{port}/?healthz=1", timeout=1)
                 if res.status_code == 200:
                     break
             except Exception:
@@ -46,7 +48,7 @@ def test_healthz_endpoint():
             raise RuntimeError("Streamlit did not start in time")
 
         start = time.time()
-        resp = requests.get(f"http://localhost:{port}/healthz", timeout=5)
+        resp = requests.get(f"http://localhost:{port}/?healthz=1", timeout=5)
         elapsed = time.time() - start
         assert resp.status_code == 200
         assert "ok" in resp.text.lower()

--- a/ui.py
+++ b/ui.py
@@ -33,23 +33,6 @@ if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
     st.write("ok")
     st.stop()
 
-# Fallback health check endpoint for CI (avoids internal monkey-patching)
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write("ok")
-    st.stop()
-
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    # Fallback health check endpoint for CI (avoids internal monkey-patching)
-    st.write("ok")
-    st.stop()
-
-# Fallback health check for CI environments
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write(
-        "ok"
-    )  # Fallback health check endpoint for CI (avoids internal monkey-patching)
-    st.stop()
-
 # Basic page setup so Streamlit responds immediately on load
 try:
     st.set_page_config(page_title="superNova_2177", layout="wide")


### PR DESCRIPTION
## Summary
- add fallback health check in `ui.py`
- check ?healthz=1 in Streamlit server test

## Testing
- `pre-commit run --files ui.py tests/test_ui_health.py .github/workflows/ci.yml .github/workflows/pr-tests.yml` *(fails: flake8 E402, mypy agent used-before-def)*
- `pytest tests/test_ui_health.py tests/test_ui_launch.py tests/ui/test_ui_healthz.py -q` *(fails: health check endpoint returns HTML)*

------
https://chatgpt.com/codex/tasks/task_e_68882f8e89148320ab3c33bf4d47b3f7