### PR TITLE
Add trending list on VibeNodes page

### DIFF
--- a/transcendental_resonance_frontend/tests/test_vibenodes_page.py
+++ b/transcendental_resonance_frontend/tests/test_vibenodes_page.py
@@ -7,4 +7,4 @@ def test_vibenodes_page_is_async():
 def test_vibenodes_page_has_search_widgets():
     src = inspect.getsource(vibenodes_page)
     assert "ui.input('Search'" in src
-    assert "ui.select(['name', 'date']" in src
+    assert "ui.select(['name', 'date', 'trending']" in src


### PR DESCRIPTION
## Summary
- extend sort options on VibeNodes page
- fetch trending nodes with `sort=trending&limit=5`
- display trending list with like/remix controls
- refresh trending list along with main list
- update tests for new select options

## Testing
- `flake8 transcendental_resonance_frontend/src/pages/vibenodes_page.py transcendental_resonance_frontend/tests/test_vibenodes_page.py`
- `pytest -q transcendental_resonance_frontend/tests/test_vibenodes_page.py -vv`
- `pytest -q` *(fails: streamlit missing and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68884207327c832086e1e0b3b45d0004