### PR TITLE
Add video chat overlay stubs

### DIFF
--- a/realtime_comm/__init__.py
+++ b/realtime_comm/__init__.py
@@ -3,4 +3,4 @@
 # Legal & Ethical Safeguards
 """Utilities for experimental real-time communication modules."""
 
-from .video_chat import VideoChatManager  # noqa: F401
+from .video_chat import FrameMetadata, VideoChatManager  # noqa: F401

--- a/realtime_comm/video_chat.py
+++ b/realtime_comm/video_chat.py
@@ -11,8 +11,8 @@ translation, transcription, and AR capabilities.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
 
 
 @dataclass
@@ -21,6 +21,17 @@ class VideoStream:
 
     user_id: str
     track_id: str
+    translation_overlay: str = ""
+    face_box: Optional[tuple[int, int, int, int]] = None
+
+
+@dataclass
+class FrameMetadata:
+    """Lightweight metadata extracted from a video frame."""
+
+    emotion: str = ""
+    lang: str = ""
+    extra: Dict[str, str] = field(default_factory=dict)
 
 
 class VideoChatManager:
@@ -59,3 +70,24 @@ class VideoChatManager:
         """Enable live translation for ``user_id`` to ``target_lang``."""
         # TODO: integrate a translation API and TTS voice cloning
         pass
+
+    def update_translation_overlay(self, user_id: str, text: str, lang: str) -> None:
+        """Overlay ``text`` in ``lang`` on ``user_id``'s stream."""
+        stream = next((s for s in self.active_streams if s.user_id == user_id), None)
+        if stream:
+            stream.translation_overlay = text
+        # TODO: render text on video frame in real time
+
+    def track_face(self, user_id: str, frame: bytes) -> None:
+        """Stub facial landmark tracking for ``user_id``."""
+        stream = next((s for s in self.active_streams if s.user_id == user_id), None)
+        if stream:
+            # Placeholder bounding box; actual detection should update this
+            stream.face_box = (0, 0, 0, 0)
+        # TODO: integrate a face tracking library
+
+    def analyze_frame(self, user_id: str, frame: bytes) -> FrameMetadata:
+        """Return live metadata derived from ``frame``."""
+        self.track_face(user_id, frame)
+        # TODO: run emotion recognition and language detection
+        return FrameMetadata(emotion="neutral", lang="en")

--- a/tests/test_video_metadata.py
+++ b/tests/test_video_metadata.py
@@ -1,0 +1,14 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from realtime_comm.video_chat import FrameMetadata, VideoChatManager
+
+
+def test_analyze_frame_stub():
+    manager = VideoChatManager()
+    manager.start_call(["alice"])
+    meta = manager.analyze_frame("alice", b"frame")
+    assert isinstance(meta, FrameMetadata)
+    assert meta.emotion == "neutral"
+    assert meta.lang == "en"


### PR DESCRIPTION
## Summary
- extend `VideoStream` with overlay and face tracking placeholders
- provide `FrameMetadata` dataclass and analysis stubs
- export `FrameMetadata` in realtime_comm package
- test new metadata stub

## Testing
- `pytest -q tests/test_video_metadata.py`
- `pytest -q` *(fails: sqlalchemy.exc.* and others)*

------
https://chatgpt.com/codex/tasks/task_e_68884e8dab9c8320bbbf36c3a6e8b9b5