### PR TITLE
Add missing disclaimers to frontend pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/src/pages/ai_assist_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """AI assistance for VibeNodes."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Interactive debug panel for dispatching frontend routes."""
 
 from __future__ import annotations

--- a/transcendental_resonance_frontend/src/pages/forks_page.py
+++ b/transcendental_resonance_frontend/src/pages/forks_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Page to list universe forks and submit votes."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Group management page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/login_page.py
+++ b/transcendental_resonance_frontend/src/pages/login_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Login and registration pages for Transcendental Resonance."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/music_page.py
+++ b/transcendental_resonance_frontend/src/pages/music_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Interactive music generation page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/src/pages/network_analysis_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Network analysis visualization page."""
 
 import json

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Governance proposals page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/src/pages/recommendations_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Recommendations discovery page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/status_page.py
+++ b/transcendental_resonance_frontend/src/pages/status_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """System status metrics page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/src/pages/system_insights_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Detailed system insights metrics page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Media upload page."""
 
 from nicegui import ui

--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Validator graph visualization page using Plotly JS."""
 
 import json

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """VibeNodes creation and listing."""
 
 from nicegui import ui


### PR DESCRIPTION
## Summary
- add the standard three-line disclaimer to UI pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.features')*

------
https://chatgpt.com/codex/tasks/task_e_68885abed59083208d14a2a2c760a098