### PR TITLE
Add Explore page with infinite scroll

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -1,15 +1,19 @@
 """Main entry point for the Transcendental Resonance frontend."""
+
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-from nicegui import ui, background_tasks
 import asyncio
 
-from .utils.api import clear_token, api_call
-from .utils.styles import apply_global_styles, set_theme, get_theme_name, THEMES
-from .pages import *  # register all pages
+from nicegui import background_tasks, ui
+
+from .pages import *  # register all pages  # noqa: F401,F403
+from .pages.explore_page import explore_page  # noqa: F401
 from .pages.system_insights_page import system_insights_page  # noqa: F401
+from .utils.api import api_call, clear_token
+from .utils.styles import (THEMES, apply_global_styles, get_theme_name,
+                           set_theme)
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
@@ -30,7 +34,7 @@ def toggle_theme() -> None:
 async def keep_backend_awake() -> None:
     """Periodically ping the backend to keep data fresh."""
     while True:
-        await api_call('GET', '/status')
+        await api_call("GET", "/status")
         await asyncio.sleep(300)
 
 
@@ -39,11 +43,13 @@ ui.button(
     on_click=toggle_theme,
 ).classes("fixed top-0 right-0 m-2")
 
-ui.on_startup(lambda: background_tasks.create(keep_backend_awake(), name='backend-pinger'))
+ui.on_startup(
+    lambda: background_tasks.create(keep_backend_awake(), name="backend-pinger")
+)
 
 # Potential future enhancements:
 # - Real-time updates via WebSockets
 # - Internationalization support
 # - Theming options
 
-ui.run(title='Transcendental Resonance', dark=True, favicon='🌌', reload=False)
+ui.run(title="Transcendental Resonance", dark=True, favicon="🌌", reload=False)

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -1,10 +1,15 @@
 """Lazy-loading access to page modules for the Transcendental Resonance frontend."""
 
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 __all__ = [
     "login_page",
     "register_page",
     "profile_page",
     "vibenodes_page",
+    "explore_page",
     "groups_page",
     "events_page",
     "proposals_page",

--- a/transcendental_resonance_frontend/src/pages/explore_page.py
+++ b/transcendental_resonance_frontend/src/pages/explore_page.py
@@ -1,0 +1,72 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from nicegui import ui
+from utils.api import TOKEN, api_call
+from utils.layout import page_container
+from utils.styles import get_theme
+
+from .login_page import login_page
+
+
+@ui.page("/explore")
+async def explore_page() -> None:
+    """Display trending VibeNodes with infinite scroll."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with page_container(THEME):
+        ui.label("Explore").classes("text-2xl font-bold mb-4").style(
+            f'color: {THEME["accent"]};'
+        )
+
+        posts_container = ui.column().classes("w-full")
+
+        limit = 10
+        offset = 0
+        loading = {"value": False}
+
+        async def load_more() -> None:
+            nonlocal offset
+            params = {"offset": offset, "limit": limit}
+            posts = await api_call("GET", "/vibenodes/trending", params) or []
+            if not posts:
+                return
+            offset += len(posts)
+            for p in posts:
+                with posts_container:
+                    with (
+                        ui.card()
+                        .classes("w-full mb-2")
+                        .style("border: 1px solid #333; background: #1e1e1e;")
+                    ):
+                        ui.label(p.get("name", "")).classes("text-lg")
+                        ui.label(p.get("description", "")).classes("text-sm")
+                        if p.get("media_url"):
+                            mtype = p.get("media_type", "")
+                            if mtype.startswith("image"):
+                                ui.image(p["media_url"]).classes("w-full")
+                            elif mtype.startswith("video"):
+                                ui.video(p["media_url"]).classes("w-full")
+                            elif mtype.startswith("audio") or mtype.startswith("music"):
+                                ui.audio(p["media_url"]).classes("w-full")
+                        ui.label(f"Likes: {p.get('likes_count', 0)}").classes("text-sm")
+
+        await load_more()
+
+        async def check_scroll() -> None:
+            if loading["value"]:
+                return
+            at_bottom = await ui.run_javascript(
+                "window.innerHeight + window.scrollY >= document.body.offsetHeight - 2",
+                respond=True,
+            )
+            if at_bottom:
+                loading["value"] = True
+                await load_more()
+                loading["value"] = False
+
+        ui.timer(1.0, lambda: ui.run_async(check_scroll()))

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -1,5 +1,9 @@
 """User profile view and editing."""
 
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 from nicegui import ui
 from utils.api import (TOKEN, api_call, clear_token, get_followers,
                        get_following, get_user, toggle_follow)
@@ -59,9 +63,7 @@ async def profile_page(username: str | None = None):
         followers_label = ui.label(f'Followers: {followers.get("count", 0)}').classes(
             "mb-2"
         )
-        following_label = ui.label(f'Following: {following.get("count", 0)}').classes(
-            "mb-4"
-        )
+        ui.label(f'Following: {following.get("count", 0)}').classes("mb-4")
 
         if target_username == my_data["username"]:
             bio = ui.input("Bio", value=user_data.get("bio", "")).classes("w-full mb-2")
@@ -100,6 +102,11 @@ async def profile_page(username: str | None = None):
         ui.button("VibeNodes", on_click=lambda: ui.open(vibenodes_page)).classes(
             "w-full mb-2"
         ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
+        from .explore_page import explore_page  # lazy import
+
+        ui.button("Explore", on_click=lambda: ui.open(explore_page)).classes(
+            "w-full mb-2"
+        ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
         ui.button("Groups", on_click=lambda: ui.open(groups_page)).classes(
             "w-full mb-2"
         ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
@@ -130,7 +137,7 @@ async def profile_page(username: str | None = None):
         ).classes("w-full").style(f'background: red; color: {THEME["text"]};')
 
         with ui.row().classes("w-full mt-4"):
-            theme_select = ui.select(
+            ui.select(
                 list(THEMES.keys()),
                 value=get_theme_name(),
                 on_change=lambda e: set_theme(e.value),

--- a/transcendental_resonance_frontend/tests/test_explore_page.py
+++ b/transcendental_resonance_frontend/tests/test_explore_page.py
@@ -1,0 +1,15 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+import inspect
+
+from pages.explore_page import explore_page
+
+
+def test_explore_page_is_async():
+    assert inspect.iscoroutinefunction(explore_page)  # nosec B101
+
+
+def test_explore_page_uses_trending_endpoint():
+    src = inspect.getsource(explore_page)
+    assert "/vibenodes/trending" in src  # nosec B101


### PR DESCRIPTION
## Summary
- add `/explore` page for trending VibeNodes
- register explore page and link from profile nav
- include disclaimer headers
- test explore page routing

## Testing
- `pre-commit run --files transcendental_resonance_frontend/src/pages/explore_page.py transcendental_resonance_frontend/src/pages/__init__.py transcendental_resonance_frontend/src/main.py transcendental_resonance_frontend/src/pages/profile_page.py transcendental_resonance_frontend/tests/test_explore_page.py`
- `pytest transcendental_resonance_frontend/tests/test_explore_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68883b3f3c308320a1b12374d2a123a6