### PR TITLE
Enhance social UI for media chat

### DIFF
--- a/transcendental_resonance_frontend/src/components/__init__.py
+++ b/transcendental_resonance_frontend/src/components/__init__.py
@@ -1,0 +1,3 @@
+from .emoji_toolbar import emoji_toolbar
+from .media_renderer import render_media_block
+from .common import standard_card, loading_skeleton, video_preview

--- a/transcendental_resonance_frontend/src/components/common.py
+++ b/transcendental_resonance_frontend/src/components/common.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from nicegui import ui
+from nicegui.element import Element
+
+
+@contextmanager
+def standard_card() -> Iterator[Element]:
+    """Reusable styled card container."""
+    with ui.card().classes('w-full mb-2').style(
+        'border: 1px solid #333; background: #1e1e1e;'
+    ) as card:
+        yield card
+
+
+def loading_skeleton(height: str = '4rem') -> Element:
+    """Display a skeleton placeholder block."""
+    return ui.skeleton().classes('w-full mb-2').style(f'height: {height};')
+
+
+def video_preview(url: str) -> Element:
+    """Render a video preview with graceful fallback."""
+    try:
+        return ui.video(url).props('controls').classes('w-full')
+    except Exception:
+        return ui.icon('videocam_off').classes('text-negative')

--- a/transcendental_resonance_frontend/src/components/emoji_toolbar.py
+++ b/transcendental_resonance_frontend/src/components/emoji_toolbar.py
@@ -1,12 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
 from nicegui import ui
-from typing import Any
 
 
 def emoji_toolbar(input_ref: Any) -> None:
-    """Add simple emoji buttons that append to the given textarea."""
-    with ui.row().classes("mb-2"):
-        for emoji in ["😀", "🔥", "🎉"]:
+    """Display emoji buttons with category selection."""
+    categories: Dict[str, List[str]] = {
+        "emotion": ["😀", "😂", "😢", "😎"],
+        "gesture": ["👍", "👎", "🙏", "👏"],
+        "hearts": ["❤️", "💜", "💖", "💙"],
+    }
+    selector = ui.select(list(categories.keys()), value="emotion").props(
+        "dense outlined"
+    ).classes("w-28 mb-1")
+    button_row = ui.row().classes("mb-2")
+
+    def populate(_: Any = None) -> None:
+        button_row.clear()
+        for emoji in categories[selector.value]:
             ui.button(
                 emoji,
-                on_click=lambda _=None, e=emoji: input_ref.set_value((input_ref.value or "") + e),
-            ).props("flat")
+                on_click=lambda _=None, e=emoji: input_ref.set_value(
+                    (input_ref.value or "") + e
+                ),
+            ).props("flat").classes("min-w-min")
+
+    selector.on("update:model-value", populate)
+    populate()

--- a/transcendental_resonance_frontend/src/components/media_renderer.py
+++ b/transcendental_resonance_frontend/src/components/media_renderer.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from nicegui import ui
+
+from .common import video_preview
 
 
 def render_media_block(url: str | None, mtype: str | None) -> None:
@@ -11,7 +15,7 @@ def render_media_block(url: str | None, mtype: str | None) -> None:
         ui.image(url).classes("w-full")
     elif mtype.startswith("video"):
         ui.label("\U0001F3A5").classes("text-lg")
-        ui.video(url).classes("w-full")
+        video_preview(url)
     elif mtype.startswith("audio") or mtype.startswith("music"):
         ui.label("\U0001F3A4").classes("text-lg")
         ui.audio(url).classes("w-full")

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -5,6 +5,8 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
+from components import emoji_toolbar, render_media_block
+from components.common import standard_card, loading_skeleton
 
 from .login_page import login_page
 
@@ -24,9 +26,38 @@ async def feed_page() -> None:
             f'color: {theme["accent"]};'
         )
 
+        with ui.card().classes('w-full mb-4').style(
+            'border: 1px solid #333; background: #1e1e1e;'
+        ):
+            post_type = ui.select(['text', 'image', 'video'], value='text').props(
+                'dense'
+            ).classes('w-24 mb-2')
+            post_input = ui.textarea('Share something...').classes('w-full mb-2')
+            emoji_toolbar(post_input)
+            preview = ui.markdown().classes('w-full mb-2')
+            post_input.on('input', lambda e: preview.set_content(post_input.value))
+
+            async def publish_post() -> None:
+                data = {'type': post_type.value, 'content': post_input.value}
+                resp = await api_call('POST', '/posts/', data, return_error=True)
+                if resp and not resp.get('error'):
+                    ui.notify('Posted!', color='positive')
+                    post_input.value = ''
+                    await refresh_feed()
+                else:
+                    ui.notify('Failed to post', color='negative')
+
+            ui.button('Publish', on_click=lambda: ui.run_async(publish_post())).style(
+                f'background: {theme["primary"]}; color: {theme["text"]};'
+            ).classes('w-full')
+
         feed_column = ui.column().classes('w-full')
 
         async def refresh_feed() -> None:
+            feed_column.clear()
+            for _ in range(3):
+                loading_skeleton()
+
             vibenodes = await api_call('GET', '/vibenodes/') or []
             events = await api_call('GET', '/events/') or []
             notifs = await api_call('GET', '/notifications/') or []
@@ -34,19 +65,23 @@ async def feed_page() -> None:
             feed_column.clear()
             for vn in vibenodes:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with standard_card():
                         ui.label('VibeNode').classes('text-sm font-bold')
                         ui.label(vn.get('description', '')).classes('text-sm')
+                        if vn.get('media_url'):
+                            render_media_block(vn['media_url'], vn.get('media_type', ''))
                         ui.link('View', f"/vibenodes/{vn['id']}")
             for ev in events:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with standard_card():
                         ui.label('Event').classes('text-sm font-bold')
                         ui.label(ev.get('description', '')).classes('text-sm')
+                        if ev.get('media_url'):
+                            render_media_block(ev['media_url'], ev.get('media_type', ''))
                         ui.link('View', f"/events/{ev['id']}")
             for n in notifs:
                 with feed_column:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with standard_card():
                         ui.label('Notification').classes('text-sm font-bold')
                         ui.label(n.get('message', '')).classes('text-sm')
                         ui.link('View', f"/notifications/{n['id']}")


### PR DESCRIPTION
## Summary
- modularize UI cards and skeleton placeholders
- extend emoji toolbar with categories
- support embedded video and posting workflow in `feed_page`
- prepare messaging page for video chat drawer and clip attachments
- add graceful async error handling

## Testing
- `pytest transcendental_resonance_frontend/tests/test_feed_page.py transcendental_resonance_frontend/tests/test_messages_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68884b0c9d8083209bd87919e137c836