### PR TITLE
Fix Streamlit boot and add API key UI

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -1,0 +1,52 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Reusable Streamlit components for API key entry and model selection."""
+
+from __future__ import annotations
+
+import os
+import streamlit as st
+
+# Mapping of provider names to environment/session keys
+PROVIDERS = {
+    "OpenAI": "OPENAI_API_KEY",
+    "Anthropic": "ANTHROPIC_API_KEY",
+    "Groq": "GROQ_API_KEY",
+    "Google": "GOOGLE_API_KEY",
+}
+
+DEFAULT_MODELS = ["GPT-4o", "Claude-3", "Gemini", "Groq"]
+
+
+def render_api_key_inputs(container: "st.delta_generator.DeltaGenerator" | None = None) -> None:
+    """Render text inputs for API keys and store them in ``st.session_state``."""
+    if container is None:
+        container = st
+
+    keys = st.session_state.get("api_keys", {})
+    container.subheader("LLM API Keys")
+    for name, env_var in PROVIDERS.items():
+        default = keys.get(env_var) or os.getenv(env_var, "")
+        key = container.text_input(f"{name} API Key", value=default, type="password")
+        if key:
+            keys[env_var] = key
+    st.session_state["api_keys"] = keys
+
+    model = container.selectbox("Model", DEFAULT_MODELS, index=0, key="selected_model")
+    st.session_state["selected_model"] = model
+
+
+def get_api_key(env_var: str) -> str:
+    """Return the stored API key for ``env_var`` if available."""
+    return st.session_state.get("api_keys", {}).get(env_var, "")
+
+
+def render_future_simulation_stub(container: "st.delta_generator.DeltaGenerator" | None = None) -> None:
+    """Display placeholders for upcoming simulation features."""
+    if container is None:
+        container = st
+    container.subheader("Simulation Inputs (coming soon)")
+    container.info(
+        "Video uploads, causal event modeling, and symbolic voting will appear here.",
+    )

--- a/ui.py
+++ b/ui.py
@@ -33,18 +33,26 @@ if st.query_params.get(HEALTH_CHECK_PARAM) == "1":
     st.stop()
 
 # Basic page setup so Streamlit responds immediately on load
-try:
-    st.set_page_config(page_title="superNova_2177", layout="wide")
-except Exception:
-    logger.exception("Failed to configure Streamlit page")
-    print("Failed to configure Streamlit page", file=sys.stderr)
-
-else:
-    st.title("superNova_2177")
-    st.success("\u2705 Streamlit loaded!")
-from streamlit_helpers import (alert, apply_theme, centered_container, header,
-                               theme_selector)
-from ui_utils import load_rfc_entries, parse_summary, summarize_text
+from ui_utils import (
+    load_rfc_entries,
+    parse_summary,
+    summarize_text,
+    render_main_ui,
+)
+render_main_ui()
+st.success("\u2705 Streamlit loaded!")
+from streamlit_helpers import (
+    alert,
+    apply_theme,
+    centered_container,
+    header,
+    theme_selector,
+)
+from api_key_input import (
+    render_api_key_inputs,
+    get_api_key,
+    render_future_simulation_stub,
+)
 
 try:
     from streamlit_app import _run_async
@@ -566,8 +574,14 @@ def render_validation_ui() -> None:
         demo_mode = demo_mode_choice == "Demo"
         theme_selector("Theme")
 
+        render_api_key_inputs()
+
         VCConfig.HIGH_RISK_THRESHOLD = st.slider(
-            "High Risk Threshold", 0.1, 1.0, float(VCConfig.HIGH_RISK_THRESHOLD), 0.05
+            "High Risk Threshold",
+            0.1,
+            1.0,
+            float(VCConfig.HIGH_RISK_THRESHOLD),
+            0.05,
         )
 
         uploaded_file = st.file_uploader(
@@ -608,16 +622,12 @@ def render_validation_ui() -> None:
             "Claude-3": "ANTHROPIC_API_KEY",
             "Gemini": "GOOGLE_API_KEY",
         }
-        api_key = ""
-        if backend_choice in key_map:
-            api_key = st.text_input(
-                f"{backend_choice} API Key",
-                value=st_secrets.get(key_map[backend_choice], ""),
-                type="password",
-            )
+        api_key = get_api_key(key_map.get(backend_choice, ""))
         event_type = st.text_input("Event", value="LLM_INCOMING")
         payload_txt = st.text_area("Payload JSON", value="{}", height=100)
         run_agent_clicked = st.button("Run Agent")
+
+        render_future_simulation_stub()
 
         st.divider()
         governance_view = st.checkbox(

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -4,7 +4,19 @@
 """Utility functions for streamlit UIs."""
 
 from pathlib import Path
+import logging
 import streamlit as st
+
+logger = logging.getLogger(__name__)
+
+
+def render_main_ui(title: str = "superNova_2177") -> None:
+    """Ensure page config and basic title are set early."""
+    try:
+        st.set_page_config(page_title=title, layout="wide")
+    except Exception:
+        logger.exception("Failed to configure Streamlit page")
+    st.title(title)
 
 
 def summarize_text(text: str, max_len: int = 150) -> str:


### PR DESCRIPTION
## Summary
- ensure page config is set early via `render_main_ui`
- introduce `api_key_input` helpers for user-owned API keys
- use new API sidebar components in `ui.py`

## Testing
- `pip install -q -r requirements-minimal.txt`
- `pytest -q` *(fails: 40 failed, 269 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688854b75f9083209fd69c6a74f78626