### PR TITLE
Handle dynamic import failure

### DIFF
--- a/quantum_sim/ui_hook.py
+++ b/quantum_sim/ui_hook.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+import logging
 from importlib import import_module
+from typing import Any, Dict
 
 from frontend_bridge import register_route_once
 from hook_manager import HookManager
@@ -11,6 +12,8 @@ from . import quantum_prediction_engine
 
 # Shared hook manager for external modules
 ui_hook_manager = HookManager()
+logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 async def quantum_prediction_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,8 +38,13 @@ async def simulate_entanglement_ui(
     user1_id = payload["user1_id"]
     user2_id = payload["user2_id"]
 
-    module = import_module("superNova_2177")
-    simulate_social_entanglement = getattr(module, "simulate_social_entanglement")
+    try:
+        module = import_module("superNova_2177")
+        simulate_social_entanglement = getattr(module, "simulate_social_entanglement")
+    except (ImportError, AttributeError) as exc:  # pragma: no cover - logging only
+        logger.error("Entanglement simulation unavailable: %s", exc)
+        return {"error": "entanglement simulation unavailable"}
+
     result = simulate_social_entanglement(db, user1_id, user2_id)
 
     await ui_hook_manager.trigger(events.ENTANGLEMENT_SIMULATION_RUN, result)


### PR DESCRIPTION
## Summary
- improve reliability of entanglement simulation route by handling import errors
- verify quantum sim UI behaviour under error conditions

## Testing
- `pre-commit run --files quantum_sim/ui_hook.py tests/ui_hooks/test_quantum_sim_ui.py`
- `pytest tests/ui_hooks/test_quantum_sim_ui.py::test_simulate_entanglement_import_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68885a9c169c8320b5b56678e4806938