### PR TITLE
Add Offline mode indicator

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -19,6 +19,7 @@ from .utils.api import (
     clear_token,
     listen_ws,
     on_ws_status_change,
+    OFFLINE_MODE,
 )
 from .utils.loading_overlay import LoadingOverlay
 from .utils.styles import (
@@ -54,6 +55,13 @@ ws_status = (
     .classes("fixed bottom-0 left-0 m-2")
     .style("color: red")
 )
+
+offline_notice = (
+    ui.label("Offline Mode – using mock services.")
+    .classes("fixed bottom-0 right-0 m-2 text-sm")
+    .style("color: orange")
+)
+offline_notice.visible = OFFLINE_MODE
 
 def _update_ws_status(status: str) -> None:
     color = "green" if status == "connected" else "red"

--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -7,6 +7,7 @@ from nicegui import ui
 
 from utils.styles import get_theme
 from utils.layout import page_container, navigation_bar
+from utils.api import TOKEN, OFFLINE_MODE
 from frontend_bridge import ROUTES, dispatch_route
 
 # Minimal example payloads for some routes
@@ -35,6 +36,12 @@ async def debug_panel_page() -> None:
         ui.label("Debug Panel").classes("text-2xl font-bold mb-4").style(
             f"color: {theme['accent']};"
         )
+        status = (
+            "Offline Mode – using mock services."
+            if OFFLINE_MODE
+            else "Online Mode"
+        )
+        ui.label(status).classes("text-sm mb-4")
 
         for name, handler in ROUTES.items():
             description = (handler.__doc__ or "").strip().splitlines()[0]

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -14,6 +14,7 @@ from nicegui import ui
 
 # Backend API base URL
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+OFFLINE_MODE: bool = os.getenv("OFFLINE_MODE", "0") == "1"
 
 logger = logging.getLogger(__name__)
 logger.propagate = False

--- a/transcendental_resonance_frontend/tests/test_offline_mode.py
+++ b/transcendental_resonance_frontend/tests/test_offline_mode.py
@@ -1,0 +1,12 @@
+import inspect
+from utils import api
+from pages.debug_panel_page import debug_panel_page
+
+
+def test_offline_mode_constant_exists():
+    assert isinstance(api.OFFLINE_MODE, bool)
+
+
+def test_debug_panel_mentions_offline():
+    source = inspect.getsource(debug_panel_page)
+    assert "Offline Mode" in source


### PR DESCRIPTION
## Summary
- surface OFFLINE_MODE flag in `utils.api`
- display Offline Mode footer in NiceGUI `main.py`
- show API status in `debug_panel_page`
- add tests for the offline mode indicator

## Testing
- `pytest -q transcendental_resonance_frontend/tests/test_offline_mode.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit', AttributeError: 'Session' object has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_68885acc6af483209f94c7d24e36a162