### PR TITLE
Add offline mode support to frontend APIs

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -19,6 +19,7 @@ from .utils.api import (
     clear_token,
     listen_ws,
     on_ws_status_change,
+    OFFLINE_MODE,
 )
 from .utils.loading_overlay import LoadingOverlay
 from .utils.styles import (
@@ -54,6 +55,11 @@ ws_status = (
     .classes("fixed bottom-0 left-0 m-2")
     .style("color: red")
 )
+
+if OFFLINE_MODE:
+    ui.label("OFFLINE MODE").classes(
+        "fixed bottom-0 w-full text-center bg-red-600 text-white"
+    )
 
 def _update_ws_status(status: str) -> None:
     color = "green" if status == "connected" else "red"

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -14,6 +14,8 @@ from nicegui import ui
 
 # Backend API base URL
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+# When running in offline mode network calls should be skipped
+OFFLINE_MODE = os.getenv("OFFLINE_MODE") == "1"
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -96,6 +98,15 @@ async def api_call(
         default_headers["Authorization"] = f"Bearer {TOKEN}"
 
     _fire_listeners(_start_listeners)
+
+    if OFFLINE_MODE:
+        logger.info("Offline mode: %s %s skipped", method, endpoint)
+        try:
+            ui.notify("Offline mode: request skipped", color="warning")
+        except Exception:
+            pass
+        _fire_listeners(_end_listeners)
+        return None
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -188,6 +199,10 @@ async def connect_ws(path: str = "/ws", timeout: float = 5.0):
     global WS_CONNECTION
     url = BACKEND_URL.replace("http", "ws") + path
     headers = {"Authorization": f"Bearer {TOKEN}"} if TOKEN else None
+    if OFFLINE_MODE:
+        logger.info("Offline mode: skipping WebSocket connection to %s", url)
+        _fire_ws_status("disconnected")
+        return None
     try:
         WS_CONNECTION = await asyncio.wait_for(
             websockets.connect(url, extra_headers=headers), timeout
@@ -206,6 +221,9 @@ async def listen_ws(
     """Listen for events on the WebSocket and pass them to ``handler``."""
     global WS_CONNECTION
     retry_delay = 3
+    if OFFLINE_MODE:
+        _fire_ws_status("disconnected")
+        return
     while True:
         ws = await connect_ws()
         if ws is None:

--- a/transcendental_resonance_frontend/tests/test_api.py
+++ b/transcendental_resonance_frontend/tests/test_api.py
@@ -1,5 +1,32 @@
 import inspect
-from utils.api import api_call
+import importlib
+import types
+import utils.api as api_mod
+import pytest
+
+api_call = api_mod.api_call
 
 def test_api_call_is_async():
     assert inspect.iscoroutinefunction(api_call)
+
+
+@pytest.mark.asyncio
+async def test_api_call_offline(monkeypatch):
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    api = importlib.reload(api_mod)
+    monkeypatch.setattr(api, "ui", types.SimpleNamespace(notify=lambda *a, **kw: None))
+    result = await api.api_call("GET", "/test")
+    assert result is None
+    monkeypatch.setenv("OFFLINE_MODE", "0")
+    importlib.reload(api_mod)
+
+
+@pytest.mark.asyncio
+async def test_get_user_recommendations_offline(monkeypatch):
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    api = importlib.reload(api_mod)
+    monkeypatch.setattr(api, "ui", types.SimpleNamespace(notify=lambda *a, **kw: None))
+    result = await api.get_user_recommendations()
+    assert result == []
+    monkeypatch.setenv("OFFLINE_MODE", "0")
+    importlib.reload(api_mod)


### PR DESCRIPTION
## Summary
- respect `OFFLINE_MODE` env var in frontend utils
- skip API and WebSocket calls when offline
- show banner in the UI for offline mode
- test placeholders when offline

## Testing
- `pytest transcendental_resonance_frontend/tests/test_api.py -q`
- `pytest -q` *(fails: 54 failed, 297 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68885abd4e24832097e2c0431fd7b0cf