### PR TITLE
Add start.sh script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+PORT="${STREAMLIT_PORT:-8888}"
+exec streamlit run streamlit_app.py --server.port "$PORT"


### PR DESCRIPTION
## Summary
- create `start.sh` script to launch Streamlit
- include required disclaimers at the top
- allow overriding the port via `$STREAMLIT_PORT`

## Testing
- `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest -q` *(fails: AttributeError & SQL errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888351100e08320a6c28b91680156ca