### PR TITLE
Fix Streamlit boot and API key input

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -1,0 +1,55 @@
+"""Reusable helpers for API key input in the Streamlit UI."""
+
+from __future__ import annotations
+
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - streamlit not available
+    st = None  # type: ignore
+
+# Mapping of display name -> (model identifier, session_state key)
+PROVIDERS = {
+    "Dummy": ("dummy", None),
+    "GPT-4o (OpenAI)": ("gpt-4o", "OPENAI_API_KEY"),
+    "Claude-3 (Anthropic)": ("claude-3", "ANTHROPIC_API_KEY"),
+    "Gemini (Google)": ("gemini", "GOOGLE_API_KEY"),
+    "Mixtral (Groq)": ("mixtral", "GROQ_API_KEY"),
+}
+
+
+def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
+    """Render model selection and API key fields.
+
+    Returns a dictionary with ``model`` and ``api_key`` keys.
+    """
+    if st is None:
+        return {"model": "dummy", "api_key": None}
+
+    names = list(PROVIDERS.keys())
+    if default in names:
+        index = names.index(default)
+    else:
+        index = 0
+    choice = st.selectbox("LLM Model", names, index=index)
+    model, key_name = PROVIDERS[choice]
+    key_val = ""
+    if key_name is not None:
+        key_val = st.text_input(
+            f"{choice} API Key",
+            type="password",
+            value=st.session_state.get(key_name, ""),
+        )
+        if key_val:
+            st.session_state[key_name] = key_val
+    st.session_state["selected_model"] = model
+    return {"model": model, "api_key": key_val or st.session_state.get(key_name)}
+
+
+def render_simulation_stubs() -> None:
+    """Placeholder inputs for upcoming simulation features."""
+    if st is None:
+        return
+    with st.expander("Future Simulation Inputs", expanded=False):
+        st.text("Video upload - coming soon")
+        st.text("Causal event modeling - TODO")
+        st.text("Symbolic voting - TODO")

--- a/ui.py
+++ b/ui.py
@@ -42,9 +42,15 @@ except Exception:
 else:
     st.title("superNova_2177")
     st.success("\u2705 Streamlit loaded!")
-from streamlit_helpers import (alert, apply_theme, centered_container, header,
-                               theme_selector)
-from ui_utils import load_rfc_entries, parse_summary, summarize_text
+from streamlit_helpers import (
+    alert,
+    apply_theme,
+    centered_container,
+    header,
+    theme_selector,
+)
+from api_key_input import render_api_key_ui, render_simulation_stubs
+from ui_utils import load_rfc_entries, parse_summary, summarize_text, render_main_ui
 
 try:
     from streamlit_app import _run_async
@@ -598,26 +604,13 @@ def render_validation_ui() -> None:
         agent_desc = AGENT_REGISTRY.get(agent_choice, {}).get("description")
         if agent_desc:
             st.caption(agent_desc)
-        backend_choice = st.selectbox(
-            "LLM Backend",
-            ["dummy", "GPT-4o", "Claude-3", "Gemini"],
-            index=0,
-        )
-        key_map = {
-            "GPT-4o": "OPENAI_API_KEY",
-            "Claude-3": "ANTHROPIC_API_KEY",
-            "Gemini": "GOOGLE_API_KEY",
-        }
-        api_key = ""
-        if backend_choice in key_map:
-            api_key = st.text_input(
-                f"{backend_choice} API Key",
-                value=st_secrets.get(key_map[backend_choice], ""),
-                type="password",
-            )
+        api_info = render_api_key_ui()
+        backend_choice = api_info.get("model", "dummy")
+        api_key = api_info.get("api_key", "") or ""
         event_type = st.text_input("Event", value="LLM_INCOMING")
         payload_txt = st.text_area("Payload JSON", value="{}", height=100)
         run_agent_clicked = st.button("Run Agent")
+        render_simulation_stubs()
 
         st.divider()
         governance_view = st.checkbox(
@@ -874,6 +867,7 @@ def render_validation_ui() -> None:
 
 
 def main() -> None:
+    render_main_ui()
     header("superNova_2177 Validation Analyzer", layout="wide")
     tab1, tab2, tab3, tab4 = st.tabs(["Validation", "Friends", "Votes", "Agents"])
     with tab1:

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -46,3 +46,17 @@ def load_rfc_entries(rfc_dir: Path):
         rfc_entries.append(entry)
         rfc_index[path.stem.lower()] = entry
     return rfc_entries, rfc_index
+
+
+def render_main_ui() -> None:
+    """Render a minimal placeholder for the Streamlit dashboard."""
+    st.title("superNova_2177")
+    st.write("UI initialization complete.")
+
+
+__all__ = [
+    "summarize_text",
+    "parse_summary",
+    "load_rfc_entries",
+    "render_main_ui",
+]


### PR DESCRIPTION
## Summary
- add reusable `api_key_input` helpers for model selection and API key storage
- expose a minimal `render_main_ui()` in `ui_utils`
- call new API key UI from the sidebar and add simulation stubs
- invoke `render_main_ui()` early during setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and various assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688853526a908320a92307df12bdc394