### PR TITLE
Fix notification when network data fails

### DIFF
--- a/transcendental_resonance_frontend/src/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/src/pages/network_analysis_page.py
@@ -78,6 +78,9 @@ async def network_page():
 
         async def refresh_network() -> None:
             analysis = await api_call("GET", "/network-analysis/")
+            if analysis is None:
+                ui.notify('Unable to load network data', color='negative')
+                return
             if analysis:
                 nodes_label.text = f"Nodes: {analysis['metrics']['node_count']}"
                 edges_label.text = f"Edges: {analysis['metrics']['edge_count']}"


### PR DESCRIPTION
## Summary
- handle `None` response from `/network-analysis/` in frontend

## Testing
- `pytest -q` *(fails: Module errors & test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68885abff1a48320b37dab3550365176