### PR TITLE
Fix Streamlit port config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 [server]
 headless = true
 enableCORS = false


### PR DESCRIPTION
## Summary
- add mandatory disclaimers to `.streamlit/config.toml`
- keep Streamlit server running on port 8888

## Testing
- `pip install -q -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest -q` *(fails: 40 failed, 251 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68883511d6d08320a0e9897582632336