### PR TITLE
Add loading skeletons to feed pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -11,6 +11,7 @@ from utils.api import api_call, TOKEN, BACKEND_URL
 import httpx
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
+from utils.features import skeleton_loader
 from .login_page import login_page
 
 
@@ -69,6 +70,10 @@ async def events_page():
                 params['search'] = search_query.value
             if sort_select.value:
                 params['sort'] = sort_select.value
+            events_list.clear()
+            with events_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-20 mb-2')
             events = await api_call('GET', '/events/', params) or []
             if search_query.value:
                 events = [e for e in events if search_query.value.lower() in e['name'].lower()]

--- a/transcendental_resonance_frontend/src/pages/explore_page.py
+++ b/transcendental_resonance_frontend/src/pages/explore_page.py
@@ -5,6 +5,7 @@
 from nicegui import ui
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
+from utils.features import skeleton_loader
 from components.media_renderer import render_media_block
 from utils.styles import get_theme
 
@@ -35,7 +36,13 @@ async def explore_page() -> None:
         async def load_more() -> None:
             nonlocal offset
             params = {"offset": offset, "limit": limit}
+            placeholders = []
+            with posts_container:
+                for _ in range(limit):
+                    placeholders.append(skeleton_loader().classes("w-full h-32 mb-2"))
             posts = await api_call("GET", "/vibenodes/trending", params) or []
+            for p in placeholders:
+                p.delete()
             if not posts:
                 return
             offset += len(posts)

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN, get_group_recommendations
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
+from utils.features import skeleton_loader
 from .login_page import login_page
 
 
@@ -48,6 +49,10 @@ async def groups_page():
                 params['search'] = search_query.value
             if sort_select.value:
                 params['sort'] = sort_select.value
+            groups_list.clear()
+            with groups_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-20 mb-2')
             groups = await api_call('GET', '/groups/', params) or []
             if search_query.value:
                 groups = [g for g in groups if search_query.value.lower() in g['name'].lower()]

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
+from utils.features import skeleton_loader
 from .login_page import login_page
 
 
@@ -45,6 +46,10 @@ async def proposals_page():
         proposals_list = ui.column().classes('w-full')
 
         async def refresh_proposals():
+            proposals_list.clear()
+            with proposals_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-20 mb-2')
             proposals = await api_call('GET', '/proposals/') or []
             proposals_list.clear()
             for p in proposals:

--- a/transcendental_resonance_frontend/src/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/src/pages/recommendations_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
+from utils.features import skeleton_loader
 from .login_page import login_page
 
 
@@ -26,6 +27,10 @@ async def recommendations_page():
         rec_list = ui.column().classes('w-full')
 
         async def refresh_recs() -> None:
+            rec_list.clear()
+            with rec_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-20 mb-2')
             recs = await api_call('GET', '/recommendations') or []
             rec_list.clear()
             for rec in recs:

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -6,6 +6,7 @@ import asyncio
 from utils.api import api_call, TOKEN, listen_ws
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
+from utils.features import skeleton_loader
 from components.media_renderer import render_media_block
 from components.emoji_toolbar import emoji_toolbar
 from utils.safe_markdown import safe_markdown
@@ -93,6 +94,10 @@ async def vibenodes_page():
 
         async def refresh_trending():
             params = {'sort': 'trending', 'limit': 5}
+            trending_list.clear()
+            with trending_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-20 mb-2')
             trending = await api_call('GET', '/vibenodes/', params) or []
             trending_list.clear()
             for vn in trending:
@@ -135,6 +140,10 @@ async def vibenodes_page():
                 params['search'] = search_query.value
             if sort_select.value:
                 params['sort'] = sort_select.value
+            vibenodes_list.clear()
+            with vibenodes_list:
+                for _ in range(3):
+                    skeleton_loader().classes('w-full h-32 mb-2')
             vibenodes = await api_call('GET', '/vibenodes/', params) or []
             if search_query.value:
                 vibenodes = [vn for vn in vibenodes if search_query.value.lower() in vn['name'].lower()]


### PR DESCRIPTION
## Summary
- improve vibenodes and explore pages with loading skeletons
- show skeletons while fetching events, groups, proposals and recommendations

## Testing
- `pytest -q` *(fails: AttributeError: 'Session' object has no attribute 'merge', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68884dd635d08320ac67d4499ecbe49d