### PR TITLE
Add profile/group recommendations

### DIFF
--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -2,7 +2,7 @@
 
 from nicegui import ui
 
-from utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN, get_group_recommendations
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page
@@ -68,3 +68,22 @@ async def groups_page():
                         )
 
         await refresh_groups()
+
+        ui.label('You may like').classes('text-xl font-bold mt-4').style(
+            f'color: {THEME["accent"]};'
+        )
+        suggestions = ui.column().classes('w-full')
+
+        async def load_suggestions() -> None:
+            recs = await get_group_recommendations()
+            for g in recs:
+                with suggestions:
+                    with ui.card().classes('w-full mb-2').style(
+                        'border: 1px solid #333; background: #1e1e1e;'
+                    ):
+                        ui.label(g.get('name', 'Unknown')).classes('text-lg')
+                        desc = g.get('description')
+                        if desc:
+                            ui.label(desc).classes('text-sm')
+
+        await load_suggestions()

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -5,8 +5,16 @@
 # Legal & Ethical Safeguards
 
 from nicegui import ui
-from utils.api import (TOKEN, api_call, clear_token, get_followers,
-                       get_following, get_user, toggle_follow)
+from utils.api import (
+    TOKEN,
+    api_call,
+    clear_token,
+    get_followers,
+    get_following,
+    get_user,
+    toggle_follow,
+    get_user_recommendations,
+)
 from utils.layout import page_container
 from utils.styles import (THEMES, get_theme, get_theme_name, set_accent,
                           set_theme)
@@ -170,3 +178,22 @@ async def profile_page(username: str | None = None):
                 value=THEME["accent"],
                 on_change=lambda e: set_accent(e.value),
             )
+
+        ui.label("You may like").classes("text-xl font-bold mt-4").style(
+            f'color: {THEME["accent"]};'
+        )
+        suggestions = ui.column().classes("w-full")
+
+        async def load_suggestions() -> None:
+            recs = await get_user_recommendations()
+            for u in recs:
+                with suggestions:
+                    with ui.card().classes('w-full mb-2').style(
+                        'border: 1px solid #333; background: #1e1e1e;'
+                    ):
+                        ui.label(u.get('username', 'Unknown')).classes('text-lg')
+                        bio = u.get('bio')
+                        if bio:
+                            ui.label(bio).classes('text-sm')
+
+        await load_suggestions()

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -116,6 +116,16 @@ async def toggle_follow(username: str) -> Optional[Dict[str, Any]]:
     return await api_call("POST", f"/users/{username}/follow")
 
 
+async def get_user_recommendations() -> list[Dict[str, Any]]:
+    """Return a list of recommended users."""
+    return await api_call("GET", "/recommendations/users") or []
+
+
+async def get_group_recommendations() -> list[Dict[str, Any]]:
+    """Return a list of recommended groups."""
+    return await api_call("GET", "/recommendations/groups") or []
+
+
 async def connect_ws(path: str = "/ws"):
     """Establish and return a WebSocket connection to the backend."""
     global WS_CONNECTION


### PR DESCRIPTION
## Summary
- create helper functions to retrieve recommended users and groups
- show recommended users on the profile page
- show recommended groups on the groups page

## Testing
- `pytest -q` *(fails: 57 failed, 277 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688841f7bb0c8320a5e87152490e21dd