### PR TITLE
Add speculative futures to VibeSimulatorEngine

### DIFF
--- a/transcendental_resonance/vibe_simulator_engine.py
+++ b/transcendental_resonance/vibe_simulator_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - allow import without NiceGUI
     from nicegui import ui
@@ -24,9 +24,10 @@ from quantum_sim import QuantumContext
 
 try:
     from transcendental_resonance_frontend.src.utils.api import (
-        listen_ws, on_ws_status_change)
-    from transcendental_resonance_frontend.src.utils.error_overlay import \
-        ErrorOverlay
+        listen_ws,
+        on_ws_status_change,
+    )
+    from transcendental_resonance_frontend.src.utils.error_overlay import ErrorOverlay
 except Exception:  # pragma: no cover - fallback when frontend not available
 
     async def listen_ws(*_args: Any, **_kwargs: Any) -> None:
@@ -52,14 +53,31 @@ class NarrativeNode:
     children: list["NarrativeNode"] = field(default_factory=list)
 
 
+@dataclass
+class SimulatedOutcome:
+    """Representation of a speculative future branch."""
+
+    title: str
+    description: str
+    mood: str
+    probability: float
+    emoji_tags: List[str]
+
+
 class VibeSimulatorEngine:
     """Predict future VibeNode trajectories using quantum heuristics."""
 
-    def __init__(self, error_overlay: Optional[ErrorOverlay] = None) -> None:
+    def __init__(
+        self,
+        error_overlay: Optional[ErrorOverlay] = None,
+        *,
+        include_emoji: bool = True,
+    ) -> None:
         self.qc = QuantumContext(simulate=True)
         self.error_overlay = error_overlay or ErrorOverlay()
         self.root = NarrativeNode("root")
         self.ws_connected = False
+        self.include_emoji = include_emoji
         on_ws_status_change(self._on_ws_status_change)
         self._listen_task: Optional[asyncio.Task] = None
         self.last_meta: Dict[str, Any] = {}
@@ -88,6 +106,38 @@ class VibeSimulatorEngine:
         else:
             self.error_overlay.hide()
 
+    def generate_possible_outcomes(self, event: str) -> List[SimulatedOutcome]:
+        """Create optimistic, chaotic and dystopian outcome branches."""
+        base = self.qc.measure_superposition(0.5)["value"]
+        optimistic_prob = min(1.0, base + 0.25)
+        chaotic_prob = max(0.0, base * 0.5)
+        dystopian_prob = max(0.0, 1 - optimistic_prob)
+
+        outcomes = [
+            SimulatedOutcome(
+                title="Optimistic",
+                description=f"In a bright timeline, {event} leads to communal bliss and free snacks for everyone.",
+                mood="uplifting",
+                probability=optimistic_prob,
+                emoji_tags=["🌈", "✨", "🥳"],
+            ),
+            SimulatedOutcome(
+                title="Chaotic",
+                description=f"Chaos theory kicks in as {event} spirals into meme-worthy unpredictability.",
+                mood="chaotic",
+                probability=chaotic_prob,
+                emoji_tags=["🤪", "🌀", "🎲"],
+            ),
+            SimulatedOutcome(
+                title="Dystopian",
+                description=f"A darker path where {event} ushers in the robo-overlords' soggy Monday.",
+                mood="dystopian",
+                probability=dystopian_prob,
+                emoji_tags=["😱", "🤖", "🌧️"],
+            ),
+        ]
+        return outcomes
+
     def run_prediction(
         self,
         event: str,
@@ -109,6 +159,8 @@ class VibeSimulatorEngine:
         else:
             self._show_feedback("vibe stable")
 
+        outcomes = self.generate_possible_outcomes(event)
+
         lines = [
             "## Predicted Future",
             f"- Event: {event}",
@@ -120,7 +172,25 @@ class VibeSimulatorEngine:
             lines.append(f"- Emotion: {emotion}")
         if timestamp is not None:
             lines.append(f"- Timestamp: {timestamp}")
+
+        lines.append("")
+        for outcome in outcomes:
+            emojis = " ".join(outcome.emoji_tags) if self.include_emoji else ""
+            lines.extend(
+                [
+                    f"### {outcome.title} {emojis}",
+                    f"- Probability: {outcome.probability:.2%}",
+                    f"- Mood: {outcome.mood}",
+                    f"- {outcome.description}",
+                    "",
+                ]
+            )
+
+        lines.append(
+            "🌀 Quantum Disclaimer: Simulations may not reflect actual vibe conditions. Use caution in all dimensions."
+        )
+
         return "\n".join(lines)
 
 
-__all__ = ["VibeSimulatorEngine", "NarrativeNode"]
+__all__ = ["VibeSimulatorEngine", "NarrativeNode", "SimulatedOutcome"]


### PR DESCRIPTION
## Summary
- enrich `VibeSimulatorEngine` with speculative outcome generation
- add `SimulatedOutcome` dataclass and emoji toggle
- display optimistic, chaotic and dystopian futures in predictions

## Testing
- `pytest transcendental_resonance`
- `pytest -q` *(fails: sqlalchemy errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_688853fb96708320af73a63e59cd15ad