### PR TITLE
Improve NiceGUI frontend resiliency

### DIFF
--- a/transcendental_resonance_frontend/src/utils/__init__.py
+++ b/transcendental_resonance_frontend/src/utils/__init__.py
@@ -10,6 +10,7 @@ from .features import (
     mobile_bottom_sheet,
     skeleton_loader,
 )
+from .error_overlay import ErrorOverlay
 
 __all__ = [
     "quick_post_button",
@@ -22,4 +23,5 @@ __all__ = [
     "profile_popover",
     "mobile_bottom_sheet",
     "skeleton_loader",
+    "ErrorOverlay",
 ]

--- a/transcendental_resonance_frontend/src/utils/error_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/error_overlay.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Simple overlay component to surface fatal errors."""
+
+from nicegui import ui
+
+
+class ErrorOverlay:
+    """Display an overlay with an error message."""
+
+    def __init__(self) -> None:
+        self._dialog = ui.dialog().props("persistent")
+        with self._dialog:
+            with ui.card():
+                self._label = ui.label("Error")
+                ui.button("Close", on_click=self.hide)
+
+    def show(self, message: str) -> None:
+        self._label.text = message
+        if not self._dialog.open:
+            self._dialog.open()
+
+    def hide(self) -> None:
+        if self._dialog.open:
+            self._dialog.close()
+
+
+__all__ = ["ErrorOverlay"]


### PR DESCRIPTION
## Summary
- add WebSocket status indicator and error overlay
- reconnect and timeout handling in utils.api
- show skeletons and fallback text in feed page
- catch-all page route and retry `ui.run()` on failure
- expose new `ErrorOverlay` utility

## Testing
- `pytest -q transcendental_resonance_frontend/tests/test_feed_page.py transcendental_resonance_frontend/tests/test_api.py`
- `pytest -q transcendental_resonance_frontend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68884eb439bc8320bb15e59858aa9e01