### PR TITLE
Update quantum futures imports

### DIFF
--- a/tests/test_external_services_clients.py
+++ b/tests/test_external_services_clients.py
@@ -5,9 +5,7 @@
 
 import pytest
 
-from external_services.llm_client import LLMClient
-from external_services.video_client import VideoClient
-from external_services.vision_client import VisionClient
+from external_services import LLMClient, VideoClient, VisionClient
 
 
 @pytest.mark.asyncio

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, List
 
-from external_services.llm_client import LLMClient
-from external_services.video_client import VideoClient
-from external_services.vision_client import VisionClient
+from external_services import (
+    analyze_timeline,
+    generate_video_preview,
+    get_speculative_futures,
+)
 
 # Satirical disclaimer appended to all speculative output
 DISCLAIMER = "This is a satirical simulation, not advice or prediction."
@@ -39,8 +41,7 @@ async def generate_speculative_futures(
     """Generate playful speculative futures for a VibeNode using ``llm_client``."""
 
     description = node.get("description", "")
-    llm = LLMClient()
-    texts = (await llm.get_speculative_futures(description)).get("futures", [])
+    texts = await get_speculative_futures(description)
     futures: List[Dict[str, str]] = []
     for text in texts[: max(1, num_variants)]:
         emoji = random.choice(list(EMOJI_GLOSSARY.keys()))  # nosec B311
@@ -51,16 +52,11 @@ async def generate_speculative_futures(
 async def generate_speculative_payload(description: str) -> List[Dict[str, str]]:
     """Return text, video, and vision analysis pairs with a disclaimer."""
 
-    llm = LLMClient()
-    texts = (await llm.get_speculative_futures(description)).get("futures", [])
+    texts = await get_speculative_futures(description)
     results: List[Dict[str, str]] = []
     for text in texts:
-        video = VideoClient()
-        vision = VisionClient()
-        video_url = (await video.generate_video_preview(prompt=text)).get(
-            "video_url", ""
-        )
-        vision_notes = (await vision.analyze_timeline(video_url)).get("events", [])
+        video_url = await generate_video_preview(prompt=text)
+        vision_notes = await analyze_timeline(video_url)
         results.append(
             {
                 "text": text,
@@ -78,9 +74,8 @@ def quantum_video_stub(*_args, **_kwargs) -> None:
 
 
 async def analyze_video_timeline(video_url: str) -> List[str]:
-    """Delegate to :class:`VisionClient` for timeline analysis."""
-    vision = VisionClient()
-    return (await vision.analyze_timeline(video_url)).get("events", [])
+    """Delegate to :func:`analyze_timeline` for vision analysis."""
+    return await analyze_timeline(video_url)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- use external services at the package level in `quantum_futures`
- adjust tests for the new import path

## Testing
- `pytest tests/test_external_services_clients.py -q`
- `pytest -q` *(fails: sqlalchemy errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_68885ac74db48320a01435891a48c0f5