### PR TITLE
Add notification badge to navbar

### DIFF
--- a/transcendental_resonance_frontend/src/utils/layout.py
+++ b/transcendental_resonance_frontend/src/utils/layout.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Optional, Generator
 
+# global notification state used for navbar badge
+NOTIFICATION_COUNT: int = 0
+NOTIFICATION_BADGE = None
+
+def set_notification_count(count: int) -> None:
+    """Update the unread notification count and badge text."""
+    global NOTIFICATION_COUNT, NOTIFICATION_BADGE
+    NOTIFICATION_COUNT = count
+    if NOTIFICATION_BADGE is not None:
+        NOTIFICATION_BADGE.text = str(count) if count else ''
+
 try:  # pragma: no cover - allow import without NiceGUI installed
     from nicegui import ui
     from nicegui.element import Element
@@ -42,6 +53,7 @@ def navigation_bar() -> Element:
         from pages.messages_page import messages_page
         from pages.groups_page import groups_page
         from pages.events_page import events_page
+        from pages.notifications_page import notifications_page
         from pages.status_page import status_page
     except Exception:
         # During testing, NiceGUI or page modules may not be available
@@ -60,6 +72,21 @@ def navigation_bar() -> Element:
         ui.button('Events', on_click=lambda: ui.open(events_page)).style(
             f'background: {theme["accent"]}; color: {theme["background"]};'
         )
+
+        with ui.row().classes('items-center'):
+            ui.button(
+                on_click=lambda: ui.open(notifications_page),
+                icon='notifications',
+            ).style(
+                f'background: {theme["accent"]}; color: {theme["background"]};'
+            )
+            global NOTIFICATION_BADGE
+            NOTIFICATION_BADGE = ui.badge(
+                str(NOTIFICATION_COUNT) if NOTIFICATION_COUNT else '',
+                color='red',
+                text_color='white',
+            )
+
         ui.button('Status', on_click=lambda: ui.open(status_page)).style(
             f'background: {theme["accent"]}; color: {theme["background"]};'
         )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,22 @@
+"""Proxy package exposing frontend utilities at the repo root."""
+
+from transcendental_resonance_frontend.src.utils import (
+    api as api_module,
+    layout as layout_module,
+    styles as styles_module,
+    demo_data as demo_data_module,
+)  # type: ignore
+import sys
+
+# expose submodules under the ``utils`` namespace
+sys.modules.setdefault(__name__ + '.api', api_module)
+sys.modules.setdefault(__name__ + '.layout', layout_module)
+sys.modules.setdefault(__name__ + '.styles', styles_module)
+sys.modules.setdefault(__name__ + '.demo_data', demo_data_module)
+
+api = api_module
+layout = layout_module
+styles = styles_module
+demo_data = demo_data_module
+
+__all__ = ["api", "layout", "styles", "demo_data"]


### PR DESCRIPTION
## Summary
- listen for WebSocket `notification` events globally and update unread count
- show a notification icon with badge in the navigation bar
- mark all notifications read when opening the page and reset the badge
- expose frontend utils at the repo root for tests

## Testing
- `PYTHONPATH=/workspace pytest tests/test_layout.py::test_page_container_returns_element -q`
- `PYTHONPATH=/workspace pytest transcendental_resonance_frontend/tests/test_demo_data.py -q`
- `PYTHONPATH=/workspace pytest -q` *(fails: sqlalchemy errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_6888420544b88320b81e1fd9c4f9a79b