### PR TITLE
Add slider filtering to validator graphs

### DIFF
--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -1,15 +1,16 @@
 """Validator graph visualization page using Plotly JS."""
 
 import json
-from nicegui import ui
 
-from utils.api import api_call, TOKEN
-from utils.styles import get_theme
+from nicegui import ui
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
+from utils.styles import get_theme
+
 from .login_page import login_page
 
 
-@ui.page('/validator-graphs')
+@ui.page("/validator-graphs")
 async def validator_graph_page():
     """Display validator network graphs."""
     if not TOKEN:
@@ -18,28 +19,60 @@ async def validator_graph_page():
 
     THEME = get_theme()
     with page_container(THEME):
-        ui.label('Validator Graphs').classes('text-2xl font-bold mb-4').style(
+        ui.label("Validator Graphs").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )
 
-        layout_select = ui.select(
-            ['random', 'circle'], value='random'
-        ).classes('w-full mb-2')
-        filter_input = ui.input('Filter by label').classes('w-full mb-4')
+        layout_select = ui.select(["random", "circle"], value="random").classes(
+            "w-full mb-2"
+        )
+        try:
+            stored = ui.run_javascript(
+                "localStorage.getItem('validator_layout')",
+                respond=True,
+            )
+            if isinstance(stored, str) and stored in ["random", "circle"]:
+                layout_select.value = stored
+        except Exception:
+            stored = None  # nosec - localStorage access may fail during testing
 
-        graph_area = ui.html('').classes('w-full h-96')
+        def _on_layout_change() -> None:
+            ui.run_javascript(
+                f"localStorage.setItem('validator_layout', '{layout_select.value}')"
+            )
+            ui.run_async(refresh_graph())
+
+        layout_select.on("change", lambda _: _on_layout_change())
+
+        filter_input = ui.input("Filter by label").classes("w-full mb-2")
+        weight_slider = ui.slider(min=0, max=1, value=0, step=0.1).classes(
+            "w-full mb-4"
+        )
+        weight_label = ui.label(f"Min Weight: {weight_slider.value}").classes("mb-4")
+        weight_slider.on(
+            "update:model-value",
+            lambda e: weight_label.set_text(f"Min Weight: {e.value}"),
+        )
+        weight_slider.on("change", lambda _: ui.run_async(refresh_graph()))
+
+        graph_area = ui.html("").classes("w-full h-96")
 
         async def refresh_graph() -> None:
-            analysis = await api_call('GET', '/network-analysis/')
+            analysis = await api_call("GET", "/network-analysis/")
             if not analysis:
                 return
-            nodes = analysis.get('nodes', [])
-            edges = analysis.get('edges', [])
-            filt = (filter_input.value or '').strip().lower()
+            nodes = analysis.get("nodes", [])
+            edges = analysis.get("edges", [])
+
+            threshold = weight_slider.value or 0
+            if threshold:
+                edges = [e for e in edges if e.get("strength", 1) >= threshold]
+
+            filt = (filter_input.value or "").strip().lower()
             if filt:
-                nodes = [n for n in nodes if filt in str(n.get('label', '')).lower()]
-                ids = {n['id'] for n in nodes}
-                edges = [e for e in edges if e['source'] in ids and e['target'] in ids]
+                nodes = [n for n in nodes if filt in str(n.get("label", "")).lower()]
+            ids = {n["id"] for n in nodes}
+            edges = [e for e in edges if e["source"] in ids and e["target"] in ids]
 
             graph_html = f"""
             <div id='validator_graph'></div>
@@ -84,9 +117,8 @@ async def validator_graph_page():
             """
             graph_area.set_content(graph_html)
 
-        ui.button('Update', on_click=refresh_graph).classes('mb-4').style(
+        ui.button("Update", on_click=refresh_graph).classes("mb-4").style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'
         )
-        layout_select.on('change', lambda _: ui.run_async(refresh_graph()))
-        filter_input.on('change', lambda _: ui.run_async(refresh_graph()))
+        filter_input.on("change", lambda _: ui.run_async(refresh_graph()))
         await refresh_graph()


### PR DESCRIPTION
## Summary
- add a weight slider with label on the validator graph page
- store layout choice in `localStorage` and restore it on load
- filter edges by minimum weight before rendering

## Testing
- `pre-commit run --files transcendental_resonance_frontend/src/pages/validator_graph_page.py`
- `pytest -q` *(fails: 40 failed, 251 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68883b41e7e08320a302c7a1df927554