### PR TITLE
Add shared nav bar

### DIFF
--- a/transcendental_resonance_frontend/src/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/src/pages/ai_assist_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def ai_assist_page(vibenode_id: int):
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('AI Assist').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -6,7 +6,7 @@ import json
 from nicegui import ui
 
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from frontend_bridge import ROUTES, dispatch_route
 
 # Minimal example payloads for some routes
@@ -30,6 +30,8 @@ async def debug_panel_page() -> None:
     """Render controls for invoking ``frontend_bridge`` routes."""
     theme = get_theme()
     with page_container(theme):
+        with nav_bar(theme):
+            pass
         ui.label("Debug Panel").classes("text-2xl font-bold mb-4").style(
             f"color: {theme['accent']};"
         )

--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def events_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Events').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/forks_page.py
+++ b/transcendental_resonance_frontend/src/pages/forks_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def forks_page() -> None:
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Universe Forks').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def groups_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Groups').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -2,7 +2,7 @@
 
 from nicegui import ui
 from utils.api import TOKEN, api_call
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import get_theme
 
 from .login_page import login_page
@@ -17,6 +17,8 @@ async def messages_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label("Messages").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/music_page.py
+++ b/transcendental_resonance_frontend/src/pages/music_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def music_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Music Generator').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/src/pages/network_analysis_page.py
@@ -4,7 +4,7 @@ import json
 
 from nicegui import ui
 from utils.api import TOKEN, api_call
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import get_theme
 
 from .login_page import login_page
@@ -19,6 +19,8 @@ async def network_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label("Network Analysis").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -2,7 +2,7 @@
 
 from nicegui import ui
 from utils.api import TOKEN, api_call
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import get_theme
 
 from .login_page import login_page
@@ -17,6 +17,8 @@ async def notifications_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label("Notifications").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -3,7 +3,7 @@
 from nicegui import ui
 from utils.api import (TOKEN, api_call, clear_token, get_followers,
                        get_following, get_user, toggle_follow)
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import (THEMES, get_theme, get_theme_name, set_accent,
                           set_theme)
 
@@ -46,6 +46,8 @@ async def profile_page(username: str | None = None):
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label(f'Welcome, {user_data["username"]}').classes(
             "text-2xl font-bold mb-4"
         ).style(f'color: {THEME["accent"]};')

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def proposals_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Proposals').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/status_page.py
+++ b/transcendental_resonance_frontend/src/pages/status_page.py
@@ -2,7 +2,7 @@
 
 from nicegui import ui
 from utils.api import api_call
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import get_theme
 
 
@@ -11,6 +11,8 @@ async def status_page():
     """Display real-time system metrics."""
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label("System Status").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/src/pages/system_insights_page.py
@@ -2,7 +2,7 @@
 
 from nicegui import ui
 from utils.api import TOKEN, api_call
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from utils.styles import get_theme
 
 from .login_page import login_page
@@ -17,6 +17,8 @@ async def system_insights_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label("System Insights").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def upload_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Upload Media').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -5,7 +5,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -18,6 +18,8 @@ async def validator_graph_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('Validator Graphs').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -4,7 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
-from utils.layout import page_container
+from utils.layout import page_container, nav_bar
 from .login_page import login_page
 
 
@@ -17,6 +17,8 @@ async def vibenodes_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        with nav_bar(THEME):
+            pass
         ui.label('VibeNodes').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/utils/layout.py
+++ b/transcendental_resonance_frontend/src/utils/layout.py
@@ -35,6 +35,30 @@ from .styles import get_theme
 
 
 @contextmanager
+def nav_bar(theme: Optional[dict] = None) -> Generator[Element, None, None]:
+    """Context manager for a simple navigation bar.
+
+    Yields a ``ui.row`` containing buttons that link to major pages. The
+    appearance of the buttons adapts to the provided ``theme``.
+    """
+    theme = theme or get_theme()
+    with ui.row().classes("w-full gap-2 mb-4") as bar:
+        style = f"background: {theme['primary']}; color: {theme['text']};"
+        links = [
+            ("Profile", "/profile"),
+            ("Groups", "/groups"),
+            ("Events", "/events"),
+            ("VibeNodes", "/vibenodes"),
+            ("Proposals", "/proposals"),
+            ("Messages", "/messages"),
+            ("Notifications", "/notifications"),
+        ]
+        for label, path in links:
+            ui.button(label, on_click=lambda p=path: ui.open(p)).style(style)
+        yield bar
+
+
+@contextmanager
 def page_container(theme: Optional[dict] = None) -> Generator[Element, None, None]:
     """Context manager for a themed page container.
 


### PR DESCRIPTION
## Summary
- provide `nav_bar` generator with themed buttons linking to common pages
- integrate the navigation bar at the top of each page container

## Testing
- `pytest --maxfail=1 -q tests/test_layout.py`

------
https://chatgpt.com/codex/tasks/task_e_68883b3d1b508320b4914563679a20be