### PR TITLE
Add notification bell component

### DIFF
--- a/transcendental_resonance_frontend/src/components/notification_bell.py
+++ b/transcendental_resonance_frontend/src/components/notification_bell.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from nicegui import ui
+
+from ..utils.api import api_call
+from ..utils.styles import get_theme
+from ..pages.notifications_page import notifications_page
+
+
+def notification_bell() -> ui.element.Element:
+    """Display a notifications icon with unread count."""
+    theme = get_theme()
+    with ui.row().classes('items-center') as container:
+        button = ui.button(icon='notifications', on_click=lambda: ui.open(notifications_page)).classes('relative')
+        badge = ui.badge('0', color=theme['accent'], text_color=theme['background']).classes('ml-1')
+
+    async def refresh_count() -> None:
+        notifications = await api_call('GET', '/notifications/') or []
+        unread = sum(1 for n in notifications if not n.get('is_read'))
+        badge.text = str(unread)
+        badge.visible = unread > 0
+
+    ui.run_async(refresh_count())
+    ui.timer(30, lambda: ui.run_async(refresh_count()))
+    return container

--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -8,11 +8,13 @@ import asyncio
 
 from .utils.api import clear_token, api_call
 from .utils.styles import apply_global_styles, set_theme, get_theme_name, THEMES
+from .utils.layout import nav_bar
 from .pages import *  # register all pages
 from .pages.system_insights_page import system_insights_page  # noqa: F401
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
+nav_bar()
 
 
 def toggle_theme() -> None:

--- a/transcendental_resonance_frontend/src/utils/layout.py
+++ b/transcendental_resonance_frontend/src/utils/layout.py
@@ -47,3 +47,15 @@ def page_container(theme: Optional[dict] = None) -> Generator[Element, None, Non
     ) as container:
         yield container
 
+
+
+def nav_bar(theme: Optional[dict] = None) -> Element:
+    """Render a simple navigation bar."""
+    theme = theme or get_theme()
+    with ui.row().classes('w-full justify-end p-2').style(
+        f"background: {theme['primary']}; color: {theme['text']};"
+    ) as bar:
+        from ..components.notification_bell import notification_bell
+
+        notification_bell()
+    return bar

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Proxy package exposing NiceGUI utilities."""
+from importlib import import_module
+import sys
+
+__all__ = ["layout", "api", "styles", "demo_data"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"transcendental_resonance_frontend.src.utils.{name}")
+        sys.modules[f"utils.{name}"] = module
+        return module
+    raise AttributeError(name)

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.api import *

--- a/utils/demo_data.py
+++ b/utils/demo_data.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.demo_data import *

--- a/utils/layout.py
+++ b/utils/layout.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.layout import *

--- a/utils/styles.py
+++ b/utils/styles.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.styles import *


### PR DESCRIPTION
## Summary
- add a `notification_bell` component showing unread count
- expose frontend utils at top level for tests
- render new nav bar with bell in `main.py`

## Testing
- `pytest -q tests/test_layout.py`
- `pytest -q transcendental_resonance_frontend/tests/test_notifications_page.py`
- `pytest -q` *(fails: sqlalchemy errors and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68883b496f408320a2e8a40b5b8b55a6