### PR TITLE
Enable live updates on VibeNodes page

### DIFF
--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -3,7 +3,7 @@
 from nicegui import ui
 import asyncio
 
-from utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN, listen_ws
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page
@@ -148,3 +148,9 @@ async def vibenodes_page():
 
 
         await refresh_vibenodes()
+
+        async def handle_event(event: dict) -> None:
+            if event.get("type") == "vibenode_updated":
+                await refresh_vibenodes()
+
+        ui.run_async(listen_ws(handle_event))


### PR DESCRIPTION
## Summary
- subscribe to websocket events on the VibeNodes page
- refresh list when `vibenode_updated` events arrive

## Testing
- `pytest transcendental_resonance_frontend/tests/test_vibenodes_page.py -q`
- `pytest -q` *(fails: 55 failed, 279 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688841fbede083209c5f7b588be36e43