### PR TITLE
Adjust UI startup paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ USER appuser
 EXPOSE 8888
 
 # Launch Streamlit UI explicitly
-CMD ["streamlit", "run", "transcendental_resonance_frontend/ui.py", "--server.port=8888", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "ui.py", "--server.port=8888", "--server.address=0.0.0.0"]

--- a/launch_ui.sh
+++ b/launch_ui.sh
@@ -2,5 +2,5 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-streamlit run transcendental_resonance_frontend/ui.py
+streamlit run ui.py
 


### PR DESCRIPTION
## Summary
- simplify launch path for the UI
- run Streamlit from `ui.py` in Docker builds
- update helper script to use new entry point

## Testing
- `pre-commit run --files Dockerfile launch_ui.sh start.sh`
- `pytest -q` *(fails: SyntaxError in transcendental_resonance_frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68886b0020a08320956d6657765059c4