### PR TITLE
Refactor external clients to modular classes

### DIFF
--- a/external_services/__init__.py
+++ b/external_services/__init__.py
@@ -3,8 +3,15 @@
 # Legal & Ethical Safeguards
 """Plug-and-play modules for external AI services."""
 
-from .llm_client import get_speculative_futures
-from .video_client import generate_video_preview
-from .vision_client import analyze_timeline
+from .llm_client import LLMClient, get_speculative_futures
+from .video_client import VideoClient, generate_video_preview
+from .vision_client import VisionClient, analyze_timeline
 
-__all__ = ["get_speculative_futures", "generate_video_preview", "analyze_timeline"]
+__all__ = [
+    "LLMClient",
+    "VideoClient",
+    "VisionClient",
+    "get_speculative_futures",
+    "generate_video_preview",
+    "analyze_timeline",
+]

--- a/external_services/base_client.py
+++ b/external_services/base_client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Base client for external API integrations with runtime BYOK support."""
+
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Dict
+
+from disclaimers import STRICTLY_SOCIAL_MEDIA
+
+
+class BaseClient:
+    """Minimal base client providing response metadata helpers."""
+
+    def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
+        self.api_url = api_url or ""
+        self.api_key = api_key or ""
+
+    @property
+    def offline(self) -> bool:
+        return (
+            os.getenv("OFFLINE_MODE", "0") == "1"
+            or not self.api_key
+            or not self.api_url
+        )
+
+    def _metadata(self, source: str) -> Dict[str, str]:
+        return {
+            "source": source,
+            "timestamp": datetime.utcnow().isoformat(),
+            "trace_id": uuid.uuid4().hex,
+            "disclaimer": STRICTLY_SOCIAL_MEDIA,
+        }
+
+    def _wrap(self, source: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        data = self._metadata(source)
+        data.update(payload)
+        return data

--- a/external_services/llm_client.py
+++ b/external_services/llm_client.py
@@ -1,40 +1,67 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
-"""Client for speculative text generation via LLM."""
-
 from __future__ import annotations
 
+"""Client for speculative text generation via LLM."""
+
+import asyncio
 import os
 
 import httpx
 
-LLM_API_URL = os.getenv("LLM_API_URL", "https://your-llm-endpoint.com/generate")
-LLM_API_KEY = os.getenv("LLM_API_KEY", "")  # <-- user inserts key here
+from .base_client import BaseClient
+
+
+class LLMClient(BaseClient):
+    """Asynchronous LLM client with offline fallback and BYOK support."""
+
+    def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
+        url = api_url or os.getenv(
+            "LLM_API_URL", "https://your-llm-endpoint.com/generate"
+        )
+        key = api_key or os.getenv("LLM_API_KEY", "")
+        super().__init__(url, key)
+
+    def get_prompt_template(self) -> str:
+        return "Give 3 short speculative futures for: '{description}' in style: {style}"
+
+    async def get_speculative_futures(
+        self, description: str, style: str = "humorous/chaotic good"
+    ) -> dict:
+        if self.offline:
+            futures = [
+                f"Offline Mode // Simulated future 1: {description} becomes a meme.",
+                f"Offline Mode // Simulated future 2: {description} triggers a time loop.",
+            ]
+            return self._wrap("LLMClient", {"futures": futures})
+        try:
+            payload = {
+                "prompt": self.get_prompt_template().format(
+                    description=description, style=style
+                ),
+                "max_tokens": 300,
+            }
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    self.api_url, json=payload, headers=headers, timeout=10
+                )
+                futures = resp.json().get("futures", [])
+            return self._wrap("LLMClient", {"futures": futures})
+        except Exception as e:  # pragma: no cover - network errors
+            return self._wrap("LLMClient", {"futures": [f"[LLM ERROR] {e}"]})
+
+    def get_speculative_futures_sync(
+        self, description: str, style: str = "humorous/chaotic good"
+    ) -> dict:
+        return asyncio.run(self.get_speculative_futures(description, style))
 
 
 async def get_speculative_futures(
     description: str, style: str = "humorous/chaotic good"
 ) -> list[str]:
-    """Return speculative future strings from a remote LLM service."""
-    if not LLM_API_KEY:
-        return [
-            f"Offline Mode // Simulated future 1: {description} becomes a meme.",
-            f"Offline Mode // Simulated future 2: {description} triggers a time loop.",
-        ]
-    try:
-        payload = {
-            "prompt": f"Give 3 short speculative futures for: '{description}' in style: {style}",
-            "max_tokens": 300,
-        }
-        headers = {"Authorization": f"Bearer {LLM_API_KEY}"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                LLM_API_URL, json=payload, headers=headers, timeout=10
-            )
-            return resp.json().get("futures", [])
-    except Exception as e:  # pragma: no cover - network errors
-        return [f"[LLM ERROR] {e}"]
+    """Backward compatible wrapper returning just the futures list."""
+    client = LLMClient()
+    result = await client.get_speculative_futures(description, style)
+    return result.get("futures", [])
 
 
-__all__ = ["get_speculative_futures"]
+__all__ = ["LLMClient", "get_speculative_futures"]

--- a/external_services/video_client.py
+++ b/external_services/video_client.py
@@ -1,33 +1,47 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
-"""Stub client for AI-driven video previews."""
-
 from __future__ import annotations
+
+"""Stub client for AI-driven video previews."""
 
 import os
 
 import httpx
 
-# Future use: https://runwayml.com or https://kling.ai
-VIDEO_API_KEY = os.getenv("VIDEO_API_KEY", "")
-VIDEO_API_URL = os.getenv("VIDEO_API_URL", "")
+from .base_client import BaseClient
+
+
+class VideoClient(BaseClient):
+    """Asynchronous video generation client with offline fallback."""
+
+    def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
+        url = api_url or os.getenv("VIDEO_API_URL", "")
+        key = api_key or os.getenv("VIDEO_API_KEY", "")
+        super().__init__(url, key)
+
+    async def generate_video_preview(self, prompt: str) -> dict:
+        if self.offline:
+            return self._wrap(
+                "VideoClient", {"video_url": "https://example.com/placeholder.mp4"}
+            )
+        try:
+            payload = {"prompt": prompt}
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    self.api_url, json=payload, headers=headers, timeout=10
+                )
+                url = resp.json().get(
+                    "video_url", "https://example.com/placeholder.mp4"
+                )
+            return self._wrap("VideoClient", {"video_url": url})
+        except Exception as e:  # pragma: no cover - network errors
+            return self._wrap("VideoClient", {"video_url": f"[VIDEO ERROR] {e}"})
 
 
 async def generate_video_preview(prompt: str) -> str:
-    """Return a URL for a generated video preview."""
-    if not VIDEO_API_KEY or not VIDEO_API_URL:
-        return "https://example.com/placeholder.mp4"
-    try:
-        payload = {"prompt": prompt}
-        headers = {"Authorization": f"Bearer {VIDEO_API_KEY}"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                VIDEO_API_URL, json=payload, headers=headers, timeout=10
-            )
-            return resp.json().get("video_url", "https://example.com/placeholder.mp4")
-    except Exception as e:  # pragma: no cover - network errors
-        return f"[VIDEO ERROR] {e}"
+    """Backward compatible wrapper returning just the URL string."""
+    client = VideoClient()
+    result = await client.generate_video_preview(prompt)
+    return result.get("video_url", "")
 
 
-__all__ = ["generate_video_preview"]
+__all__ = ["VideoClient", "generate_video_preview"]

--- a/external_services/vision_client.py
+++ b/external_services/vision_client.py
@@ -1,32 +1,52 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
-"""Stub client for AI-powered vision timeline analysis."""
-
 from __future__ import annotations
 
+"""Stub client for AI-powered vision timeline analysis."""
+
+import hashlib
 import os
 
 import httpx
 
-VISION_API_KEY = os.getenv("VISION_API_KEY", "")
-VISION_API_URL = os.getenv("VISION_API_URL", "")
+from .base_client import BaseClient
+
+
+class VisionClient(BaseClient):
+    """Asynchronous vision analysis client with deterministic offline fallback."""
+
+    def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
+        url = api_url or os.getenv("VISION_API_URL", "")
+        key = api_key or os.getenv("VISION_API_KEY", "")
+        super().__init__(url, key)
+
+    async def analyze_timeline(self, video_url: str) -> dict:
+        if self.offline:
+            digest = hashlib.md5(video_url.encode(), usedforsecurity=False).hexdigest()[
+                :6
+            ]
+            caption = f"offline-caption-{digest}"
+            events = ["Offline Mode // No vision analysis available"]
+            return self._wrap("VisionClient", {"events": events, "caption": caption})
+        try:
+            payload = {"video_url": video_url}
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    self.api_url, json=payload, headers=headers, timeout=10
+                )
+                events = resp.json().get("events", [])
+                caption = resp.json().get("caption", "")
+            return self._wrap("VisionClient", {"events": events, "caption": caption})
+        except Exception as e:  # pragma: no cover - network errors
+            return self._wrap(
+                "VisionClient", {"events": [f"[VISION ERROR] {e}"], "caption": ""}
+            )
 
 
 async def analyze_timeline(video_url: str) -> list[str]:
-    """Return a list of detected events for ``video_url``."""
-    if not VISION_API_KEY or not VISION_API_URL:
-        return ["Offline Mode // No vision analysis available"]
-    try:
-        payload = {"video_url": video_url}
-        headers = {"Authorization": f"Bearer {VISION_API_KEY}"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                VISION_API_URL, json=payload, headers=headers, timeout=10
-            )
-            return resp.json().get("events", [])
-    except Exception as e:  # pragma: no cover - network errors
-        return [f"[VISION ERROR] {e}"]
+    """Backward compatible wrapper returning only the events list."""
+    client = VisionClient()
+    result = await client.analyze_timeline(video_url)
+    return result.get("events", [])
 
 
-__all__ = ["analyze_timeline"]
+__all__ = ["VisionClient", "analyze_timeline"]

--- a/tests/test_external_services_clients.py
+++ b/tests/test_external_services_clients.py
@@ -5,30 +5,42 @@
 
 import pytest
 
-from external_services.llm_client import get_speculative_futures
-from external_services.video_client import generate_video_preview
-from external_services.vision_client import analyze_timeline
+from external_services.llm_client import LLMClient
+from external_services.video_client import VideoClient
+from external_services.vision_client import VisionClient
 
 
 @pytest.mark.asyncio
 async def test_llm_client_offline(monkeypatch):
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     monkeypatch.delenv("LLM_API_URL", raising=False)
-    results = await get_speculative_futures("test")
-    assert results and "Offline Mode" in results[0]  # nosec B101
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    client = LLMClient()
+    result = await client.get_speculative_futures("test")
+    assert result["futures"] and "Offline Mode" in result["futures"][0]  # nosec B101
+    for key in ("source", "timestamp", "trace_id", "disclaimer"):
+        assert key in result  # nosec B101
 
 
 @pytest.mark.asyncio
 async def test_video_client_offline(monkeypatch):
     monkeypatch.delenv("VIDEO_API_KEY", raising=False)
     monkeypatch.delenv("VIDEO_API_URL", raising=False)
-    url = await generate_video_preview("hello")
-    assert "placeholder" in url  # nosec B101
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    client = VideoClient()
+    result = await client.generate_video_preview("hello")
+    assert "placeholder" in result["video_url"]  # nosec B101
+    for key in ("source", "timestamp", "trace_id", "disclaimer"):
+        assert key in result  # nosec B101
 
 
 @pytest.mark.asyncio
 async def test_vision_client_offline(monkeypatch):
     monkeypatch.delenv("VISION_API_KEY", raising=False)
     monkeypatch.delenv("VISION_API_URL", raising=False)
-    notes = await analyze_timeline("https://example.com/video.mp4")
-    assert notes and "Offline" in notes[0]  # nosec B101
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    client = VisionClient()
+    result = await client.analyze_timeline("https://example.com/video.mp4")
+    assert result["events"] and "Offline" in result["events"][0]  # nosec B101
+    for key in ("source", "timestamp", "trace_id", "disclaimer"):
+        assert key in result  # nosec B101

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, List
 
-from external_services.llm_client import get_speculative_futures
-from external_services.video_client import generate_video_preview
-from external_services.vision_client import analyze_timeline
+from external_services.llm_client import LLMClient
+from external_services.video_client import VideoClient
+from external_services.vision_client import VisionClient
 
 # Satirical disclaimer appended to all speculative output
 DISCLAIMER = "This is a satirical simulation, not advice or prediction."
@@ -39,7 +39,8 @@ async def generate_speculative_futures(
     """Generate playful speculative futures for a VibeNode using ``llm_client``."""
 
     description = node.get("description", "")
-    texts = await get_speculative_futures(description)
+    llm = LLMClient()
+    texts = (await llm.get_speculative_futures(description)).get("futures", [])
     futures: List[Dict[str, str]] = []
     for text in texts[: max(1, num_variants)]:
         emoji = random.choice(list(EMOJI_GLOSSARY.keys()))  # nosec B311
@@ -50,11 +51,16 @@ async def generate_speculative_futures(
 async def generate_speculative_payload(description: str) -> List[Dict[str, str]]:
     """Return text, video, and vision analysis pairs with a disclaimer."""
 
-    texts = await get_speculative_futures(description)
+    llm = LLMClient()
+    texts = (await llm.get_speculative_futures(description)).get("futures", [])
     results: List[Dict[str, str]] = []
     for text in texts:
-        video_url = await generate_video_preview(prompt=text)
-        vision_notes = await analyze_timeline(video_url)
+        video = VideoClient()
+        vision = VisionClient()
+        video_url = (await video.generate_video_preview(prompt=text)).get(
+            "video_url", ""
+        )
+        vision_notes = (await vision.analyze_timeline(video_url)).get("events", [])
         results.append(
             {
                 "text": text,
@@ -72,8 +78,9 @@ def quantum_video_stub(*_args, **_kwargs) -> None:
 
 
 async def analyze_video_timeline(video_url: str) -> List[str]:
-    """Delegate to :func:`external_services.vision_client.analyze_timeline`."""
-    return await analyze_timeline(video_url)
+    """Delegate to :class:`VisionClient` for timeline analysis."""
+    vision = VisionClient()
+    return (await vision.analyze_timeline(video_url)).get("events", [])
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- introduce `BaseClient` with metadata helpers and offline detection
- refactor LLM, video and vision clients into class-based wrappers using `BaseClient`
- update quantum futures module to use new clients
- improve external service tests with metadata checks

## Testing
- `pre-commit run --files external_services/base_client.py external_services/llm_client.py external_services/video_client.py external_services/vision_client.py external_services/__init__.py transcendental_resonance_frontend/src/quantum_futures.py tests/test_external_services_clients.py`
- `pytest -q tests/test_external_services_clients.py`

------
https://chatgpt.com/codex/tasks/task_e_688857b51a808320a1d4ba7e31dfa649