### PR TITLE
Add unified feed page

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -11,6 +11,7 @@ from nicegui import background_tasks, ui
 from .pages import *  # register all pages  # noqa: F401,F403
 from .pages.explore_page import explore_page  # noqa: F401
 from .pages.system_insights_page import system_insights_page  # noqa: F401
+from .pages.feed_page import feed_page  # noqa: F401
 from .utils.api import api_call, clear_token
 from .utils.styles import (THEMES, apply_global_styles, get_theme_name,
                            set_theme)

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "proposals_page",
     "notifications_page",
     "messages_page",
+    "feed_page",
     "ai_assist_page",
     "upload_page",
     "music_page",

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -1,0 +1,52 @@
+"""Unified feed combining VibeNodes, Events, and Notifications."""
+
+from nicegui import ui
+
+from utils.api import TOKEN, api_call
+from utils.layout import page_container
+from utils.styles import get_theme
+
+from .login_page import login_page
+
+
+@ui.page('/feed')
+async def feed_page() -> None:
+    """Display a combined feed of recent activity."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    theme = get_theme()
+    with page_container(theme):
+        ui.label('Feed').classes('text-2xl font-bold mb-4').style(
+            f'color: {theme["accent"]};'
+        )
+
+        feed_column = ui.column().classes('w-full')
+
+        async def refresh_feed() -> None:
+            vibenodes = await api_call('GET', '/vibenodes/') or []
+            events = await api_call('GET', '/events/') or []
+            notifs = await api_call('GET', '/notifications/') or []
+
+            feed_column.clear()
+            for vn in vibenodes:
+                with feed_column:
+                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                        ui.label('VibeNode').classes('text-sm font-bold')
+                        ui.label(vn.get('description', '')).classes('text-sm')
+                        ui.link('View', f"/vibenodes/{vn['id']}")
+            for ev in events:
+                with feed_column:
+                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                        ui.label('Event').classes('text-sm font-bold')
+                        ui.label(ev.get('description', '')).classes('text-sm')
+                        ui.link('View', f"/events/{ev['id']}")
+            for n in notifs:
+                with feed_column:
+                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                        ui.label('Notification').classes('text-sm font-bold')
+                        ui.label(n.get('message', '')).classes('text-sm')
+                        ui.link('View', f"/notifications/{n['id']}")
+
+        await refresh_feed()

--- a/transcendental_resonance_frontend/tests/test_feed_page.py
+++ b/transcendental_resonance_frontend/tests/test_feed_page.py
@@ -1,0 +1,6 @@
+import inspect
+from pages.feed_page import feed_page
+
+
+def test_feed_page_is_async():
+    assert inspect.iscoroutinefunction(feed_page)


### PR DESCRIPTION
## Summary
- create new feed page that combines vibenodes, events and notifications
- expose feed page via pages `__init__` and register in main
- test feed page imports and runs asynchronously

## Testing
- `pytest -q` *(fails: 55 failed, 280 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688841fd6e888320b9a2580c5b993301