### PR TITLE
Add calendar download to events

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Compatibility wrapper exposing frontend utilities under ``utils`` package."""
+
+from importlib import import_module
+
+_frontend_utils = import_module("transcendental_resonance_frontend.src.utils")
+
+__all__ = getattr(_frontend_utils, "__all__", [])
+
+def __getattr__(name: str):
+    return getattr(_frontend_utils, name)
+
+# expose common modules directly
+from . import api, layout, styles, demo_data  # noqa: F401

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.api import *

--- a/utils/demo_data.py
+++ b/utils/demo_data.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.demo_data import *

--- a/utils/layout.py
+++ b/utils/layout.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.layout import *

--- a/utils/styles.py
+++ b/utils/styles.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.styles import *


### PR DESCRIPTION
## Summary
- add calendar download button in events page
- bridge frontend utilities under a new `utils` package for tests

## Testing
- `pytest transcendental_resonance_frontend/tests/test_events_page.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688841f431308320975cb6991480cfb2