### PR TITLE
Add avatar support in profile and upload pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -48,17 +48,23 @@ async def profile_page(username: str | None = None):
 
     followers = await get_followers(target_username)
     following = await get_following(target_username)
-    avatar_url = user_data.get("avatar_url")
+
+    # always fetch avatar_url from /users/<username>
+    avatar_resp = await api_call("GET", f"/users/{target_username}") or {}
+    avatar_url = avatar_resp.get("avatar_url")
 
     THEME = get_theme()
     with page_container(THEME):
+        avatar_img = (
+            ui.image(avatar_url)
+            .classes("w-32 h-32 rounded-full mb-2")
+            if avatar_url
+            else ui.icon("person").classes("text-8xl mb-2")
+        )
+
         ui.label(f'Welcome, {user_data["username"]}').classes(
             "text-2xl font-bold mb-4"
         ).style(f'color: {THEME["accent"]};')
-
-        avatar_img = ui.image(
-            avatar_url or "https://via.placeholder.com/150"
-        ).classes("w-32 h-32 rounded-full mb-4")
 
         ui.label(f'Harmony Score: {user_data["harmony_score"]}').classes("mb-2")
         ui.label(f'Creative Spark: {user_data["creative_spark"]}').classes("mb-2")

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -44,4 +44,19 @@ async def upload_page():
             .props('label=Drop files here') \
             .classes('w-full mb-4 border-2 border-dashed rounded-lg p-4')
 
-        ui.label('Select or drop files to upload').classes('text-center')
+        ui.label('Select or drop files to upload').classes('text-center mb-8')
+
+        ui.label('Upload New Avatar').classes('text-xl font-bold mb-2').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        async def handle_avatar_upload(event):
+            files = {'file': (event.name, event.content.read(), 'multipart/form-data')}
+            resp = await api_call('POST', '/upload/avatar', files=files)
+            if resp and resp.get('avatar_url'):
+                await api_call('PUT', '/users/me', {'avatar_url': resp['avatar_url']})
+                ui.notify('Avatar updated', color='positive')
+
+        ui.upload(on_upload=lambda e: ui.run_async(handle_avatar_upload(e))) \
+            .props('label=Choose avatar image') \
+            .classes('w-full mb-4')


### PR DESCRIPTION
## Summary
- fetch avatar URL from `/users/<username>`
- display the avatar above the username with fallback icon
- add avatar upload capability

## Testing
- `pytest -q` *(fails: 55 failed, 279 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688841fa191483208f9d80c1bf81639e