### PR TITLE
Add trending page

### DIFF
--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "ai_assist_page",
     "upload_page",
     "music_page",
+    "trending_page",
     "status_page",
     "network_page",
     "system_insights_page",

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -1,11 +1,21 @@
 """User profile view and editing."""
 
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 from nicegui import ui
-from utils.api import (TOKEN, api_call, clear_token, get_followers,
-                       get_following, get_user, toggle_follow)
+from utils.api import (
+    TOKEN,
+    api_call,
+    clear_token,
+    get_followers,
+    get_following,
+    get_user,
+    toggle_follow,
+)
 from utils.layout import page_container
-from utils.styles import (THEMES, get_theme, get_theme_name, set_accent,
-                          set_theme)
+from utils.styles import THEMES, get_theme, get_theme_name, set_accent, set_theme
 
 from .events_page import events_page
 from .groups_page import groups_page
@@ -14,6 +24,7 @@ from .messages_page import messages_page
 from .notifications_page import notifications_page
 from .proposals_page import proposals_page
 from .vibenodes_page import vibenodes_page
+from .trending_page import trending_page
 
 
 @ui.page("/profile")
@@ -98,6 +109,9 @@ async def profile_page(username: str | None = None):
             )
 
         ui.button("VibeNodes", on_click=lambda: ui.open(vibenodes_page)).classes(
+            "w-full mb-2"
+        ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
+        ui.button("Trending", on_click=lambda: ui.open(trending_page)).classes(
             "w-full mb-2"
         ).style(f'background: {THEME["accent"]}; color: {THEME["background"]};')
         ui.button("Groups", on_click=lambda: ui.open(groups_page)).classes(

--- a/transcendental_resonance_frontend/src/pages/trending_page.py
+++ b/transcendental_resonance_frontend/src/pages/trending_page.py
@@ -1,0 +1,72 @@
+"""Trending VibeNodes feed."""
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from nicegui import ui
+
+from utils.api import api_call, TOKEN
+from utils.styles import get_theme
+from utils.layout import page_container
+from .login_page import login_page
+
+
+@ui.page("/trending")
+async def trending_page():
+    """Display trending VibeNodes."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with page_container(THEME):
+        ui.label("Trending").classes("text-2xl font-bold mb-4").style(
+            f'color: {THEME["accent"]};'
+        )
+
+        items = ui.column().classes("w-full")
+
+        async def refresh_trending() -> None:
+            data = await api_call("GET", "/vibenodes/trending") or []
+            items.clear()
+            for vn in data:
+                with items:
+                    with (
+                        ui.card()
+                        .classes("w-full mb-2")
+                        .style("border: 1px solid #333; background: #1e1e1e;")
+                    ):
+                        ui.label(vn["name"]).classes("text-lg")
+                        ui.label(vn["description"]).classes("text-sm")
+                        if vn.get("media_url"):
+                            mtype = vn.get("media_type", "")
+                            if mtype.startswith("image"):
+                                ui.image(vn["media_url"]).classes("w-full")
+                            elif mtype.startswith("video"):
+                                ui.video(vn["media_url"]).classes("w-full")
+                            elif mtype.startswith("audio") or mtype.startswith("music"):
+                                ui.audio(vn["media_url"]).classes("w-full")
+                        ui.label(f"Likes: {vn.get('likes_count', 0)}").classes(
+                            "text-sm"
+                        )
+
+                        async def like_fn(vn_id=vn["id"]):
+                            await api_call("POST", f"/vibenodes/{vn_id}/like")
+                            await refresh_trending()
+
+                        ui.button("Like/Unlike", on_click=like_fn).style(
+                            f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                        )
+
+                        async def remix_fn(vn_id=vn["id"]):
+                            await api_call("POST", f"/vibenodes/{vn_id}/remix")
+                            ui.notify("Remix created!", color="positive")
+                            await refresh_trending()
+
+                        ui.button("Remix", on_click=remix_fn).style(
+                            f'background: {THEME["primary"]}; color: {THEME["text"]};'
+                        )
+
+        await refresh_trending()
+        ui.timer(60, lambda: ui.run_async(refresh_trending()))


### PR DESCRIPTION
## Summary
- create `trending_page` with like/remix actions
- register new page for lazy loading
- insert button for Trending in the profile navigation
- ensure navigation page includes disclaimers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: streamlit; many downstream errors)*

------
https://chatgpt.com/codex/tasks/task_e_68883b6df8c083209967db1263b3ab9b