### PR TITLE
Add negative toast on API failure

### DIFF
--- a/transcendental_resonance_frontend/src/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/src/pages/ai_assist_page.py
@@ -31,6 +31,8 @@ async def ai_assist_page(vibenode_id: int):
             if resp:
                 ui.label('AI Response:').classes('mb-2')
                 ui.label(resp['response']).classes('text-sm break-words')
+            else:
+                ui.notify('Action failed', color='negative')
 
         ui.button('Get AI Help', on_click=get_ai_response).classes('w-full').style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'

--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -55,6 +55,8 @@ async def events_page():
             if resp:
                 ui.notify('Event created!', color='positive')
                 await refresh_events()
+            else:
+                ui.notify('Action failed', color='negative')
 
         ui.button('Create Event', on_click=create_event).classes('w-full mb-4').style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -38,6 +38,8 @@ async def proposals_page():
             if resp:
                 ui.notify('Proposal created!', color='positive')
                 await refresh_proposals()
+            else:
+                ui.notify('Action failed', color='negative')
 
         ui.button('Create Proposal', on_click=create_proposal).classes('w-full mb-4').style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'


### PR DESCRIPTION
## Summary
- show error messages when POST calls fail in events, proposals, and AI assist pages

## Testing
- `pytest -q` *(fails: 40 failed, 272 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68885abbc3488320ba01c2a37bb0dfda