### PR TITLE
Fix duplicate predictions hook import

### DIFF
--- a/frontend_bridge.py
+++ b/frontend_bridge.py
@@ -223,7 +223,6 @@ import prediction_manager.ui_hook  # noqa: F401 - route registration
 import vote_registry.ui_hook  # noqa: F401 - route registration
 import optimization.ui_hook  # noqa: F401 - route registration
 import causal_graph.ui_hook  # noqa: F401 - route registration
-import predictions.ui_hook  # noqa: F401 - route registration
 import social.ui_hook  # noqa: F401 - route registration
 import social.follow_ui_hook  # noqa: F401 - route registration
 import quantum_sim.ui_hook  # noqa: F401 - route registration


### PR DESCRIPTION
## Summary
- remove redundant predictions hook import from `frontend_bridge.py`

## Testing
- `pytest tests/test_frontend_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888393722188320871ef22a5360a316