### PR TITLE
Fix Streamlit frontend module import

### DIFF
--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -10,5 +10,5 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Importing the package starts the NiceGUI app via src.main
-import_module("transcendental_resonance_frontend")
+# Import the package's ``__main__`` module which launches the NiceGUI app
+import_module("transcendental_resonance_frontend.__main__")


### PR DESCRIPTION
## Summary
- run `__main__` of `transcendental_resonance_frontend` so the NiceGUI UI launches

## Testing
- `python - <<'PY'
import importlib, sys
from pathlib import Path
ROOT = Path('transcendental_resonance_frontend/ui.py').resolve().parents[1]
sys.path.insert(0, str(ROOT))
importlib.import_module('transcendental_resonance_frontend.__main__')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68886be527a483209e5e3c9de12f40a2