### PR TITLE
Fix spinner cancellation handling

### DIFF
--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,0 +1,19 @@
+import asyncio
+import contextlib
+import pytest
+
+@pytest.mark.asyncio
+async def test_cancelled_spinner_suppressed():
+    async def spin():
+        while True:
+            await asyncio.sleep(0.01)
+
+    spinner = asyncio.create_task(spin())
+    spinner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await spinner
+
+    spinner = asyncio.create_task(spin())
+    spinner.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await spinner

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -2,6 +2,7 @@
 
 from nicegui import ui
 import asyncio
+import contextlib
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -29,17 +30,25 @@ async def upload_page():
         async def handle_upload(event):
             with progress_container:
                 progress = ui.linear_progress(value=0).classes('w-full mb-2')
+
             async def spin():
                 while progress.value < 0.95:
                     await asyncio.sleep(0.1)
                     progress.value += 0.05
+
             spinner = asyncio.create_task(spin())
-            files = {'file': (event.name, event.content.read(), 'multipart/form-data')}
-            resp = await api_call('POST', '/upload/', files=files)
-            spinner.cancel()
-            progress.value = 1.0
-            if resp:
-                ui.notify(f"Uploaded: {resp['media_url']}", color='positive')
+            try:
+                files = {
+                    'file': (event.name, event.content.read(), 'multipart/form-data')
+                }
+                resp = await api_call('POST', '/upload/', files=files)
+                progress.value = 1.0
+                if resp:
+                    ui.notify(f"Uploaded: {resp['media_url']}", color='positive')
+            finally:
+                spinner.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await spinner
 
         ui.upload(multiple=True, auto_upload=True,
                   on_upload=lambda e: ui.run_async(handle_upload(e))) \

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -2,6 +2,7 @@
 
 from nicegui import ui
 import asyncio
+import contextlib
 
 from utils.api import api_call, TOKEN, listen_ws
 from utils.styles import get_theme
@@ -49,21 +50,29 @@ async def vibenodes_page():
         async def handle_upload(event):
             with progress_container:
                 progress = ui.linear_progress(value=0).classes('w-full mb-2')
+
             async def spin():
                 while progress.value < 0.95:
                     await asyncio.sleep(0.1)
                     progress.value += 0.05
+
             spinner = asyncio.create_task(spin())
-            files = {'file': (event.name, event.content.read(), 'multipart/form-data')}
-            resp = await api_call('POST', '/upload/', files=files)
-            spinner.cancel()
-            progress.value = 1.0
-            if resp:
-                uploaded_media['url'] = resp.get('media_url')
-                uploaded_media['type'] = resp.get('media_type')
-                ui.notify('Media uploaded', color='positive')
-                if uploaded_media['type'] and uploaded_media['type'].startswith('image'):
-                    ui.image(uploaded_media['url']).classes('w-full mb-2')
+            try:
+                files = {
+                    'file': (event.name, event.content.read(), 'multipart/form-data')
+                }
+                resp = await api_call('POST', '/upload/', files=files)
+                progress.value = 1.0
+                if resp:
+                    uploaded_media['url'] = resp.get('media_url')
+                    uploaded_media['type'] = resp.get('media_type')
+                    ui.notify('Media uploaded', color='positive')
+                    if uploaded_media['type'] and uploaded_media['type'].startswith('image'):
+                        ui.image(uploaded_media['url']).classes('w-full mb-2')
+            finally:
+                spinner.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await spinner
 
         ui.upload(multiple=True, auto_upload=True,
                   on_upload=lambda e: ui.run_async(handle_upload(e))) \


### PR DESCRIPTION
## Summary
- wrap async upload spinners in `try/finally`
- await cancelled spinner tasks and suppress `CancelledError`
- add unit test covering spinner cancellation

## Testing
- `pytest tests/test_spinner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68885ad9f7008320a246dfac0c44d7c0