### PR TITLE
Handle join_call errors and add tests

### DIFF
--- a/tests/test_video_chat_page.py
+++ b/tests/test_video_chat_page.py
@@ -1,0 +1,114 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+class DummyCtx:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def classes(self, *args):
+        return self
+
+    def style(self, *args):
+        return self
+
+
+class DummyEl(DummyCtx):
+    def __init__(self):
+        self.value = None
+
+    def on(self, *args, **kwargs):
+        pass
+
+    def props(self, *args):
+        return self
+
+
+class StubUI:
+    def __init__(self):
+        self.notify_calls = []
+        self.button_callbacks = []
+        self.last_coro = None
+
+    def page(self, *args, **kwargs):
+        def decorator(f):
+            return f
+
+        return decorator
+
+    def camera(self):
+        return DummyEl()
+
+    def video(self):
+        return DummyEl()
+
+    def button(self, label, on_click=None, **kwargs):
+        self.button_callbacks.append((label, on_click))
+        return DummyEl()
+
+    def run_async(self, coro):
+        self.last_coro = coro
+
+    def label(self, *args, **kwargs):
+        return DummyEl()
+
+    def notify(self, msg, color=None):
+        self.notify_calls.append((msg, color))
+
+    def open(self, *args, **kwargs):
+        pass
+
+    def row(self):
+        return DummyCtx()
+
+    def column(self):
+        return DummyCtx()
+
+
+@pytest.mark.asyncio
+async def test_join_call_notifies(monkeypatch):
+    stub_ui = StubUI()
+    nicegui_mod = types.ModuleType("nicegui")
+    nicegui_mod.ui = stub_ui
+    element_mod = types.ModuleType("nicegui.element")
+    element_mod.Element = object
+    monkeypatch.setitem(sys.modules, "nicegui", nicegui_mod)
+    monkeypatch.setitem(sys.modules, "nicegui.element", element_mod)
+    monkeypatch.setitem(sys.modules, "httpx", types.ModuleType("httpx"))
+    monkeypatch.setitem(sys.modules, "websockets", types.ModuleType("websockets"))
+
+    import importlib
+    import transcendental_resonance_frontend.src.utils.layout as layout
+
+    importlib.reload(layout)
+
+    import transcendental_resonance_frontend.src.utils.api as api
+
+    async def bad_listen_ws(handler):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(api, "listen_ws", bad_listen_ws)
+    monkeypatch.setattr(api, "TOKEN", "t", raising=False)
+
+    page = importlib.reload(
+        importlib.import_module(
+            "transcendental_resonance_frontend.src.pages.video_chat_page"
+        )
+    )
+    monkeypatch.setattr(page, "listen_ws", bad_listen_ws)
+    monkeypatch.setattr(page, "TOKEN", "t", raising=False)
+
+    await page.video_chat_page()
+    join_cb = [cb for label, cb in stub_ui.button_callbacks if label == "Join Call"][0]
+    join_cb()
+    try:
+        await stub_ui.last_coro
+    except RuntimeError:
+        pass
+
+    assert ("Unable to join video chat", "negative") in stub_ui.notify_calls

--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -37,7 +37,10 @@ async def video_chat_page() -> None:
                 remote_view.source = event.get("data")
 
         async def join_call() -> None:
-            await listen_ws(handle_event)
+            try:
+                await listen_ws(handle_event)
+            except Exception:  # pragma: no cover - network issues
+                ui.notify("Unable to join video chat", color="negative")
 
         async def send_frame() -> None:
             if WS_CONNECTION and local_cam.value:
@@ -47,3 +50,6 @@ async def video_chat_page() -> None:
 
         local_cam.on("capture", lambda _: ui.run_async(send_frame()))
         ui.button("Join Call", on_click=lambda: ui.run_async(join_call()))
+        ui.label("Note: Video chat is unavailable when offline.").classes(
+            "text-xs opacity-75 mt-2"
+        )


### PR DESCRIPTION
## Summary
- handle exceptions when joining video chat and notify user
- show note that video chat doesn't work offline
- add regression test for join_call error handling

## Testing
- `pytest tests/test_video_chat_page.py::test_join_call_notifies -q`
- `pytest -q` *(fails: ModuleNotFoundError/AttributeError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68885adb1770832094dda8cc8bf198cc