### PR TITLE
Add placeholder external service clients

### DIFF
--- a/external_services/__init__.py
+++ b/external_services/__init__.py
@@ -5,5 +5,6 @@
 
 from .llm_client import get_speculative_futures
 from .video_client import generate_video_preview
+from .vision_client import analyze_timeline
 
-__all__ = ["get_speculative_futures", "generate_video_preview"]
+__all__ = ["get_speculative_futures", "generate_video_preview", "analyze_timeline"]

--- a/external_services/llm_client.py
+++ b/external_services/llm_client.py
@@ -6,12 +6,16 @@
 from __future__ import annotations
 
 import os
+
 import httpx
 
 LLM_API_URL = os.getenv("LLM_API_URL", "https://your-llm-endpoint.com/generate")
 LLM_API_KEY = os.getenv("LLM_API_KEY", "")  # <-- user inserts key here
 
-async def get_speculative_futures(description: str, style: str = "humorous/chaotic good") -> list[str]:
+
+async def get_speculative_futures(
+    description: str, style: str = "humorous/chaotic good"
+) -> list[str]:
     """Return speculative future strings from a remote LLM service."""
     if not LLM_API_KEY:
         return [
@@ -25,9 +29,12 @@ async def get_speculative_futures(description: str, style: str = "humorous/chaot
         }
         headers = {"Authorization": f"Bearer {LLM_API_KEY}"}
         async with httpx.AsyncClient() as client:
-            resp = await client.post(LLM_API_URL, json=payload, headers=headers, timeout=10)
+            resp = await client.post(
+                LLM_API_URL, json=payload, headers=headers, timeout=10
+            )
             return resp.json().get("futures", [])
     except Exception as e:  # pragma: no cover - network errors
         return [f"[LLM ERROR] {e}"]
+
 
 __all__ = ["get_speculative_futures"]

--- a/external_services/video_client.py
+++ b/external_services/video_client.py
@@ -7,15 +7,27 @@ from __future__ import annotations
 
 import os
 
+import httpx
+
 # Future use: https://runwayml.com or https://kling.ai
 VIDEO_API_KEY = os.getenv("VIDEO_API_KEY", "")
 VIDEO_API_URL = os.getenv("VIDEO_API_URL", "")
+
 
 async def generate_video_preview(prompt: str) -> str:
     """Return a URL for a generated video preview."""
     if not VIDEO_API_KEY or not VIDEO_API_URL:
         return "https://example.com/placeholder.mp4"
-    # TODO: implement real API call
-    return "https://your-api.com/generated_clip.mp4"
+    try:
+        payload = {"prompt": prompt}
+        headers = {"Authorization": f"Bearer {VIDEO_API_KEY}"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                VIDEO_API_URL, json=payload, headers=headers, timeout=10
+            )
+            return resp.json().get("video_url", "https://example.com/placeholder.mp4")
+    except Exception as e:  # pragma: no cover - network errors
+        return f"[VIDEO ERROR] {e}"
+
 
 __all__ = ["generate_video_preview"]

--- a/external_services/vision_client.py
+++ b/external_services/vision_client.py
@@ -1,0 +1,32 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Stub client for AI-powered vision timeline analysis."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+VISION_API_KEY = os.getenv("VISION_API_KEY", "")
+VISION_API_URL = os.getenv("VISION_API_URL", "")
+
+
+async def analyze_timeline(video_url: str) -> list[str]:
+    """Return a list of detected events for ``video_url``."""
+    if not VISION_API_KEY or not VISION_API_URL:
+        return ["Offline Mode // No vision analysis available"]
+    try:
+        payload = {"video_url": video_url}
+        headers = {"Authorization": f"Bearer {VISION_API_KEY}"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                VISION_API_URL, json=payload, headers=headers, timeout=10
+            )
+            return resp.json().get("events", [])
+    except Exception as e:  # pragma: no cover - network errors
+        return [f"[VISION ERROR] {e}"]
+
+
+__all__ = ["analyze_timeline"]

--- a/tests/test_external_services_clients.py
+++ b/tests/test_external_services_clients.py
@@ -1,0 +1,34 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Basic import and offline-mode checks for external service clients."""
+
+import pytest
+
+from external_services.llm_client import get_speculative_futures
+from external_services.video_client import generate_video_preview
+from external_services.vision_client import analyze_timeline
+
+
+@pytest.mark.asyncio
+async def test_llm_client_offline(monkeypatch):
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_URL", raising=False)
+    results = await get_speculative_futures("test")
+    assert results and "Offline Mode" in results[0]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_video_client_offline(monkeypatch):
+    monkeypatch.delenv("VIDEO_API_KEY", raising=False)
+    monkeypatch.delenv("VIDEO_API_URL", raising=False)
+    url = await generate_video_preview("hello")
+    assert "placeholder" in url  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_vision_client_offline(monkeypatch):
+    monkeypatch.delenv("VISION_API_KEY", raising=False)
+    monkeypatch.delenv("VISION_API_URL", raising=False)
+    notes = await analyze_timeline("https://example.com/video.mp4")
+    assert notes and "Offline" in notes[0]  # nosec B101

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -10,11 +10,12 @@ futures for VibeNodes and include stubs for upcoming vision and video hooks.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
 import random
+from typing import Any, Dict, List
 
 from external_services.llm_client import get_speculative_futures
 from external_services.video_client import generate_video_preview
+from external_services.vision_client import analyze_timeline
 
 # Satirical disclaimer appended to all speculative output
 DISCLAIMER = "This is a satirical simulation, not advice or prediction."
@@ -29,7 +30,7 @@ EMOJI_GLOSSARY: Dict[str, str] = {
 
 def _entropy_tag() -> float:
     """Return a random entropy tag used for demo purposes."""
-    return random.random()
+    return random.random()  # nosec B311
 
 
 async def generate_speculative_futures(
@@ -41,23 +42,27 @@ async def generate_speculative_futures(
     texts = await get_speculative_futures(description)
     futures: List[Dict[str, str]] = []
     for text in texts[: max(1, num_variants)]:
-        emoji = random.choice(list(EMOJI_GLOSSARY.keys()))
+        emoji = random.choice(list(EMOJI_GLOSSARY.keys()))  # nosec B311
         futures.append({"text": f"{text} {emoji}", "entropy": f"{_entropy_tag():.2f}"})
     return futures
 
 
 async def generate_speculative_payload(description: str) -> List[Dict[str, str]]:
-    """Return text and video pairs with a disclaimer."""
+    """Return text, video, and vision analysis pairs with a disclaimer."""
 
     texts = await get_speculative_futures(description)
     results: List[Dict[str, str]] = []
     for text in texts:
         video_url = await generate_video_preview(prompt=text)
-        results.append({
-            "text": text,
-            "video_url": video_url,
-            "disclaimer": DISCLAIMER,
-        })
+        vision_notes = await analyze_timeline(video_url)
+        results.append(
+            {
+                "text": text,
+                "video_url": video_url,
+                "vision_notes": vision_notes,
+                "disclaimer": DISCLAIMER,
+            }
+        )
     return results
 
 
@@ -66,9 +71,9 @@ def quantum_video_stub(*_args, **_kwargs) -> None:
     return None
 
 
-def analyze_video_timeline(*_args, **_kwargs) -> List[str]:
-    """Placeholder for vision reasoning agent hooks."""
-    return []
+async def analyze_video_timeline(video_url: str) -> List[str]:
+    """Delegate to :func:`external_services.vision_client.analyze_timeline`."""
+    return await analyze_timeline(video_url)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add stubbed clients for LLM, video, and vision services
- provide env var configuration with offline fallbacks and error handling
- integrate new clients into `generate_speculative_payload`
- expose new `analyze_timeline` in `external_services`
- add tests covering offline behaviour

## Testing
- `pre-commit run --files external_services/llm_client.py external_services/video_client.py external_services/vision_client.py external_services/__init__.py transcendental_resonance_frontend/src/quantum_futures.py tests/test_external_services_clients.py`
- `pytest -q tests/test_external_services_clients.py`

------
https://chatgpt.com/codex/tasks/task_e_6888559691948320a14b931c49564c3c