### PR TITLE
Add global search widget

### DIFF
--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -149,3 +149,29 @@ async def listen_ws(handler: Callable[[dict], Awaitable[None]]) -> None:
             await ws.close()
         if WS_CONNECTION is ws:
             WS_CONNECTION = None
+
+
+async def combined_search(query: str) -> list[Dict[str, Any]]:
+    """Search across users, VibeNodes, and events."""
+    params = {"search": query}
+    results: list[Dict[str, Any]] = []
+
+    users = await api_call("GET", "/users/", params) or []
+    for u in users:
+        label = u.get("username") or u.get("name")
+        if label:
+            results.append({"type": "user", "label": label, "id": u.get("username")})
+
+    vns = await api_call("GET", "/vibenodes/", params) or []
+    for vn in vns:
+        label = vn.get("name")
+        if label:
+            results.append({"type": "vibenode", "label": label, "id": vn.get("id")})
+
+    events = await api_call("GET", "/events/", params) or []
+    for ev in events:
+        label = ev.get("name") or ev.get("title")
+        if label:
+            results.append({"type": "event", "label": label, "id": ev.get("id")})
+
+    return results

--- a/transcendental_resonance_frontend/tests/test_layout.py
+++ b/transcendental_resonance_frontend/tests/test_layout.py
@@ -1,0 +1,16 @@
+import inspect
+from utils.layout import search_widget, page_container
+
+
+def test_search_widget_defined():
+    assert inspect.isfunction(search_widget)
+
+
+def test_search_widget_uses_combined_search():
+    src = inspect.getsource(search_widget)
+    assert "combined_search" in src
+
+
+def test_page_container_calls_search_widget():
+    src = inspect.getsource(page_container)
+    assert "search_widget()" in src


### PR DESCRIPTION
## Summary
- implement `combined_search` API helper
- embed global search in layout page container
- unit test layout search integration

## Testing
- `pip install -q websockets`
- `pytest -q` *(fails: 40 failed, 260 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688841f578388320822cfbe4006a67a9