### PR TITLE
Add loading overlay and API request events

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -12,11 +12,13 @@ from .pages import *  # register all pages  # noqa: F401,F403
 from .pages.explore_page import explore_page  # noqa: F401
 from .pages.system_insights_page import system_insights_page  # noqa: F401
 from .utils.api import api_call, clear_token
+from .utils.loading_overlay import LoadingOverlay
 from .utils.styles import (THEMES, apply_global_styles, get_theme_name,
                            set_theme)
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
+LoadingOverlay()
 
 
 def toggle_theme() -> None:

--- a/transcendental_resonance_frontend/src/utils/loading_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/loading_overlay.py
@@ -1,0 +1,34 @@
+"""UI component displaying a loading spinner during API requests."""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from .api import on_request_start, on_request_end
+
+
+class LoadingOverlay:
+    """Display a simple spinner dialog while API calls are running."""
+
+    def __init__(self) -> None:
+        self._count = 0
+        self._dialog = ui.dialog().props("persistent")
+        with self._dialog:
+            with ui.card():
+                ui.spinner(size="lg")
+
+        on_request_start(self._on_start)
+        on_request_end(self._on_end)
+
+    def _on_start(self) -> None:
+        self._count += 1
+        if not self._dialog.open:
+            self._dialog.open()
+
+    def _on_end(self) -> None:
+        self._count = max(0, self._count - 1)
+        if self._count == 0 and self._dialog.open:
+            self._dialog.close()
+
+
+__all__ = ["LoadingOverlay"]


### PR DESCRIPTION
## Summary
- dispatch callbacks before and after `api_call`
- show global loading overlay while API requests are running
- enable overlay across all pages

## Testing
- `pytest -q` *(fails: 55 failed, 279 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688841f0f04c83208491b1b182b06e7a