### PR TITLE
Fix HookManager import

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, TYPE_CHECKING
 from virtual_diary import load_entries
 from config import Config, get_emoji_weights
+from hook_manager import HookManager
 
 if TYPE_CHECKING:
     from superNova_2177 import (


### PR DESCRIPTION
## Summary
- directly import `HookManager` in `agent_core`

## Testing
- `make lint`
- `make test` *(fails: sqlalchemy errors and missing environment settings)*

------
https://chatgpt.com/codex/tasks/task_e_68885aac32348320ab5924a4749532be