### PR TITLE
Use async callbacks for validator graph refresh

### DIFF
--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -87,6 +87,6 @@ async def validator_graph_page():
         ui.button('Update', on_click=refresh_graph).classes('mb-4').style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'
         )
-        layout_select.on('change', lambda _: refresh_graph())
-        filter_input.on('change', lambda _: refresh_graph())
+        layout_select.on('change', lambda _: ui.run_async(refresh_graph()))
+        filter_input.on('change', lambda _: ui.run_async(refresh_graph()))
         await refresh_graph()


### PR DESCRIPTION
## Summary
- trigger async refresh when changing layout or filter inputs

## Testing
- `pytest -q` *(fails: 38 failed, 253 passed, 35 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688838c2bac88320984708a6dd8f3094