### PR TITLE
Fix async uploads

### DIFF
--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -21,7 +21,7 @@ async def upload_page():
             f'color: {THEME["accent"]};'
         )
 
-        ui.upload(on_upload=lambda e: handle_upload(e.content, e.name)).classes('w-full mb-4')
+        ui.upload(on_upload=lambda e: ui.run_async(handle_upload(e.content, e.name))).classes('w-full mb-4')
 
         async def handle_upload(content, name):
             files = {'file': (name, content.read(), 'multipart/form-data')}

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -45,7 +45,7 @@ async def vibenodes_page():
                 if uploaded_media['type'] and uploaded_media['type'].startswith('image'):
                     ui.image(uploaded_media['url']).classes('w-full mb-2')
 
-        ui.upload(on_upload=lambda e: handle_upload(e.content, e.name)).classes('w-full mb-2')
+        ui.upload(on_upload=lambda e: ui.run_async(handle_upload(e.content, e.name))).classes('w-full mb-2')
 
         async def create_vibenode():
             data = {


### PR DESCRIPTION
## Summary
- keep `handle_upload` as async in pages
- call uploads with `ui.run_async` for non-blocking behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_688838c3dcb88320ab0fc33763357ddb