### PR TITLE
Fix Token imports for debug and status pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from nicegui import ui
 
+from utils.api import TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
 from frontend_bridge import ROUTES, dispatch_route

--- a/transcendental_resonance_frontend/src/pages/status_page.py
+++ b/transcendental_resonance_frontend/src/pages/status_page.py
@@ -1,7 +1,7 @@
 """System status metrics page."""
 
 from nicegui import ui
-from utils.api import api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
 


### PR DESCRIPTION
## Summary
- add missing `TOKEN` import to debug panel page
- import `TOKEN` alongside `api_call` in status page
- verify pages compile without errors

## Testing
- `python -m py_compile transcendental_resonance_frontend/src/pages/debug_panel_page.py transcendental_resonance_frontend/src/pages/status_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68885a6363a08320a7475f6c70bcdcfe