### PR TITLE
Improve error handling on explore page

### DIFF
--- a/tests/test_explore_page.py
+++ b/tests/test_explore_page.py
@@ -1,0 +1,73 @@
+import pytest
+
+from contextlib import contextmanager
+
+
+class Dummy:
+    def __call__(self, *a, **k):
+        return self
+
+    def classes(self, *a, **k):
+        return self
+
+    def style(self, *a, **k):
+        return self
+
+    def on(self, *a, **k):
+        return self
+
+    def delete(self):
+        pass
+
+    def clear(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_explore_page_failure(monkeypatch):
+    xp = pytest.importorskip(
+        'transcendental_resonance_frontend.src.pages.explore_page'
+    )
+
+    monkeypatch.setattr(xp, 'TOKEN', 'tok')
+    monkeypatch.setattr(xp, 'login_page', lambda: None)
+    monkeypatch.setattr(xp, 'navigation_bar', lambda: None)
+    monkeypatch.setattr(xp, 'render_media_block', lambda *a, **k: None)
+    monkeypatch.setattr(xp, 'get_theme', lambda: {'accent': '', 'background': ''})
+
+    @contextmanager
+    def fake_page_container(theme=None):
+        yield Dummy()
+
+    monkeypatch.setattr(xp, 'page_container', fake_page_container)
+    monkeypatch.setattr(xp.ui, 'label', lambda *a, **k: Dummy())
+    monkeypatch.setattr(xp.ui, 'column', lambda *a, **k: Dummy())
+    monkeypatch.setattr(xp.ui, 'card', lambda *a, **k: Dummy())
+    monkeypatch.setattr(xp, 'skeleton_loader', lambda *a, **k: Dummy())
+    monkeypatch.setattr(xp.ui, 'run_javascript', lambda *a, **k: False)
+    monkeypatch.setattr(xp.ui, 'timer', lambda *a, **k: None)
+    monkeypatch.setattr(xp.ui, 'open', lambda *a, **k: None)
+    monkeypatch.setattr(xp.ui, 'run_async', lambda coro: None)
+
+    notified = {}
+
+    def fake_notify(msg, color=None):
+        notified['msg'] = msg
+        notified['color'] = color
+
+    monkeypatch.setattr(xp.ui, 'notify', fake_notify)
+
+    async def fake_api(*a, **k):
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr(xp, 'api_call', fake_api)
+
+    await xp.explore_page()
+
+    assert notified == {'msg': 'Failed to load posts', 'color': 'negative'}

--- a/transcendental_resonance_frontend/src/pages/explore_page.py
+++ b/transcendental_resonance_frontend/src/pages/explore_page.py
@@ -40,9 +40,16 @@ async def explore_page() -> None:
             with posts_container:
                 for _ in range(limit):
                     placeholders.append(skeleton_loader().classes("w-full h-32 mb-2"))
-            posts = await api_call("GET", "/vibenodes/trending", params) or []
+            posts = None
+            try:
+                posts = await api_call("GET", "/vibenodes/trending", params)
+            except Exception:
+                posts = None
             for p in placeholders:
                 p.delete()
+            if posts is None:
+                ui.notify('Failed to load posts', color='negative')
+                return
             if not posts:
                 return
             offset += len(posts)


### PR DESCRIPTION
## Summary
- wrap `api_call` in `explore_page.load_more` with try/except
- show notification on failure and skip rendering
- add regression test for load failure path

## Testing
- `make test` *(fails: 56 failed, 294 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68885ae6414483209e189f5b8e766bd1