### PR TITLE
Fix streamlit startup

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,7 +3,8 @@
 # Legal & Ethical Safeguards
 [server]
 headless = true
-port = 8501
+port = 8888
+address = "0.0.0.0"
 enableCORS = false
 
 [theme]

--- a/start.sh
+++ b/start.sh
@@ -11,5 +11,6 @@ if [[ -z "$UI_FILE" ]]; then
   exit 1
 fi
 
-echo "🚀 Launching Streamlit UI: $UI_FILE"
-streamlit run "$UI_FILE" --server.headless true --server.port 8501
+PORT="${STREAMLIT_PORT:-${PORT:-8888}}"
+echo "🚀 Launching Streamlit UI: $UI_FILE on port $PORT"
+streamlit run "$UI_FILE" --server.headless true --server.address 0.0.0.0 --server.port "$PORT"


### PR DESCRIPTION
## Summary
- bind Streamlit to all interfaces using port env vars in `start.sh`
- set new default port and address in `.streamlit/config.toml`

## Testing
- `make test` *(fails: sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_688837427e008320a5ab537f91e054eb