### PR TITLE
Add scaffolds for new UI features

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -14,12 +14,31 @@ from .pages.system_insights_page import system_insights_page  # noqa: F401
 from .pages.feed_page import feed_page  # noqa: F401
 from .utils.api import api_call, clear_token
 from .utils.loading_overlay import LoadingOverlay
-from .utils.styles import (THEMES, apply_global_styles, get_theme_name,
-                           set_theme)
+from .utils.styles import (
+    THEMES,
+    apply_global_styles,
+    get_theme_name,
+    set_theme,
+    toggle_high_contrast,
+)
+from .utils.features import (
+    notification_drawer,
+    high_contrast_switch,
+    shortcut_help_dialog,
+    theme_personalization_panel,
+    onboarding_overlay,
+)
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
 LoadingOverlay()
+
+drawer = notification_drawer()
+help_dialog = shortcut_help_dialog(["N = new post", "/ = search"])
+onboarding = onboarding_overlay()
+contrast_toggle = high_contrast_switch()
+contrast_toggle.on("change", lambda e: toggle_high_contrast(e.value))
+theme_personalization_panel()
 
 
 def toggle_theme() -> None:

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
+from utils.features import quick_post_button, skeleton_loader, swipeable_glow_card
 
 from .login_page import login_page
 
@@ -24,7 +25,20 @@ async def feed_page() -> None:
 
         feed_column = ui.column().classes('w-full')
 
+        post_dialog = ui.dialog()
+        with post_dialog:
+            with ui.card():
+                ui.label('Compose new Vibe').classes('text-lg font-bold')
+                ui.textarea('What\'s on your mind?').classes('w-full mb-2')
+                ui.button('Post').on('click', post_dialog.close)
+
+        quick_post_button(lambda: post_dialog.open())
+
         async def refresh_feed() -> None:
+            feed_column.clear()
+            with feed_column:
+                skeleton_loader()
+
             vibenodes = await api_call('GET', '/vibenodes/') or []
             events = await api_call('GET', '/events/') or []
             notifs = await api_call('GET', '/notifications/') or []
@@ -32,19 +46,19 @@ async def feed_page() -> None:
             feed_column.clear()
             for vn in vibenodes:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
                         ui.label('VibeNode').classes('text-sm font-bold')
                         ui.label(vn.get('description', '')).classes('text-sm')
                         ui.link('View', f"/vibenodes/{vn['id']}")
             for ev in events:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
                         ui.label('Event').classes('text-sm font-bold')
                         ui.label(ev.get('description', '')).classes('text-sm')
                         ui.link('View', f"/events/{ev['id']}")
             for n in notifs:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
                         ui.label('Notification').classes('text-sm font-bold')
                         ui.label(n.get('message', '')).classes('text-sm')
                         ui.link('View', f"/notifications/{n['id']}")

--- a/transcendental_resonance_frontend/src/utils/__init__.py
+++ b/transcendental_resonance_frontend/src/utils/__init__.py
@@ -1,0 +1,25 @@
+from .features import (
+    quick_post_button,
+    swipeable_glow_card,
+    notification_drawer,
+    high_contrast_switch,
+    shortcut_help_dialog,
+    theme_personalization_panel,
+    onboarding_overlay,
+    profile_popover,
+    mobile_bottom_sheet,
+    skeleton_loader,
+)
+
+__all__ = [
+    "quick_post_button",
+    "swipeable_glow_card",
+    "notification_drawer",
+    "high_contrast_switch",
+    "shortcut_help_dialog",
+    "theme_personalization_panel",
+    "onboarding_overlay",
+    "profile_popover",
+    "mobile_bottom_sheet",
+    "skeleton_loader",
+]

--- a/transcendental_resonance_frontend/src/utils/features.py
+++ b/transcendental_resonance_frontend/src/utils/features.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+"""Scaffolding components for upcoming UI features."""
+
+try:  # pragma: no cover - allow import without NiceGUI installed
+    from nicegui import ui
+    from nicegui.element import Element
+except Exception:  # pragma: no cover - fallback stubs for testing
+    import types
+
+    class Element:  # type: ignore
+        pass
+
+    def _dummy_element() -> Element:
+        return Element()
+
+    class _DummyUI:
+        def button(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def card(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def left_drawer(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def switch(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def dialog(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def color_picker(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def overlay(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def tooltip(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def bottom_sheet(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+        def skeleton(self, *args, **kwargs) -> Element:
+            return _dummy_element()
+
+    ui = _DummyUI()  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Basic scaffolding functions
+# ---------------------------------------------------------------------------
+
+def quick_post_button(on_click) -> Element:
+    """Floating action button opening the post dialog."""
+    return ui.button(icon="add", on_click=on_click).props(
+        "fab fixed bottom right bg-primary text-white"
+    )
+
+
+def swipeable_glow_card() -> Element:
+    """Card placeholder with swipe handling and neon glow class."""
+    card = ui.card().classes("glow-card")
+    card.on("swipe", lambda _: None)
+    return card
+
+
+def notification_drawer() -> Element:
+    """Sliding drawer for real-time notifications."""
+    return ui.left_drawer().props("overlay")
+
+
+def high_contrast_switch() -> Element:
+    """Toggle switch for high contrast mode."""
+    return ui.switch("High Contrast")
+
+
+def shortcut_help_dialog(shortcuts: list[str] | None = None) -> Element:
+    """Dialog listing keyboard shortcuts."""
+    dlg = ui.dialog()
+    with dlg:
+        with ui.card():
+            ui.label("Keyboard Shortcuts").classes("text-lg font-bold")
+            if shortcuts:
+                for s in shortcuts:
+                    ui.label(s).classes("text-sm")
+    return dlg
+
+
+def theme_personalization_panel() -> Element:
+    """Simple color picker for theme personalization."""
+    return ui.color_picker()
+
+
+def onboarding_overlay() -> Element:
+    """Transient overlay shown on first login."""
+    return ui.overlay("Welcome!").props("transition-fade").close_on_click(True)
+
+
+def profile_popover() -> Element:
+    """Popover stub showing quick profile info."""
+    return ui.tooltip("profile")
+
+
+def mobile_bottom_sheet() -> Element:
+    """Bottom sheet for mobile actions."""
+    return ui.bottom_sheet()
+
+
+def skeleton_loader() -> Element:
+    """Animated skeleton loader placeholder."""
+    return ui.skeleton().classes("animate-pulse")
+
+
+__all__ = [
+    "quick_post_button",
+    "swipeable_glow_card",
+    "notification_drawer",
+    "high_contrast_switch",
+    "shortcut_help_dialog",
+    "theme_personalization_panel",
+    "onboarding_overlay",
+    "profile_popover",
+    "mobile_bottom_sheet",
+    "skeleton_loader",
+]

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -34,6 +34,13 @@ THEMES: Dict[str, Dict[str, str]] = {
         "text": "#F8F8F2",
         "gradient": "linear-gradient(135deg, #FF0080 0%, #00F0FF 100%)",
     },
+    "high_contrast": {
+        "primary": "#000000",
+        "accent": "#FFFF00",
+        "background": "#000000",
+        "text": "#FFFFFF",
+        "gradient": "linear-gradient(135deg, #000000 0%, #222222 100%)",
+    },
 }
 
 # Currently active theme name and accent color. They can be changed at runtime
@@ -83,6 +90,7 @@ def apply_global_styles() -> None:
             body {{ font-family: {font_family}; background: {theme['background']}; color: {theme['text']}; }}
             .q-btn:hover {{ border: 1px solid {theme['accent']}; }}
             .futuristic-gradient {{ background: {theme['gradient']}; }}
+            .glow-card {{ border: 1px solid {theme["accent"]}; box-shadow: 0 0 6px {theme["accent"]}; }}
         </style>
         """
     )
@@ -118,3 +126,14 @@ def set_accent(color: str) -> None:
     ui.run_javascript(f"localStorage.setItem('accent', '{color}')")
     apply_global_styles()
 
+
+_previous_theme = ACTIVE_THEME_NAME
+
+def toggle_high_contrast(enabled: bool) -> None:
+    """Enable or disable high contrast mode."""
+    global _previous_theme
+    if enabled:
+        _previous_theme = ACTIVE_THEME_NAME
+        set_theme("high_contrast")
+    else:
+        set_theme(_previous_theme)

--- a/transcendental_resonance_frontend/tests/test_features.py
+++ b/transcendental_resonance_frontend/tests/test_features.py
@@ -1,0 +1,18 @@
+import inspect
+from utils.features import (
+    quick_post_button,
+    high_contrast_switch,
+    skeleton_loader,
+)
+
+
+def test_quick_post_button_callable():
+    assert callable(quick_post_button)
+
+
+def test_high_contrast_switch_callable():
+    assert callable(high_contrast_switch)
+
+
+def test_skeleton_loader_callable():
+    assert callable(skeleton_loader)

--- a/transcendental_resonance_frontend/tests/test_styles.py
+++ b/transcendental_resonance_frontend/tests/test_styles.py
@@ -32,3 +32,20 @@ def test_set_accent_overrides_default(monkeypatch):
     styles.set_theme("dark")
     styles.set_accent("#123456")
     assert styles.get_theme()["accent"] == "#123456"
+
+def test_toggle_high_contrast(monkeypatch):
+    dummy = dummy_ui({})
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.set_theme("dark")
+    styles.toggle_high_contrast(True)
+    assert styles.get_theme_name() == "high_contrast"
+    styles.toggle_high_contrast(False)
+    assert styles.get_theme_name() == "dark"
+
+
+def test_glow_card_css(monkeypatch):
+    captured = {}
+    dummy = dummy_ui(captured)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.apply_global_styles()
+    assert ".glow-card" in captured["html"]


### PR DESCRIPTION
## Summary
- scaffold upcoming UI components in `features.py`
- export scaffolds via utils package
- implement floating FAB, neon cards and skeleton loaders in feed page
- extend theme support with high contrast mode and glow CSS
- hook new components into the main app
- add unit tests for new features and styling helpers

## Testing
- `pytest transcendental_resonance_frontend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688848d71c988320bd9c83439c31d55d