### PR TITLE
Add calendar filter for events

### DIFF
--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -1,4 +1,9 @@
-"""Event management page."""
+"""Event management page.
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""
 
 from nicegui import ui
 
@@ -22,7 +27,8 @@ async def events_page():
         )
 
         search_query = ui.input('Search').classes('w-full mb-2')
-        sort_select = ui.select(['name', 'date'], value='name').classes('w-full mb-4')
+        sort_select = ui.select(['name', 'date'], value='name').classes('w-full mb-2')
+        date_filter = ui.date().classes('w-full mb-4')
 
         e_name = ui.input('Event Name').classes('w-full mb-2')
         e_desc = ui.textarea('Description').classes('w-full mb-2')
@@ -52,6 +58,8 @@ async def events_page():
 
         events_list = ui.column().classes('w-full')
 
+        date_filter.on('update:model-value', lambda _: ui.run_async(refresh_events()))
+
         async def refresh_events():
             params = {}
             if search_query.value:
@@ -61,6 +69,12 @@ async def events_page():
             events = await api_call('GET', '/events/', params) or []
             if search_query.value:
                 events = [e for e in events if search_query.value.lower() in e['name'].lower()]
+            if date_filter.value:
+                events = [
+                    e
+                    for e in events
+                    if e.get('start_time', '').startswith(str(date_filter.value))
+                ]
             if sort_select.value:
                 if sort_select.value == 'name':
                     events.sort(key=lambda x: x.get('name', ''))

--- a/transcendental_resonance_frontend/tests/test_events_page.py
+++ b/transcendental_resonance_frontend/tests/test_events_page.py
@@ -8,3 +8,4 @@ def test_events_page_has_search_widgets():
     src = inspect.getsource(events_page)
     assert "ui.input('Search'" in src
     assert "ui.select(['name', 'date']" in src
+    assert "ui.date(" in src


### PR DESCRIPTION
## Summary
- enhance Events page with calendar widget
- include legal disclaimers in page source
- filter events when a date is selected
- test for calendar widget presence

## Testing
- `pytest transcendental_resonance_frontend/tests/test_events_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68884208373483209901bd1e7b8caeb2