### PR TITLE
Handle frontend spinner tasks via background manager

### DIFF
--- a/tests/test_background_task_spinner.py
+++ b/tests/test_background_task_spinner.py
@@ -1,0 +1,30 @@
+import asyncio
+import contextlib
+import pytest
+
+# nicegui may be a stub without background_tasks in tests
+import nicegui
+
+class DummyBG:
+    def create(self, coro, name=None):
+        return asyncio.create_task(coro)
+
+@pytest.mark.asyncio
+async def test_spinner_task_completes_without_warning(recwarn):
+    nicegui.background_tasks = DummyBG()
+    progress = 0.0
+
+    async def spin():
+        nonlocal progress
+        while progress < 0.2:
+            await asyncio.sleep(0)
+            progress += 0.1
+
+    task = nicegui.background_tasks.create(spin(), name='test')
+    try:
+        await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    assert not recwarn.list

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -1,7 +1,8 @@
 """VibeNodes creation and listing."""
 
-from nicegui import ui
+from nicegui import ui, background_tasks
 import asyncio
+import contextlib
 
 from utils.api import api_call, TOKEN, listen_ws
 from utils.styles import get_theme
@@ -49,15 +50,21 @@ async def vibenodes_page():
         async def handle_upload(event):
             with progress_container:
                 progress = ui.linear_progress(value=0).classes('w-full mb-2')
+
             async def spin():
                 while progress.value < 0.95:
                     await asyncio.sleep(0.1)
                     progress.value += 0.05
-            spinner = asyncio.create_task(spin())
-            files = {'file': (event.name, event.content.read(), 'multipart/form-data')}
-            resp = await api_call('POST', '/upload/', files=files)
-            spinner.cancel()
-            progress.value = 1.0
+
+            spinner = background_tasks.create(spin(), name='upload-progress')
+            try:
+                files = {'file': (event.name, event.content.read(), 'multipart/form-data')}
+                resp = await api_call('POST', '/upload/', files=files)
+            finally:
+                spinner.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await spinner
+                progress.value = 1.0
             if resp:
                 uploaded_media['url'] = resp.get('media_url')
                 uploaded_media['type'] = resp.get('media_type')


### PR DESCRIPTION
## Summary
- use `background_tasks.create` for upload spinners
- cancel and await spinner tasks in `finally` blocks
- test that background tasks cleanup yields no warnings

## Testing
- `pytest -q tests/test_background_task_spinner.py`

------
https://chatgpt.com/codex/tasks/task_e_68885ae8c0748320908e64c3df716494