### PR TITLE
Add customizable themes

### DIFF
--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -8,8 +8,14 @@ from nicegui import ui
 from utils.api import (TOKEN, api_call, clear_token, get_followers,
                        get_following, get_user, toggle_follow)
 from utils.layout import page_container
-from utils.styles import (THEMES, get_theme, get_theme_name, set_accent,
-                          set_theme)
+from utils.styles import (
+    THEMES,
+    create_custom_theme,
+    get_theme,
+    get_theme_name,
+    set_accent,
+    set_theme,
+)
 
 from .events_page import events_page
 from .groups_page import groups_page
@@ -170,3 +176,24 @@ async def profile_page(username: str | None = None):
                 value=THEME["accent"],
                 on_change=lambda e: set_accent(e.value),
             )
+
+        with ui.row().classes("w-full mt-2"):
+            name_input = ui.input("New Theme Name").classes("mr-2")
+            bg_input = ui.color_input(
+                "Background",
+                value=THEME["background"],
+            ).classes("mr-2")
+            text_input = ui.color_input(
+                "Text",
+                value=THEME["text"],
+            ).classes("mr-2")
+
+            def store_theme() -> None:
+                if not name_input.value:
+                    ui.notify("Enter a theme name", color="warning")
+                    return
+                create_custom_theme(name_input.value, bg_input.value, text_input.value)
+                set_theme(name_input.value)
+                ui.notify("Theme saved", color="positive")
+
+            ui.button("Save Theme", on_click=store_theme)

--- a/transcendental_resonance_frontend/tests/test_styles.py
+++ b/transcendental_resonance_frontend/tests/test_styles.py
@@ -32,3 +32,39 @@ def test_set_accent_overrides_default(monkeypatch):
     styles.set_theme("dark")
     styles.set_accent("#123456")
     assert styles.get_theme()["accent"] == "#123456"
+
+
+def test_custom_palette_loaded(monkeypatch):
+    captured = {}
+
+    def run_js(script, respond=False):
+        if "customThemes" in script:
+            return '{"custom": {"primary": "#000", "accent": "#111", "background": "#222", "text": "#fff", "gradient": ""}}'
+        return None
+
+    dummy = types.SimpleNamespace(add_head_html=lambda html: captured.setdefault("html", html), run_javascript=run_js)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.apply_global_styles()
+    assert "custom" in styles.THEMES
+
+
+def test_save_custom_theme_persists(monkeypatch):
+    calls = {}
+
+    def run_js(script):
+        calls.setdefault("script", []).append(script)
+
+    dummy = types.SimpleNamespace(add_head_html=lambda *_args, **_kw: None, run_javascript=run_js)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.save_custom_theme(
+        "my",
+        {
+            "primary": "#000",
+            "accent": "#111",
+            "background": "#222",
+            "text": "#fff",
+            "gradient": "",
+        },
+    )
+    assert any("customThemes" in s for s in calls.get("script", []))
+    assert "my" in styles.THEMES


### PR DESCRIPTION
## Summary
- extend styling utils to manage custom themes
- allow saving personalized palettes on the profile page
- test saving and loading of custom themes

## Testing
- `pytest transcendental_resonance_frontend/tests/test_styles.py -q`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888420a52448320a791e18ed5f6b88a