### PR TITLE
Add navigation bar utility

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -8,11 +8,13 @@ import asyncio
 
 from .utils.api import clear_token, api_call
 from .utils.styles import apply_global_styles, set_theme, get_theme_name, THEMES
+from .utils.navbar import navigation_bar
 from .pages import *  # register all pages
 from .pages.system_insights_page import system_insights_page  # noqa: F401
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
+navigation_bar()
 
 
 def toggle_theme() -> None:

--- a/transcendental_resonance_frontend/src/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/src/pages/ai_assist_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def ai_assist_page(vibenode_id: int):
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('AI Assist').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -7,6 +7,7 @@ from nicegui import ui
 
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from frontend_bridge import ROUTES, dispatch_route
 
 # Minimal example payloads for some routes
@@ -30,6 +31,7 @@ async def debug_panel_page() -> None:
     """Render controls for invoking ``frontend_bridge`` routes."""
     theme = get_theme()
     with page_container(theme):
+        navigation_bar()
         ui.label("Debug Panel").classes("text-2xl font-bold mb-4").style(
             f"color: {theme['accent']};"
         )

--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def events_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Events').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/forks_page.py
+++ b/transcendental_resonance_frontend/src/pages/forks_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def forks_page() -> None:
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Universe Forks').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def groups_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Groups').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/login_page.py
+++ b/transcendental_resonance_frontend/src/pages/login_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 
 from utils.api import api_call, set_token
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 
 @ui.page('/')
@@ -13,6 +14,7 @@ async def login_page():
     with ui.column().classes('w-full max-w-md mx-auto p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):
+        navigation_bar()
         ui.label('Transcendental Resonance').classes(
             'text-3xl font-bold text-center mb-4'
         ).style(f'color: {THEME["accent"]};')
@@ -52,6 +54,7 @@ async def register_page():
     with ui.column().classes('w-full max-w-md mx-auto p-4').style(
         f'background: {THEME["gradient"]}; color: {THEME["text"]};'
     ):
+        navigation_bar()
         ui.label('Register').classes('text-2xl font-bold text-center mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 from .login_page import login_page
 
@@ -17,6 +18,7 @@ async def messages_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label("Messages").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/music_page.py
+++ b/transcendental_resonance_frontend/src/pages/music_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def music_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Music Generator').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/src/pages/network_analysis_page.py
@@ -6,6 +6,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 from .login_page import login_page
 
@@ -19,6 +20,7 @@ async def network_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label("Network Analysis").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 from .login_page import login_page
 
@@ -17,6 +18,7 @@ async def notifications_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label("Notifications").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -4,8 +4,14 @@ from nicegui import ui
 from utils.api import (TOKEN, api_call, clear_token, get_followers,
                        get_following, get_user, toggle_follow)
 from utils.layout import page_container
-from utils.styles import (THEMES, get_theme, get_theme_name, set_accent,
-                          set_theme)
+from utils.styles import (
+    THEMES,
+    get_theme,
+    get_theme_name,
+    set_accent,
+    set_theme,
+)
+from utils.navbar import navigation_bar
 
 from .events_page import events_page
 from .groups_page import groups_page
@@ -46,6 +52,7 @@ async def profile_page(username: str | None = None):
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label(f'Welcome, {user_data["username"]}').classes(
             "text-2xl font-bold mb-4"
         ).style(f'color: {THEME["accent"]};')

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def proposals_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Proposals').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/status_page.py
+++ b/transcendental_resonance_frontend/src/pages/status_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 from utils.api import api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 
 @ui.page("/status")
@@ -11,6 +12,7 @@ async def status_page():
     """Display real-time system metrics."""
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label("System Status").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/src/pages/system_insights_page.py
@@ -4,6 +4,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.navbar import navigation_bar
 
 from .login_page import login_page
 
@@ -17,6 +18,7 @@ async def system_insights_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label("System Insights").classes("text-2xl font-bold mb-4").style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def upload_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Upload Media').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -6,6 +6,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -18,6 +19,7 @@ async def validator_graph_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('Validator Graphs').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.navbar import navigation_bar
 from .login_page import login_page
 
 
@@ -17,6 +18,7 @@ async def vibenodes_page():
 
     THEME = get_theme()
     with page_container(THEME):
+        navigation_bar()
         ui.label('VibeNodes').classes('text-2xl font-bold mb-4').style(
             f'color: {THEME["accent"]};'
         )

--- a/transcendental_resonance_frontend/src/utils/navbar.py
+++ b/transcendental_resonance_frontend/src/utils/navbar.py
@@ -1,0 +1,25 @@
+"""Reusable navigation bar for the Transcendental Resonance UI."""
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from nicegui import ui
+
+from .styles import get_theme
+
+
+def navigation_bar() -> None:
+    """Render the standard navigation bar with themed links."""
+    theme = get_theme()
+    with ui.row().classes('navigation-bar w-full mb-4').style(
+        f"background: {theme['primary']}; color: {theme['text']};"
+    ):
+        ui.link('Profile', '/profile').classes('px-2')
+        ui.link('VibeNodes', '/vibenodes').classes('px-2')
+        ui.link('Groups', '/groups').classes('px-2')
+        ui.link('Events', '/events').classes('px-2')
+        ui.link('Proposals', '/proposals').classes('px-2')
+        ui.link('Messages', '/messages').classes('px-2')
+        ui.link('Status', '/status').classes('px-2')
+        ui.link('Insights', '/system-insights').classes('px-2')
+

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -68,6 +68,8 @@ def apply_global_styles() -> None:
             body {{ font-family: 'Inter', sans-serif; background: {theme['background']}; color: {theme['text']}; }}
             .q-btn:hover {{ border: 1px solid {theme['accent']}; }}
             .futuristic-gradient {{ background: {theme['gradient']}; }}
+            .navigation-bar {{ background: {theme['primary']}; color: {theme['text']}; }}
+            .navigation-bar a {{ color: {theme['text']}; text-decoration: none; padding: 0 0.5rem; }}
         </style>
         """
     )


### PR DESCRIPTION
## Summary
- implement standard `navigation_bar` component
- style navbar according to theme
- include navigation bar in the main module and all page views

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit'; 39 failed, 252 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68883b7cf54c83209a5415cab77d49d7