### PR TITLE
Add websocket updates for messages and notifications

### DIFF
--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -1,7 +1,10 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Messaging system page."""
 
 from nicegui import ui
-from utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 
@@ -52,3 +55,9 @@ async def messages_page():
 
         await refresh_messages()
         ui.timer(30, lambda: ui.run_async(refresh_messages()))
+
+        async def handle_event(event: dict) -> None:
+            if event.get("type") == "message":
+                await refresh_messages()
+
+        ui.run_async(listen_ws(handle_event))

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -1,7 +1,10 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """User notifications page."""
 
 from nicegui import ui
-from utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 
@@ -46,3 +49,9 @@ async def notifications_page():
 
         await refresh_notifs()
         ui.timer(30, lambda: ui.run_async(refresh_notifs()))
+
+        async def handle_event(event: dict) -> None:
+            if event.get("type") == "notification":
+                await refresh_notifs()
+
+        ui.run_async(listen_ws(handle_event))


### PR DESCRIPTION
## Summary
- connect websocket client in `api` and expose helpers
- wire messages and notifications pages to websocket updates
- keep existing timer refresh as fallback

## Testing
- `pre-commit run --files transcendental_resonance_frontend/src/utils/api.py transcendental_resonance_frontend/src/pages/messages_page.py transcendental_resonance_frontend/src/pages/notifications_page.py`
- `pytest -q` *(fails: many tests errored due to missing database and session setup)*

------
https://chatgpt.com/codex/tasks/task_e_68883b3abc5c8320aa9573b06adb0595