### PR TITLE
Add check for unawaited api_call in page modules

### DIFF
--- a/tests/test_unawaited_api_calls.py
+++ b/tests/test_unawaited_api_calls.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from tests.unawaited_helper import find_unawaited_api_calls
+
+PAGES = [
+    "transcendental_resonance_frontend/src/pages/feed_page.py",
+    "transcendental_resonance_frontend/src/pages/messages_page.py",
+    "transcendental_resonance_frontend/src/pages/profile_page.py",
+]
+
+
+def test_no_unawaited_api_calls():
+    for page in PAGES:
+        source = Path(page).read_text()
+        lines = find_unawaited_api_calls(source)
+        assert not lines, f"Unawaited api_call on lines {lines} in {page}"

--- a/tests/unawaited_helper.py
+++ b/tests/unawaited_helper.py
@@ -1,0 +1,29 @@
+import ast
+from typing import List
+
+
+def find_unawaited_api_calls(source: str) -> List[int]:
+    """Return line numbers containing unawaited ``api_call`` invocations."""
+    tree = ast.parse(source)
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack = []
+            self.unawaited: List[int] = []
+
+        def visit(self, node: ast.AST) -> None:  # type: ignore[override]
+            self.stack.append(node)
+            super().visit(node)
+            self.stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:  # type: ignore[override]
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "api_call":
+                parent = self.stack[-2] if len(self.stack) >= 2 else None
+                if not isinstance(parent, ast.Await):
+                    self.unawaited.append(node.lineno)
+            self.generic_visit(node)
+
+    visitor = Visitor()
+    visitor.visit(tree)
+    return visitor.unawaited


### PR DESCRIPTION
## Summary
- add helper for scanning source files for unawaited `api_call`
- create test verifying feed_page, messages_page and profile_page never call the API without awaiting

## Testing
- `pytest tests/test_unawaited_api_calls.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68885a7caf8c8320bd8dd66182811075