### PR TITLE
Fix Streamlit package path

### DIFF
--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -6,9 +6,15 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
+
+# Ensure we can import the package whether launched locally or on Streamlit Cloud
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+PKG_DIR = ROOT / "transcendental_resonance_frontend"
+SRC_DIR = PKG_DIR / "src"
+
+for path in (ROOT, PKG_DIR, SRC_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 # Importing the package starts the NiceGUI app via src.main
 import_module("transcendental_resonance_frontend")


### PR DESCRIPTION
## Summary
- ensure the Transcendental Resonance frontend can be imported when run via Streamlit

## Testing
- `python -m compileall transcendental_resonance_frontend`
- `pytest transcendental_resonance_frontend/tests/test_pages_init_imports.py::test_register_page_importable -q` *(fails: SyntaxError in api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68886bdd4e908320a7ea65fcab8c0dc0