### PR TITLE
Add video chat roadmap

### DIFF
--- a/docs/tasks/video_chat_translation_plan.md
+++ b/docs/tasks/video_chat_translation_plan.md
@@ -1,0 +1,34 @@
+<!--
+STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+-->
+# Video Chat Translation Module Plan
+
+This document sketches a roadmap for integrating real-time communication features with translation and enhanced interactivity.
+
+## Overview
+
+The module aims to provide video chat with live translation, lip-sync overlays, voice cloning, AR effects, transcription, gestural commands, emotion cues, noise suppression, and real-time collaboration tools.
+
+## Components
+
+1. **Integrated Video Chat** – Build or integrate a WebRTC-based system for peer-to-peer or group calls. Screen sharing and recording should be supported.
+2. **Live Translation** – Use a cloud translation API or on-device model to provide subtitles or synthesized audio in the participant's chosen language.
+3. **Lip-Sync Overlay** – Apply a pre-trained model that adjusts mouth movements to match translated speech.
+4. **AI Voice Cloning** – Capture a speaker profile and generate translated audio using their voice via TTS.
+5. **AR Filters** – Allow participants to apply masks, backgrounds, or effects during calls.
+6. **Transcription & Recording** – Store call transcripts and optional video recordings for later review.
+7. **Gestural Commands** – Detect basic hand gestures or facial expressions to trigger mute, unmute, or recording actions.
+8. **Emotion Detection** – Provide visual indicators of sentiment or tone using facial or voice cues.
+9. **AI Noise Suppression** – Filter background noise and enhance vocal clarity.
+10. **Real-Time Co-Working** – Offer collaborative whiteboards, shared notes, or screen annotations with AI summarization of meeting minutes.
+
+## Next Steps
+
+- Evaluate open-source WebRTC libraries and select one for integration.
+- Research translation APIs that provide low latency streaming and investigate model-based alternatives for offline use.
+- Prototype lip-sync and voice cloning using small sample datasets.
+- Add a demo interface that layers AR filters and records the session for later playback.
+- Design REST or websocket endpoints for these features and document them under `docs/routes.md`.
+


### PR DESCRIPTION
## Summary
- outline a video chat and translation module in docs

## Testing
- `pytest -q` *(fails: 40 failed, 261 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688848adaf68832080aaea20ad320456