### PR TITLE
Fix Streamlit startup binding

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,7 +3,8 @@
 # Legal & Ethical Safeguards
 [server]
 headless = true
-port = 8501
+port = 8888
+address = "0.0.0.0"
 enableCORS = false
 
 [theme]

--- a/start.sh
+++ b/start.sh
@@ -11,5 +11,10 @@ if [[ -z "$UI_FILE" ]]; then
   exit 1
 fi
 
-echo "🚀 Launching Streamlit UI: $UI_FILE"
-streamlit run "$UI_FILE" --server.headless true --server.port 8501
+PORT="${STREAMLIT_PORT:-${PORT:-8888}}"
+
+echo "🚀 Launching Streamlit UI: $UI_FILE on port $PORT"
+streamlit run "$UI_FILE" \
+  --server.headless true \
+  --server.address 0.0.0.0 \
+  --server.port "$PORT"


### PR DESCRIPTION
## Summary
- update `.streamlit/config.toml` to bind to `0.0.0.0` on port 8888
- allow port override and address binding in `start.sh`

## Testing
- `pre-commit run --files start.sh .streamlit/config.toml`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688837427e008320a5ab537f91e054eb