### PR TITLE
Add start script and update Streamlit config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,4 +1,7 @@
 [server]
 headless = true
+port = 8501
 enableCORS = false
-port = 8888
+
+[theme]
+base = "dark"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ supernova-federate create --creator Alice --config HARMONY_WEIGHT=0.9
 # Cast a vote on a fork
 supernova-federate vote <fork_id> --voter Bob --vote yes
 ````
+
+## 🔧 Local Development
+
+To launch the Streamlit UI:
+
+```bash
+chmod +x start.sh
+./start.sh
+```
+
+This script will find and launch `ui.py` automatically from any directory in the repo.
+
 ## ☁️ Launch Online
 
 [![Run in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/BP-H/superNova_2177)

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+# Dynamically find ui.py and launch it
+UI_FILE=$(find . -type f -name "ui.py" | head -n 1)
+
+if [[ -z "$UI_FILE" ]]; then
+  echo "❌ ui.py not found. Please ensure it exists." >&2
+  exit 1
+fi
+
+echo "🚀 Launching Streamlit UI: $UI_FILE"
+streamlit run "$UI_FILE" --server.headless true --server.port 8501


### PR DESCRIPTION
## Summary
- add dynamic `start.sh` launcher for Streamlit UI
- update Streamlit config to use port 8501 and dark theme
- document new start script in README

## Testing
- `python -m scripts.check_disclaimers HEAD`
- `pytest -k patch_monitor -q`

------
https://chatgpt.com/codex/tasks/task_e_68883088c77083209e19d1865acb74f1