### PR TITLE
Add recommendations discovery page

### DIFF
--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "vibenodes_page",
     "groups_page",
     "events_page",
+    "recommendations_page",
     "proposals_page",
     "notifications_page",
     "messages_page",

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -14,6 +14,7 @@ from .messages_page import messages_page
 from .notifications_page import notifications_page
 from .proposals_page import proposals_page
 from .vibenodes_page import vibenodes_page
+from .recommendations_page import recommendations_page
 
 
 @ui.page("/profile")
@@ -115,6 +116,9 @@ async def profile_page(username: str | None = None):
             f'background: {THEME["accent"]}; color: {THEME["background"]};'
         )
         ui.button("Messages", on_click=lambda: ui.open(messages_page)).classes(
+            "w-full mb-2"
+        ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
+        ui.button("Discover", on_click=lambda: ui.open(recommendations_page)).classes(
             "w-full mb-2"
         ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
         from .system_insights_page import system_insights_page  # lazy import

--- a/transcendental_resonance_frontend/src/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/src/pages/recommendations_page.py
@@ -1,0 +1,62 @@
+"""Recommendations discovery page."""
+
+from nicegui import ui
+
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
+from utils.layout import page_container
+from .login_page import login_page
+
+
+@ui.page('/discover')
+async def recommendations_page():
+    """Fetch and display recommended users, groups, or events."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with page_container(THEME):
+        ui.label('Discover').classes('text-2xl font-bold mb-4').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        rec_list = ui.column().classes('w-full')
+
+        async def refresh_recs() -> None:
+            recs = await api_call('GET', '/recommendations') or []
+            rec_list.clear()
+            for rec in recs:
+                with rec_list:
+                    with ui.card().classes('w-full mb-2').style(
+                        'border: 1px solid #333; background: #1e1e1e;'
+                    ):
+                        name = rec.get('name') or rec.get('username', 'Unknown')
+                        ui.label(name).classes('text-lg')
+                        desc = rec.get('description') or rec.get('bio')
+                        if desc:
+                            ui.label(desc).classes('text-sm')
+                        rtype = rec.get('type')
+                        if rtype == 'user':
+                            async def follow_fn(u=rec.get('id')):
+                                await api_call('POST', f'/users/{u}/follow')
+                                await refresh_recs()
+                            ui.button('Follow/Unfollow', on_click=follow_fn).style(
+                                f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                            )
+                        elif rtype == 'group':
+                            async def join_fn(g=rec.get('id')):
+                                await api_call('POST', f'/groups/{g}/join')
+                                await refresh_recs()
+                            ui.button('Join/Leave', on_click=join_fn).style(
+                                f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                            )
+                        elif rtype == 'event':
+                            async def attend_fn(e=rec.get('id')):
+                                await api_call('POST', f'/events/{e}/attend')
+                                await refresh_recs()
+                            ui.button('Attend/Leave', on_click=attend_fn).style(
+                                f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                            )
+
+        await refresh_recs()

--- a/transcendental_resonance_frontend/tests/test_recommendations_page.py
+++ b/transcendental_resonance_frontend/tests/test_recommendations_page.py
@@ -1,0 +1,6 @@
+import inspect
+from pages.recommendations_page import recommendations_page
+
+
+def test_recommendations_page_is_async():
+    assert inspect.iscoroutinefunction(recommendations_page)


### PR DESCRIPTION
## Summary
- add new recommendations page for discovering users, groups or events
- expose new page from `pages` package and profile navigation
- include basic unit test for new page

## Testing
- `pytest transcendental_resonance_frontend/tests/test_recommendations_page.py -q`
- `pytest -q` *(fails: AGENT_REGISTRY assertion and others)*

------
https://chatgpt.com/codex/tasks/task_e_68883b6b67d48320ab4260e63a16f624