### PR TITLE
Fix missing ID handling in simulate entanglement

### DIFF
--- a/quantum_sim/ui_hook.py
+++ b/quantum_sim/ui_hook.py
@@ -32,8 +32,12 @@ async def simulate_entanglement_ui(
     **_: Any,
 ) -> Dict[str, Any]:
     """Run social entanglement simulation between two users."""
-    user1_id = payload["user1_id"]
-    user2_id = payload["user2_id"]
+    user1_id = payload.get("user1_id")
+    user2_id = payload.get("user2_id")
+    if user1_id is None:
+        raise ValueError("simulate_entanglement_ui requires 'user1_id' in payload")
+    if user2_id is None:
+        raise ValueError("simulate_entanglement_ui requires 'user2_id' in payload")
 
     module = import_module("superNova_2177")
     simulate_social_entanglement = getattr(module, "simulate_social_entanglement")


### PR DESCRIPTION
## Summary
- fetch entanglement user IDs using `get`
- raise helpful errors when an ID is missing

## Testing
- `pytest -q` *(fails: AssertionError in test_agent_registry)*

------
https://chatgpt.com/codex/tasks/task_e_68885a9acba0832098c0bd283d76ba4a