### PR TITLE
Fix feed page compose dialog

### DIFF
--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -36,13 +36,7 @@ async def feed_page() -> None:
 
         feed_column = ui.column().classes('w-full')
 
-        post_dialog = ui.dialog()
-        with post_dialog:
-            with ui.card():
-                ui.label('Compose new Vibe').classes('text-lg font-bold')
-                ui.textarea('What\'s on your mind?').classes('w-full mb-2')
-                ui.button('Post').on('click', post_dialog.close)
-
+        # Floating action button for composing posts
         quick_post_button(lambda: post_dialog.open())
 
         async def refresh_feed() -> None:


### PR DESCRIPTION
## Summary
- remove the redundant compose dialog
- keep the later compose dialog and hook up the quick post button to it

## Testing
- `flake8`
- `make test` *(fails: 40 failed, 272 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68885ad6c78c8320b9b3081dceda7610