### PR TITLE
Use thread executor for quantum predictions

### DIFF
--- a/quantum_sim/ui_hook.py
+++ b/quantum_sim/ui_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 from importlib import import_module
+import asyncio
 
 from frontend_bridge import register_route_once
 from hook_manager import HookManager
@@ -16,7 +17,7 @@ ui_hook_manager = HookManager()
 async def quantum_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Run quantum_prediction_engine on user_ids from payload."""
     user_ids = payload.get("user_ids", [])
-    result = quantum_prediction_engine(user_ids)
+    result = await asyncio.to_thread(quantum_prediction_engine, user_ids)
     minimal = {
         "predicted_interactions": result.get("predicted_interactions", {}),
         "overall_quantum_coherence": result.get("overall_quantum_coherence", 0.0),


### PR DESCRIPTION
## Summary
- update `quantum_prediction_ui` to offload heavy prediction work to a thread

## Testing
- `pytest tests/ui_hooks/test_quantum_sim.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68885a9daa14832080975581d257ce91