### PR TITLE
Fix lazy page imports

### DIFF
--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -23,7 +23,13 @@ __all__ = [
 
 
 def __getattr__(name):
+    """Dynamically load page functions from their modules."""
     if name in __all__:
-        module = __import__(f"pages.{name}", fromlist=[name])
+        module_map = {
+            "register_page": "login_page",
+            "network_page": "network_analysis_page",
+        }
+        module_name = module_map.get(name, name)
+        module = __import__(f"pages.{module_name}", fromlist=[name])
         return getattr(module, name)
     raise AttributeError(name)

--- a/transcendental_resonance_frontend/tests/test_pages_init_imports.py
+++ b/transcendental_resonance_frontend/tests/test_pages_init_imports.py
@@ -1,0 +1,11 @@
+import inspect
+
+from pages import register_page, network_page
+
+
+def test_register_page_importable():
+    assert inspect.iscoroutinefunction(register_page)
+
+
+def test_network_page_importable():
+    assert inspect.iscoroutinefunction(network_page)


### PR DESCRIPTION
## Summary
- support mapping register_page and network_page names in pages package
- add tests ensuring these names import correctly

## Testing
- `pytest transcendental_resonance_frontend/tests/test_pages_init_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888393b00948320b31b85f494cfcb00