### PR TITLE
Add quantum futures simulation in feed

### DIFF
--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -1,4 +1,9 @@
-"""Unified feed combining VibeNodes, Events, and Notifications."""
+"""Unified feed combining VibeNodes, Events, and Notifications.
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""
 
 from nicegui import ui
 
@@ -6,6 +11,7 @@ from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
 from utils.features import quick_post_button, skeleton_loader, swipeable_glow_card
+from quantum_futures import generate_futures, SIMULATION_DISCLAIMER
 
 from .login_page import login_page
 
@@ -26,6 +32,11 @@ async def feed_page() -> None:
         )
 
         feed_column = ui.column().classes('w-full')
+
+        show_sim_toggle = ui.switch(
+            'Enable Simulation View', value=False
+        ).classes('mb-4')
+        show_sim_toggle.on('change', lambda _: ui.run_async(refresh_feed()))
 
         post_dialog = ui.dialog()
         with post_dialog:
@@ -52,6 +63,12 @@ async def feed_page() -> None:
                         ui.label('VibeNode').classes('text-sm font-bold')
                         ui.label(vn.get('description', '')).classes('text-sm')
                         ui.link('View', f"/vibenodes/{vn['id']}")
+                        if show_sim_toggle.value:
+                            futures = generate_futures(vn.get('description', '') or str(vn.get('id')), 3)
+                            with ui.expansion('Speculative Futures', value=False).classes('w-full mt-2'):
+                                for fut in futures:
+                                    ui.label(f"{fut['emoji']} {fut['message']}").classes('text-sm italic')
+                                ui.markdown(SIMULATION_DISCLAIMER).classes('text-xs text-grey')
             for ev in events:
                 with feed_column:
                     with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -1,0 +1,51 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Quantum-inspired speculative futures generator.
+
+This module provides placeholder logic for generating hypothetical timeline
+branches for VibeNodes. It is designed with future quantum hypothesis modeling
+in mind, including forks, decoherence logic, and entropy tagging. Outputs are
+annotated with whimsical emoji metadata and include a markdown disclaimer.
+"""
+
+from __future__ import annotations
+
+from typing import List, Dict
+import random
+
+SIMULATION_DISCLAIMER = (
+    "*This is a satirical simulation, not advice or prediction.*"
+)
+
+# Sarcastic quantum emoji glossary
+QUANTUM_EMOJI: Dict[str, str] = {
+    "\U0001F468\u200D\U0001F4BB": "time ripple",  # 👨‍💻
+    "\U0001F300": "quantum swirl",  # 🌀
+    "\u2728": "entropic spark",     # ✨
+    "\U0001F916": "coherence bot",   # 🤖
+}
+
+
+def generate_futures(text: str, n: int = 3) -> List[Dict[str, str]]:
+    """Return up to ``n`` speculative future outcomes for ``text``.
+
+    This placeholder implementation randomly combines story fragments to
+    emulate quantum timeline branches. Real implementations may use LLMs and
+    scientific models to predict forked outcomes.
+    """
+    outcomes: List[Dict[str, str]] = []
+    fragments = [
+        "friendship blossoms",
+        "chaos ensues",
+        "a hidden talent emerges",
+    ]
+    for i in range(n):
+        emoji = random.choice(list(QUANTUM_EMOJI.keys()))
+        message = (
+            f"Scenario {i + 1}: '{text}' leads to {random.choice(fragments)}."
+        )
+        outcomes.append({"message": message, "emoji": emoji})
+    return outcomes
+
+__all__ = ["generate_futures", "QUANTUM_EMOJI", "SIMULATION_DISCLAIMER"]


### PR DESCRIPTION
## Summary
- add `quantum_futures` module with placeholder quantum timeline generator
- show optional speculative futures for each VibeNode in the feed
- include satire disclaimer and emoji glossary
- add toggle to enable/disable futures view

## Testing
- `pytest transcendental_resonance_frontend/tests/test_feed_page.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'streamlit', plus many failures)*

------
https://chatgpt.com/codex/tasks/task_e_68884f875420832093a1adb68c4e85d7