### PR TITLE
Handle WebSocket cleanup

### DIFF
--- a/tests/test_listen_ws_cancel.py
+++ b/tests/test_listen_ws_cancel.py
@@ -1,0 +1,36 @@
+import asyncio
+import pytest
+
+import utils.api as api
+import transcendental_resonance_frontend.src.utils.api as tr_api
+
+class DummyWS:
+    def __init__(self):
+        self.closed = False
+    def __aiter__(self):
+        return self
+    async def __anext__(self):
+        await asyncio.sleep(0)
+        return '{}'
+    async def close(self):
+        self.closed = True
+
+@pytest.mark.asyncio
+async def test_listen_ws_stops_on_cancel(monkeypatch):
+    ws = DummyWS()
+    async def fake_connect_ws(*_a, **_kw):
+        return ws
+    monkeypatch.setattr(tr_api, 'connect_ws', fake_connect_ws)
+    api.WS_CONNECTION = None
+    tr_api.WS_CONNECTION = None
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    task = api.listen_ws(handle, reconnect=False)
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert ws.closed

--- a/transcendental_resonance/vibe_simulator_engine.py
+++ b/transcendental_resonance/vibe_simulator_engine.py
@@ -30,8 +30,11 @@ try:
     from transcendental_resonance_frontend.src.utils.error_overlay import ErrorOverlay
 except Exception:  # pragma: no cover - fallback when frontend not available
 
-    async def listen_ws(*_args: Any, **_kwargs: Any) -> None:
-        return None
+    def listen_ws(*_args: Any, **_kwargs: Any) -> asyncio.Task:
+        async def dummy() -> None:
+            return None
+
+        return asyncio.create_task(dummy())
 
     def on_ws_status_change(*_args: Any, **_kwargs: Any) -> None:
         return None
@@ -86,7 +89,7 @@ class VibeSimulatorEngine:
         """Begin listening for WebSocket frame metadata."""
 
         if self._listen_task is None:
-            self._listen_task = asyncio.create_task(listen_ws(self._handle_ws_event))
+            self._listen_task = listen_ws(self._handle_ws_event)
 
     async def _on_ws_status_change(self, status: str) -> None:
         self.ws_connected = status == "connected"

--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -98,7 +98,8 @@ async def notification_listener() -> None:
             message = event.get("message", "You have a new notification!")
             ui.notify(message, type="info", position="bottom-right")
 
-    await listen_ws(handle_event)
+    ws_task = listen_ws(handle_event)
+    await ws_task
 
 
 @ui.page("*")

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -124,4 +124,5 @@ async def messages_page():
             if event.get("type") == "message":
                 await refresh_messages()
 
-        ui.run_async(listen_ws(handle_event))
+        ws_task = listen_ws(handle_event)
+        ui.context.client.on_disconnect(lambda: ws_task.cancel())

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -56,4 +56,5 @@ async def notifications_page():
             if event.get("type") == "notification":
                 await refresh_notifs()
 
-        ui.run_async(listen_ws(handle_event))
+        ws_task = listen_ws(handle_event)
+        ui.context.client.on_disconnect(lambda: ws_task.cancel())

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -238,4 +238,5 @@ async def vibenodes_page():
             if event.get("type") == "vibenode_updated":
                 await refresh_vibenodes()
 
-        ui.run_async(listen_ws(handle_event))
+        ws_task = listen_ws(handle_event)
+        ui.context.client.on_disconnect(lambda: ws_task.cancel())

--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -37,7 +37,8 @@ async def video_chat_page() -> None:
                 remote_view.source = event.get("data")
 
         async def join_call() -> None:
-            await listen_ws(handle_event)
+            ws_task = listen_ws(handle_event)
+            await ws_task
 
         async def send_frame() -> None:
             if WS_CONNECTION and local_cam.value:


### PR DESCRIPTION
## Summary
- start websocket listener via `listen_ws` and return the created task
- use returned task in NiceGUI pages and cancel it on disconnect
- adjust simulator and main app to new interface
- add regression test for cancelling websocket listener

## Testing
- `pytest tests/test_listen_ws_cancel.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68885ae517488320bd2de0d05792456b