### PR TITLE
Fix event loop usage

### DIFF
--- a/scientific_utils.py
+++ b/scientific_utils.py
@@ -379,7 +379,7 @@ async def async_add_event(logchain: "LogChain", event: Dict[str, Any]) -> None:
     validation_notes: manual tests confirm event logged
     approximation: exact
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, logchain.add, event)
 
 

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -1168,7 +1168,7 @@ class LogChain:
 
 
 async def async_add_event(logchain: "LogChain", event: Dict[str, Any]) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, logchain.add, event)
 
 
@@ -3550,7 +3550,7 @@ async def adaptive_optimization_task(db_session_factory):
 
 
 async def startup_event():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     loop.create_task(passive_aura_resonance_task(SessionLocal))
     loop.create_task(ai_persona_evolution_task(SessionLocal))
     loop.create_task(ai_guinness_pursuit_task(SessionLocal))


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop()` instead of deprecated `get_event_loop`
- update startup event to new API

## Testing
- `pytest -q` *(fails: 40 failed, 251 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68883b213d3483208ebf187d7045e294