### PR TITLE
Add share buttons to events and VibeNodes pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -79,5 +79,14 @@ async def events_page():
                         ui.button('Attend/Leave', on_click=attend_fn).style(
                             f'background: {THEME["accent"]}; color: {THEME["background"]};'
                         )
+                        async def share_fn(e_id=e['id']):
+                            link = f"/events/{e_id}"
+                            ui.run_javascript(
+                                f"navigator.clipboard.writeText(window.location.origin + '{link}')"
+                            )
+                            ui.notify('Link copied')
+                        ui.button('Share', on_click=share_fn).style(
+                            f'background: {THEME["primary"]}; color: {THEME["text"]};'
+                        )
 
         await refresh_events()

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -111,5 +111,14 @@ async def vibenodes_page():
                         ui.button('Remix', on_click=remix_fn).style(
                             f'background: {THEME["primary"]}; color: {THEME["text"]};'
                         )
+                        async def share_fn(vn_id=vn['id']):
+                            link = f"/vibenodes/{vn_id}"
+                            ui.run_javascript(
+                                f"navigator.clipboard.writeText(window.location.origin + '{link}')"
+                            )
+                            ui.notify('Link copied')
+                        ui.button('Share', on_click=share_fn).style(
+                            f'background: {THEME["primary"]}; color: {THEME["text"]};'
+                        )
 
         await refresh_vibenodes()


### PR DESCRIPTION
## Summary
- add a button to copy the event's page link on `events_page`
- add a similar sharing button for each VibeNode card

## Testing
- `make test` *(fails: many tests error due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68883b6fd5208320ae69b49f18d1f70f