### PR TITLE
Register NiceGUI pages on startup

### DIFF
--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -1,0 +1,7 @@
+"""Launch the Transcendental Resonance NiceGUI app."""
+
+from .src.pages import *  # noqa: F401,F403 - register page decorators
+from .src.main import run_app  # provides the run loop and additional setup
+
+if __name__ == "__main__":
+    run_app()


### PR DESCRIPTION
## Summary
- add new `ui.py` entrypoint under `transcendental_resonance_frontend`
  that imports all NiceGUI pages so their `@ui.page` decorators execute
- delegate to `run_app()` from `src.main` which calls `ui.run()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit', SyntaxError in NiceGUI modules)*

------
https://chatgpt.com/codex/tasks/task_e_688866c026688320a3c14438791e099a