### PR TITLE
Fix Streamlit boot + API key UI

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -1,0 +1,29 @@
+import streamlit as st
+
+# Map service labels to session state keys
+SERVICE_KEYS = {
+    "OpenAI": "OPENAI_API_KEY",
+    "Anthropic": "ANTHROPIC_API_KEY",
+    "Groq": "GROQ_API_KEY",
+    "Gemini": "GOOGLE_API_KEY",
+}
+
+
+def render_api_key_inputs() -> None:
+    """Render simple sidebar inputs for user provided API keys."""
+    st.sidebar.subheader("LLM API Keys")
+    for label, key in SERVICE_KEYS.items():
+        default = st.session_state.get(key, "")
+        st.session_state[key] = st.sidebar.text_input(
+            f"{label} API Key",
+            value=default,
+            type="password",
+        )
+
+    model = st.sidebar.selectbox(
+        "Default Model",
+        ["gpt-4o", "claude-3", "gemini", "groq"],
+        index=0,
+    )
+    st.session_state["MODEL_CHOICE"] = model
+

--- a/ui.py
+++ b/ui.py
@@ -2,6 +2,19 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
+import streamlit as st
+
+try:  # basic setup before heavy imports
+    st.set_page_config(page_title="superNova_2177", layout="wide")
+except Exception:
+    pass
+st.title("superNova_2177")
+
+HEALTH_CHECK_PARAM = "healthz"
+if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
+    st.write("ok")
+    st.stop()
+
 import asyncio
 import difflib
 import io
@@ -21,30 +34,15 @@ plt = None  # imported lazily in run_analysis
 nx = None  # imported lazily in run_analysis
 go = None  # imported lazily in run_analysis
 Network = None  # imported lazily in run_analysis
-# Import Streamlit and register fallback health check
-import streamlit as st
-
-# Name of the query parameter used for the CI health check. Adjust here if the
-# health check endpoint ever changes.
-HEALTH_CHECK_PARAM = "healthz"
-
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
-    st.write("ok")
-    st.stop()
-
-# Basic page setup so Streamlit responds immediately on load
-try:
-    st.set_page_config(page_title="superNova_2177", layout="wide")
-except Exception:
-    logger.exception("Failed to configure Streamlit page")
-    print("Failed to configure Streamlit page", file=sys.stderr)
-
-else:
-    st.title("superNova_2177")
-    st.success("\u2705 Streamlit loaded!")
-from streamlit_helpers import (alert, apply_theme, centered_container, header,
-                               theme_selector)
+from streamlit_helpers import (
+    alert,
+    apply_theme,
+    centered_container,
+    header,
+    theme_selector,
+)
 from ui_utils import load_rfc_entries, parse_summary, summarize_text
+from api_key_input import render_api_key_inputs
 
 try:
     from streamlit_app import _run_async
@@ -560,6 +558,16 @@ def render_validation_ui() -> None:
         else:
             alert("SECRET_KEY missing", "warning")
 
+        try:
+            render_api_key_inputs()
+        except Exception as exc:
+            st.warning(f"API key inputs failed: {exc}")
+
+        with st.expander("Future Simulation Inputs"):
+            st.caption(
+                "Video, causal event modeling and symbolic voting will appear here."
+            )
+
         st.divider()
         st.subheader("Settings")
         demo_mode_choice = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
@@ -905,8 +913,10 @@ if __name__ == "__main__":
 
     apply_theme(st.session_state["theme"])
 
+    from ui_utils import render_main_ui
+
     try:
-        main()
+        render_main_ui()
     except Exception as exc:  # pragma: no cover - startup diagnostics
         logger.exception("UI startup failed")
         print(f"Startup failed: {exc}", file=sys.stderr)

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -46,3 +46,11 @@ def load_rfc_entries(rfc_dir: Path):
         rfc_entries.append(entry)
         rfc_index[path.stem.lower()] = entry
     return rfc_entries, rfc_index
+
+
+def render_main_ui() -> None:
+    """Entry point wrapper for the main UI module."""
+    from ui import main as _main
+
+    _main()
+


### PR DESCRIPTION
## Summary
- configure Streamlit before heavy imports in `ui.py`
- add helper for API key input widgets
- expose `render_main_ui` in `ui_utils`
- show API key fields in sidebar with error handling
- call new helper when launching via __main__

## Testing
- `pytest -q` *(fails: 55 failed, 291 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688854b75f9083209fd69c6a74f78626