### PR TITLE
Handle invalid last_login value

### DIFF
--- a/login_router.py
+++ b/login_router.py
@@ -45,9 +45,12 @@ def login_for_access_token(
     if not user.consent_given:
         raise InvalidConsentError("User has revoked consent.")
     streaks = user.engagement_streaks or {}
-    last_login = datetime.datetime.fromisoformat(
-        streaks.get("last_login", "1970-01-01T00:00:00")
-    )
+    try:
+        last_login = datetime.datetime.fromisoformat(
+            streaks.get("last_login", "1970-01-01T00:00:00")
+        )
+    except ValueError:
+        last_login = datetime.datetime(1970, 1, 1)
     now = datetime.datetime.utcnow()
     if (now.date() - last_login.date()).days == 1:
         streaks["daily"] = streaks.get("daily", 0) + 1


### PR DESCRIPTION
## Summary
- catch malformed engagement streak timestamps

## Testing
- `pytest tests/universe/test_login_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68885a8c05108320a76d76d81bef51dd