### PR TITLE
Add video chat frontend and backend

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2469,7 +2469,10 @@ def get_music_generator(
     return MusicGeneratorService(db, user)
 
 from login_router import router as login_router
+from video_chat_router import router as video_chat_router
+
 app.include_router(login_router)
+app.include_router(video_chat_router)
 
 
 # Endpoints (Full implementation from FastAPI files, enhanced)

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "forks_page",
     "validator_graph_page",
     "debug_panel_page",
+    "video_chat_page",
 ]
 
 

--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -1,0 +1,49 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Experimental video chat page."""
+
+from __future__ import annotations
+
+import json
+from nicegui import ui
+
+from utils.api import TOKEN, connect_ws, listen_ws, WS_CONNECTION
+from utils.layout import page_container, navigation_bar
+from utils.styles import get_theme
+from .login_page import login_page
+
+
+@ui.page("/video-chat")
+async def video_chat_page() -> None:
+    """Simple camera demo with WebSocket signaling."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with page_container(THEME):
+        if TOKEN:
+            navigation_bar()
+        ui.label("Video Chat").classes("text-2xl font-bold mb-4").style(
+            f'color: {THEME["accent"]};'
+        )
+
+        local_cam = ui.camera().classes("w-full mb-4")
+        remote_view = ui.video().props("autoplay playsinline").classes("w-full mb-4")
+
+        async def handle_event(event: dict) -> None:
+            if event.get("type") == "frame":
+                remote_view.source = event.get("data")
+
+        async def join_call() -> None:
+            await listen_ws(handle_event)
+
+        async def send_frame() -> None:
+            if WS_CONNECTION and local_cam.value:
+                await WS_CONNECTION.send_text(
+                    json.dumps({"type": "frame", "data": local_cam.value})
+                )
+
+        local_cam.on("capture", lambda _: ui.run_async(send_frame()))
+        ui.button("Join Call", on_click=lambda: ui.run_async(join_call()))

--- a/video_chat_router.py
+++ b/video_chat_router.py
@@ -1,0 +1,49 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""WebSocket endpoints for experimental video chat."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from typing import List
+
+router = APIRouter()
+
+
+class ConnectionManager:
+    """Track active video chat websocket connections."""
+
+    def __init__(self) -> None:
+        self.active: List[WebSocket] = []
+
+    async def connect(self, ws: WebSocket) -> None:
+        await ws.accept()
+        self.active.append(ws)
+
+    def disconnect(self, ws: WebSocket) -> None:
+        if ws in self.active:
+            self.active.remove(ws)
+
+    async def broadcast(self, message: str, sender: WebSocket) -> None:
+        for conn in list(self.active):
+            if conn is not sender:
+                try:
+                    await conn.send_text(message)
+                except Exception:
+                    self.disconnect(conn)
+
+
+manager = ConnectionManager()
+
+
+@router.websocket("/ws/video")
+async def video_ws(websocket: WebSocket) -> None:
+    """Relay video chat signaling messages between participants."""
+    await manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.broadcast(data, sender=websocket)
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)


### PR DESCRIPTION
## Summary
- add `video_chat_page` to the NiceGUI frontend
- expose `/ws/video` websocket endpoint via new router
- register the new page for routing
- include the new router in the FastAPI app

## Testing
- `pip install -r requirements-minimal.txt -r requirements-dev.txt`
- `pytest -q` *(fails: 40 failed, 266 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68884dd60b5483209c1929f860afb60b