### PR TITLE
Add modular social UI with media features

### DIFF
--- a/transcendental_resonance_frontend/src/components/__init__.py
+++ b/transcendental_resonance_frontend/src/components/__init__.py
@@ -1,0 +1,11 @@
+from .emoji_toolbar import emoji_toolbar
+from .media_renderer import render_media_block
+from .social_ui import create_post_composer, video_chat_scaffold, message_composer
+
+__all__ = [
+    'emoji_toolbar',
+    'render_media_block',
+    'create_post_composer',
+    'video_chat_scaffold',
+    'message_composer',
+]

--- a/transcendental_resonance_frontend/src/components/emoji_toolbar.py
+++ b/transcendental_resonance_frontend/src/components/emoji_toolbar.py
@@ -1,12 +1,26 @@
 from nicegui import ui
 from typing import Any
 
+CATEGORIES = {
+    "emotion": ["😀", "😂", "😊", "😭"],
+    "gesture": ["👍", "🤘", "🙏", "👏"],
+    "hearts": ["❤️", "💜", "💙", "💚"],
+}
+
 
 def emoji_toolbar(input_ref: Any) -> None:
-    """Add simple emoji buttons that append to the given textarea."""
-    with ui.row().classes("mb-2"):
-        for emoji in ["😀", "🔥", "🎉"]:
-            ui.button(
-                emoji,
-                on_click=lambda _=None, e=emoji: input_ref.set_value((input_ref.value or "") + e),
-            ).props("flat")
+    """Add emoji buttons with simple category tabs."""
+    tabs = ui.tabs(list(CATEGORIES.keys()), value="emotion").classes("mb-1")
+    container = ui.row().classes("mb-2")
+
+    def populate(category: str) -> None:
+        container.clear()
+        with container:
+            for emoji in CATEGORIES[category]:
+                ui.button(
+                    emoji,
+                    on_click=lambda _=None, e=emoji: input_ref.set_value((input_ref.value or "") + e),
+                ).props("flat", "dense")
+
+    tabs.on("update:model-value", lambda e: populate(e.value))
+    populate("emotion")

--- a/transcendental_resonance_frontend/src/components/media_renderer.py
+++ b/transcendental_resonance_frontend/src/components/media_renderer.py
@@ -11,7 +11,14 @@ def render_media_block(url: str | None, mtype: str | None) -> None:
         ui.image(url).classes("w-full")
     elif mtype.startswith("video"):
         ui.label("\U0001F3A5").classes("text-lg")
-        ui.video(url).classes("w-full")
+        player = ui.video(url).classes("w-full").props("controls")
+        player.on(
+            "error",
+            lambda _: (
+                player.set_visibility(False),
+                ui.icon("videocam_off").classes("text-3xl")
+            ),
+        )
     elif mtype.startswith("audio") or mtype.startswith("music"):
         ui.label("\U0001F3A4").classes("text-lg")
         ui.audio(url).classes("w-full")

--- a/transcendental_resonance_frontend/src/components/social_ui.py
+++ b/transcendental_resonance_frontend/src/components/social_ui.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Callable, Awaitable, Tuple
+from nicegui import ui
+
+from .emoji_toolbar import emoji_toolbar
+from utils.safe_markdown import safe_markdown
+
+
+def create_post_composer(theme: dict) -> Tuple[ui.select, ui.textarea]:
+    """Simple composer for feed posts with markdown preview."""
+
+    with ui.card().classes('w-full mb-2').style('background:#1e1e1e;border:1px solid #333;'):
+        post_type = ui.select(['text', 'image', 'video'], value='text').classes('mb-2')
+        content = ui.textarea('Share something...').classes('w-full mb-2')
+        preview = ui.markdown().classes('w-full mb-2')
+        content.on('update:model-value', lambda e: preview.set_content(safe_markdown(e.value)))
+        ui.button('Post', on_click=lambda: ui.notify('Posting coming soon'),
+                  ).classes('w-full').style(f'background:{theme["primary"]};color:{theme["text"]};')
+    return post_type, content
+
+
+def video_chat_scaffold(theme: dict):
+    """Return a dialog placeholder for live video chat."""
+    dialog = ui.dialog()
+    with dialog:
+        with ui.card().classes('w-80 p-2'):
+            ui.label('Live Video Chat').classes('text-lg mb-2').style(f'color:{theme["accent"]};')
+            ui.label('Coming soon...').classes('text-sm')
+            ui.button('Close', on_click=dialog.close).classes('mt-2').props('flat')
+    return dialog
+
+
+def message_composer(theme: dict, on_send: Callable[[str], Awaitable[None]]):
+    """Message input area with emoji toolbar and send button."""
+    content = ui.textarea('Message').classes('w-full mb-2')
+    emoji_toolbar(content)
+    ui.button('Attach Clip', on_click=lambda: ui.notify('Attach clip coming soon')).props('outline').classes('mb-2')
+
+    async def _send() -> None:
+        try:
+            await on_send(content.value)
+            content.value = ''
+        except Exception:
+            ui.notify('Failed to send message', color='negative')
+
+    ui.button('Send', on_click=lambda: ui.run_async(_send())).classes('w-full').style(
+        f'background:{theme["primary"]};color:{theme["text"]};')
+    return content

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -5,6 +5,8 @@ from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
+from components.media_renderer import render_media_block
+from components.social_ui import create_post_composer
 
 from .login_page import login_page
 
@@ -24,25 +26,36 @@ async def feed_page() -> None:
             f'color: {theme["accent"]};'
         )
 
+        post_type, post_content = create_post_composer(theme)
+        ui.separator().classes('my-2')
+
         feed_column = ui.column().classes('w-full')
+        loading_column = ui.column().classes('w-full')
 
         async def refresh_feed() -> None:
+            for _ in range(3):
+                with loading_column:
+                    ui.skeleton().classes('w-full h-20 mb-2').props('animation="wave"')
+
             vibenodes = await api_call('GET', '/vibenodes/') or []
             events = await api_call('GET', '/events/') or []
             notifs = await api_call('GET', '/notifications/') or []
 
             feed_column.clear()
+            loading_column.clear()
             for vn in vibenodes:
                 with feed_column:
                     with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
                         ui.label('VibeNode').classes('text-sm font-bold')
                         ui.label(vn.get('description', '')).classes('text-sm')
+                        render_media_block(vn.get('media_url'), vn.get('media_type'))
                         ui.link('View', f"/vibenodes/{vn['id']}")
             for ev in events:
                 with feed_column:
                     with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
                         ui.label('Event').classes('text-sm font-bold')
                         ui.label(ev.get('description', '')).classes('text-sm')
+                        render_media_block(ev.get('media_url'), ev.get('media_type'))
                         ui.link('View', f"/events/{ev['id']}")
             for n in notifs:
                 with feed_column:

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -7,6 +7,7 @@ from nicegui import ui
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container, navigation_bar
 from components.emoji_toolbar import emoji_toolbar
+from components.social_ui import video_chat_scaffold
 from utils.safe_markdown import safe_markdown
 from utils.styles import get_theme
 
@@ -34,6 +35,17 @@ async def messages_page():
             group_id.on("blur", lambda _: ui.run_async(refresh_messages()))
         content = ui.textarea("Message").classes("w-full mb-2")
         emoji_toolbar(content)
+        ui.button(
+            "Attach Clip",
+            on_click=lambda: ui.notify("Recording feature coming soon"),
+        ).props("outline").classes("mb-2")
+        video_drawer = video_chat_scaffold(THEME)
+        ui.button(
+            "Video Chat",
+            on_click=video_drawer.open,
+        ).classes("mb-2").style(
+            f'background: {THEME["accent"]}; color: {THEME["background"]};'
+        )
 
         async def send_message():
             data = {"content": content.value}
@@ -41,7 +53,11 @@ async def messages_page():
                 endpoint = f"/groups/{group_id.value}/messages"
             else:
                 endpoint = f"/messages/{recipient.value}"
-            resp = await api_call("POST", endpoint, data)
+            try:
+                resp = await api_call("POST", endpoint, data)
+            except Exception:
+                ui.notify("Failed to send", color="negative")
+                return
             if resp:
                 ui.notify("Message sent!", color="positive")
                 await refresh_messages()


### PR DESCRIPTION
## Summary
- modularize emoji toolbar and media rendering for reuse
- add post composer with markdown preview on feed page
- introduce skeleton loading states and basic video previews
- expand emoji toolbar with categories and add placeholder hooks for clips and video chat
- create common social UI helpers

## Testing
- `pytest transcendental_resonance_frontend/tests/test_feed_page.py -q`
- `pytest -q` *(fails: AttributeError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68884b0c9d8083209bd87919e137c836