### PR TITLE
Fix test collection by adding websockets

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ bandit
 httpx==0.27.0
 streamlit-ace
 kaleido
+websockets
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -16,6 +16,7 @@ passlib[bcrypt]
 python-jose[cryptography]
 prometheus-client
 streamlit
+websockets
 types-requests
 
 # appended for compatibility with test suites

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -17,6 +17,7 @@ qrcode
 asyncpg
 streamlit-ace
 kaleido
+websockets
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,6 @@ email-validator
 httpx==0.27.0
 streamlit-ace
 kaleido
+websockets
 plotly
 pyvis


### PR DESCRIPTION
## Summary
- add the missing **websockets** dependency to all requirement files

## Testing
- `pytest transcendental_resonance_frontend/tests/test_recommendations_page.py -q`
- `pytest -q` *(fails: 55 failed, 279 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888411a0d7c8320a132a84f9c145ef9