### PR TITLE
Fix Streamlit boot and add API key UI

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -1,0 +1,36 @@
+"""Reusable Streamlit widgets for API key input."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+# Map provider display names to environment variable keys and model options
+PROVIDERS = {
+    "OpenAI": {"env": "OPENAI_API_KEY", "models": ["gpt-4o", "gpt-3.5-turbo"]},
+    "Anthropic": {"env": "ANTHROPIC_API_KEY", "models": ["claude-3-opus", "claude-3-haiku"]},
+    "Groq": {"env": "GROQ_API_KEY", "models": ["mixtral-8x7b", "llama3-70b"]},
+}
+
+
+def render_api_key_inputs() -> dict[str, str]:
+    """Render provider/model selectors and store keys in ``st.session_state``.
+
+    Returns a dictionary with ``provider``, ``api_key`` and ``model`` fields.
+    """
+    if "api_keys" not in st.session_state:
+        st.session_state["api_keys"] = {}
+
+    provider = st.selectbox("Model Provider", list(PROVIDERS))
+    meta = PROVIDERS[provider]
+    key_name = meta["env"]
+    default = st.session_state["api_keys"].get(key_name, "")
+    api_key = st.text_input(f"{provider} API Key", value=default, type="password")
+    st.session_state["api_keys"][key_name] = api_key
+
+    model = st.selectbox("Model", meta.get("models", []), key=f"model_{provider}")
+    st.session_state["api_keys"][f"model_{provider}"] = model
+
+    return {"provider": provider, "api_key": api_key, "model": model}
+
+
+__all__ = ["render_api_key_inputs", "PROVIDERS"]

--- a/ui.py
+++ b/ui.py
@@ -42,9 +42,20 @@ except Exception:
 else:
     st.title("superNova_2177")
     st.success("\u2705 Streamlit loaded!")
-from streamlit_helpers import (alert, apply_theme, centered_container, header,
-                               theme_selector)
-from ui_utils import load_rfc_entries, parse_summary, summarize_text
+from streamlit_helpers import (
+    alert,
+    apply_theme,
+    centered_container,
+    header,
+    theme_selector,
+)
+from ui_utils import (
+    load_rfc_entries,
+    parse_summary,
+    summarize_text,
+    render_main_ui,
+)
+from api_key_input import render_api_key_inputs
 
 try:
     from streamlit_app import _run_async
@@ -560,6 +571,9 @@ def render_validation_ui() -> None:
         else:
             alert("SECRET_KEY missing", "warning")
 
+        st.subheader("API Keys")
+        render_api_key_inputs()
+
         st.divider()
         st.subheader("Settings")
         demo_mode_choice = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
@@ -607,13 +621,13 @@ def render_validation_ui() -> None:
             "GPT-4o": "OPENAI_API_KEY",
             "Claude-3": "ANTHROPIC_API_KEY",
             "Gemini": "GOOGLE_API_KEY",
+            "Groq": "GROQ_API_KEY",
         }
         api_key = ""
         if backend_choice in key_map:
-            api_key = st.text_input(
-                f"{backend_choice} API Key",
-                value=st_secrets.get(key_map[backend_choice], ""),
-                type="password",
+            api_key = st.session_state.get("api_keys", {}).get(
+                key_map[backend_choice],
+                st_secrets.get(key_map[backend_choice], ""),
             )
         event_type = st.text_input("Event", value="LLM_INCOMING")
         payload_txt = st.text_area("Payload JSON", value="{}", height=100)
@@ -874,6 +888,7 @@ def render_validation_ui() -> None:
 
 
 def main() -> None:
+    render_main_ui()
     header("superNova_2177 Validation Analyzer", layout="wide")
     tab1, tab2, tab3, tab4 = st.tabs(["Validation", "Friends", "Votes", "Agents"])
     with tab1:

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -46,3 +46,17 @@ def load_rfc_entries(rfc_dir: Path):
         rfc_entries.append(entry)
         rfc_index[path.stem.lower()] = entry
     return rfc_entries, rfc_index
+
+
+def render_main_ui() -> None:
+    """Render a minimal placeholder UI for fast health checks."""
+    st.title("superNova_2177")
+    st.write("UI loaded")
+
+
+__all__ = [
+    "summarize_text",
+    "parse_summary",
+    "load_rfc_entries",
+    "render_main_ui",
+]


### PR DESCRIPTION
## Summary
- ensure UI bootstrap is quick by rendering minimal header via `render_main_ui`
- expose new API key input widget for user-provided LLM keys
- call new helper in the sidebar
- reuse stored keys when running agents

## Testing
- `pytest -k ui -q` *(fails: ModuleNotFoundError: 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_688854b75f9083209fd69c6a74f78626