### PR TITLE
Modular external services for Quantum Futures

### DIFF
--- a/external_services/__init__.py
+++ b/external_services/__init__.py
@@ -1,0 +1,9 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Plug-and-play modules for external AI services."""
+
+from .llm_client import get_speculative_futures
+from .video_client import generate_video_preview
+
+__all__ = ["get_speculative_futures", "generate_video_preview"]

--- a/external_services/llm_client.py
+++ b/external_services/llm_client.py
@@ -1,0 +1,33 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Client for speculative text generation via LLM."""
+
+from __future__ import annotations
+
+import os
+import httpx
+
+LLM_API_URL = os.getenv("LLM_API_URL", "https://your-llm-endpoint.com/generate")
+LLM_API_KEY = os.getenv("LLM_API_KEY", "")  # <-- user inserts key here
+
+async def get_speculative_futures(description: str, style: str = "humorous/chaotic good") -> list[str]:
+    """Return speculative future strings from a remote LLM service."""
+    if not LLM_API_KEY:
+        return [
+            f"Offline Mode // Simulated future 1: {description} becomes a meme.",
+            f"Offline Mode // Simulated future 2: {description} triggers a time loop.",
+        ]
+    try:
+        payload = {
+            "prompt": f"Give 3 short speculative futures for: '{description}' in style: {style}",
+            "max_tokens": 300,
+        }
+        headers = {"Authorization": f"Bearer {LLM_API_KEY}"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(LLM_API_URL, json=payload, headers=headers, timeout=10)
+            return resp.json().get("futures", [])
+    except Exception as e:  # pragma: no cover - network errors
+        return [f"[LLM ERROR] {e}"]
+
+__all__ = ["get_speculative_futures"]

--- a/external_services/video_client.py
+++ b/external_services/video_client.py
@@ -1,0 +1,21 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Stub client for AI-driven video previews."""
+
+from __future__ import annotations
+
+import os
+
+# Future use: https://runwayml.com or https://kling.ai
+VIDEO_API_KEY = os.getenv("VIDEO_API_KEY", "")
+VIDEO_API_URL = os.getenv("VIDEO_API_URL", "")
+
+async def generate_video_preview(prompt: str) -> str:
+    """Return a URL for a generated video preview."""
+    if not VIDEO_API_KEY or not VIDEO_API_URL:
+        return "https://example.com/placeholder.mp4"
+    # TODO: implement real API call
+    return "https://your-api.com/generated_clip.mp4"
+
+__all__ = ["generate_video_preview"]

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -73,7 +73,7 @@ async def feed_page() -> None:
                         ui.label(vn.get('description', '')).classes('text-sm')
                         ui.link('View', f"/vibenodes/{vn['id']}")
                         if simulation_switch.value:
-                            futures = generate_speculative_futures(vn)
+                            futures = await generate_speculative_futures(vn)
                             with ui.expansion('Speculative futures', value=False).classes('w-full mt-2'):
                                 for fut in futures:
                                     ui.markdown(fut['text']).classes('text-sm italic')
@@ -85,7 +85,7 @@ async def feed_page() -> None:
                         ui.label(ev.get('description', '')).classes('text-sm')
                         ui.link('View', f"/events/{ev['id']}")
                         if simulation_switch.value:
-                            futures = generate_speculative_futures(ev)
+                            futures = await generate_speculative_futures(ev)
                             with ui.expansion('Speculative futures', value=False).classes('w-full mt-2'):
                                 for fut in futures:
                                     ui.markdown(fut['text']).classes('text-sm italic')
@@ -97,7 +97,7 @@ async def feed_page() -> None:
                         ui.label(n.get('message', '')).classes('text-sm')
                         ui.link('View', f"/notifications/{n['id']}")
                         if simulation_switch.value:
-                            futures = generate_speculative_futures(n)
+                            futures = await generate_speculative_futures(n)
                             with ui.expansion('Speculative futures', value=False).classes('w-full mt-2'):
                                 for fut in futures:
                                     ui.markdown(fut['text']).classes('text-sm italic')

--- a/transcendental_resonance_frontend/tests/test_quantum_futures.py
+++ b/transcendental_resonance_frontend/tests/test_quantum_futures.py
@@ -1,9 +1,11 @@
 import inspect
+import pytest
 from quantum_futures import generate_speculative_futures, DISCLAIMER
 
 
-def test_generate_speculative_futures_length():
-    futures = generate_speculative_futures({'description': 'test'}, num_variants=2)
+@pytest.mark.asyncio
+async def test_generate_speculative_futures_length():
+    futures = await generate_speculative_futures({'description': 'test'}, num_variants=2)
     assert isinstance(futures, list)
     assert len(futures) == 2
 


### PR DESCRIPTION
## Summary
- add new `external_services` package with LLM and video stubs
- refactor `quantum_futures` to use these clients and expose `generate_speculative_payload`
- update feed page to await the asynchronous futures generator
- adjust tests for async usage

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q` *(fails: AssertionError in tests/test_agent_registry.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_6888526ef3e483209491bf36fa7e6975