### PR TITLE
Fix UI entrypoint for Streamlit Cloud

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
   },
   "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
   "postAttachCommand": {
-    "server": "streamlit run ui.py --server.enableCORS false --server.enableXsrfProtection false"
+    "server": "streamlit run transcendental_resonance_frontend/ui.py --server.enableCORS false --server.enableXsrfProtection false"
   },
   "portsAttributes": {
     "8888": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Streamlit smoke test
         run: |
           PORT=${STREAMLIT_PORT:-8888}
-          streamlit run ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
+          streamlit run transcendental_resonance_frontend/ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
           for i in {1..30}; do
             if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Streamlit smoke test
         run: |
           PORT=${STREAMLIT_PORT:-8888}
-          streamlit run ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
+          streamlit run transcendental_resonance_frontend/ui.py --server.headless true --server.port "$PORT" >streamlit.log 2>&1 &
           for i in {1..20}; do
             if curl -f http://localhost:"$PORT" >/dev/null 2>&1; then
               echo "Streamlit started after $i seconds"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ USER appuser
 EXPOSE 8888
 
 # Launch Streamlit UI explicitly
-CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8888", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "transcendental_resonance_frontend/ui.py", "--server.port=8888", "--server.address=0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ lint:
 	mypy
 
 ui:
-	streamlit run streamlit_app.py
+        streamlit run transcendental_resonance_frontend/ui.py

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ chmod +x start.sh
 ./start.sh
 ```
 
-This script will find and launch `ui.py` automatically from any directory in the repo.
+This script launches `transcendental_resonance_frontend/ui.py` automatically from any directory in the repo.
 
 ## ☁️ Launch Online
 
@@ -356,7 +356,7 @@ module falls back to a development setup equivalent to:
 The dashboard provides real-time integrity metrics and network graphs built with `streamlit`, `networkx`, and `matplotlib`. Upload your validations JSON or enable demo mode to populate the table. You can edit rows inline before re-running the analysis to see how scores change.
 
 ```bash
-streamlit run streamlit_app.py
+streamlit run transcendental_resonance_frontend/ui.py
 ```
 
 Use the sidebar file uploader to select or update your dataset, then click **Run Analysis** to refresh the report.
@@ -408,7 +408,7 @@ Deploy the demo UI online with Streamlit Cloud:
 
 1. Fork this repository on GitHub.
 2. Sign in to [Streamlit Cloud](https://streamlit.io/cloud) and select **New app**.
-3. Choose the repo and set `streamlit_app.py` as the entry point.
+3. Choose the repo and set `transcendental_resonance_frontend/ui.py` as the entry point.
 4. Add your `SECRET_KEY` and set a `DATABASE_URL` secret with your connection string under **Secrets** in the app settings.
 5. Streamlit will install dependencies from `requirements-streamlit.txt` and launch the app.
 

--- a/launch_ui.sh
+++ b/launch_ui.sh
@@ -2,5 +2,5 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-streamlit run streamlit_app.py
+streamlit run transcendental_resonance_frontend/ui.py
 

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -18,7 +18,9 @@ asyncpg
 streamlit-ace
 kaleido
 websockets
+nicegui
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ kaleido
 websockets
 plotly
 pyvis
+nicegui

--- a/start.sh
+++ b/start.sh
@@ -3,11 +3,11 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-# Dynamically find ui.py and launch it
-UI_FILE=$(find . -type f -name "ui.py" | head -n 1)
+# Launch the NiceGUI wrapper for Streamlit Cloud
+UI_FILE="transcendental_resonance_frontend/ui.py"
 
-if [[ -z "$UI_FILE" ]]; then
-  echo "❌ ui.py not found. Please ensure it exists." >&2
+if [[ ! -f "$UI_FILE" ]]; then
+  echo "❌ $UI_FILE not found. Please ensure it exists." >&2
   exit 1
 fi
 

--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -1,0 +1,14 @@
+"""Streamlit entry point to launch the NiceGUI-based Transcendental Resonance UI."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Importing the package starts the NiceGUI app via src.main
+import_module("transcendental_resonance_frontend")


### PR DESCRIPTION
## Summary
- add `nicegui` to requirements
- create Streamlit wrapper `transcendental_resonance_frontend/ui.py`
- point Dockerfile, scripts and workflows to new entrypoint
- document new launch command in README

## Testing
- `pre-commit run --files requirements.txt requirements-streamlit.txt Dockerfile launch_ui.sh start.sh Makefile .devcontainer/devcontainer.json .github/workflows/ci.yml .github/workflows/pr-tests.yml README.md transcendental_resonance_frontend/ui.py`
- `pytest -q` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888656e28b48320ada0ec0eabce9c0f