### PR TITLE
Move hooks.events import out of inner scopes

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -50,6 +50,11 @@ if TYPE_CHECKING:
 
 from moderation_utils import Vaccine
 
+try:  # pragma: no cover - optional dependency may not be available
+    from hooks import events
+except Exception:  # pragma: no cover - graceful fallback
+    events = None  # type: ignore[assignment]
+
 # Provide a minimal fallback implementation of ``LogChain`` if the real
 # class is unavailable at runtime. Tests only require ``add``,
 # ``replay_events``, ``verify`` and ``entries`` attributes.
@@ -131,8 +136,8 @@ class RemixAgent:
         # Track awarded fork badges for users
         self.fork_badges: Dict[str, list[str]] = {}
         # Register hook for cross remix creation events
-        from hooks import events
-        self.hooks.register_hook(events.CROSS_REMIX_CREATED, self.on_cross_remix_created)
+        if events is not None:
+            self.hooks.register_hook(events.CROSS_REMIX_CREATED, self.on_cross_remix_created)
         self.event_count = 0
         self.processed_nonces = {}
         self._cleanup_thread = threading.Thread(
@@ -885,10 +890,10 @@ class RemixAgent:
         )
         self.storage.set_coin(new_coin_id, new_coin.to_dict())
         # Trigger hooks after a successful cross remix
-        from hooks import events
-        self.hooks.fire_hooks(
-            events.CROSS_REMIX_CREATED, {"coin_id": new_coin_id, "user": user}
-        )
+        if events is not None:
+            self.hooks.fire_hooks(
+                events.CROSS_REMIX_CREATED, {"coin_id": new_coin_id, "user": user}
+            )
 
     def _apply_DAILY_DECAY(self, event: ApplyDailyDecayPayload) -> None:
         users = self.storage.get_all_users()

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -517,6 +517,11 @@ from hook_manager import HookManager
 from prediction_manager import PredictionManager
 from resonance_music import generate_midi_from_metrics
 
+try:  # pragma: no cover - optional dependency may not be available
+    from hooks import events
+except Exception:  # pragma: no cover - graceful fallback
+    events = None  # type: ignore[assignment]
+
 # Import system configuration early so metrics can be started with the proper
 # port value. Other modules follow the same pattern by exposing a ``CONFIG``
 # variable pointing at ``config.Config``.  Without this, ``CONFIG`` is undefined
@@ -2106,10 +2111,10 @@ class CosmicNexus:
             else:
                 logging.warning("Ignoring invalid config key %s", key)
         self.sub_universes[fork_id] = fork_agent
-        from hooks import events
-        self.hooks.register_hook(
-            events.CROSS_REMIX, lambda data: self.handle_cross_remix(data, fork_id)
-        )
+        if events is not None:
+            self.hooks.register_hook(
+                events.CROSS_REMIX, lambda data: self.handle_cross_remix(data, fork_id)
+            )
 
         # persist fork info for DAO governance
         db = self._get_session()
@@ -2281,8 +2286,7 @@ class EntropyTracker(RemixAgent):
             user = User.from_dict(user_data, self.config)
             info = calculate_interaction_entropy(user, db)
             self.current_entropy = float(info.get("value", 0.0))
-            if self.current_entropy > self.entropy_threshold:
-                from hooks import events
+            if self.current_entropy > self.entropy_threshold and events is not None:
                 self.cosmic_nexus.hooks.fire_hooks(
                     events.ENTROPY_DIVERGENCE,
                     {"universe": id(self), "entropy": self.current_entropy},

--- a/validator_reputation_tracker_ui_hook.py
+++ b/validator_reputation_tracker_ui_hook.py
@@ -6,6 +6,11 @@ from frontend_bridge import register_route_once
 from hook_manager import HookManager
 from validator_reputation_tracker import update_validator_reputations
 
+try:  # pragma: no cover - optional dependency may not be available
+    from hooks import events
+except Exception:  # pragma: no cover - graceful fallback
+    events = None  # type: ignore[assignment]
+
 ui_hook_manager = HookManager()
 
 
@@ -13,9 +18,9 @@ async def update_reputations_ui(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Update validator reputations from a UI payload."""
     validations = payload.get("validations", [])
     result = update_validator_reputations(validations)
-    from hooks import events
     minimal = {"reputations": result.get("reputations", {})}
-    await ui_hook_manager.trigger(events.VALIDATOR_REPUTATIONS, minimal)
+    if events is not None:
+        await ui_hook_manager.trigger(events.VALIDATOR_REPUTATIONS, minimal)
     return minimal
 
 


### PR DESCRIPTION
## Summary
- lift `from hooks import events` into module scope in several files
- guard each import with a fallback
- use imported `events` when available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68885a9419108320b1ea590e361f9576