### PR TITLE
Remove NiceGUI build steps

### DIFF
--- a/install/install_android.sh
+++ b/install/install_android.sh
@@ -15,13 +15,12 @@ pip install -r requirements.txt
 FRONTEND_DIR=transcendental_resonance_frontend
 if [ -d "$FRONTEND_DIR" ]; then
     pip install -r "$FRONTEND_DIR/requirements.txt"
-    nicegui "$FRONTEND_DIR/src/main.py" --port 8080 &
 fi
 uvicorn superNova_2177:app --host 0.0.0.0 --port 8000 &
 sleep 2
 python - <<'PY'
 import qrcode, os
-url = 'http://'+os.popen('ip addr show wlan0 | grep "inet "').read().split()[1].split('/')[0]+':8080'
+url = 'http://'+os.popen('ip addr show wlan0 | grep "inet "').read().split()[1].split('/')[0]+':8000'
 print('Scan to open:', url)
 qrcode.make(url).print_ascii(invert=True)
 PY

--- a/install/install_desktop.bat
+++ b/install/install_desktop.bat
@@ -9,8 +9,7 @@ pip install -r requirements.txt
 set FRONTEND_DIR=transcendental_resonance_frontend
 if exist %FRONTEND_DIR% (
     pip install -r %FRONTEND_DIR%\requirements.txt
-    start nicegui %FRONTEND_DIR%\src\main.py
 )
 start uvicorn superNova_2177:app --reload
 timeout /t 2
-start http://localhost:8080
+start http://localhost:8000

--- a/install/install_desktop.sh
+++ b/install/install_desktop.sh
@@ -16,8 +16,7 @@ pip install -r requirements.txt
 FRONTEND_DIR=transcendental_resonance_frontend
 if [ -d "$FRONTEND_DIR" ]; then
     pip install -r "$FRONTEND_DIR/requirements.txt"
-    nicegui "$FRONTEND_DIR/src/main.py" &
 fi
 uvicorn superNova_2177:app --reload &
 sleep 2
-xdg-open http://localhost:8080 || open http://localhost:8080
+xdg-open http://localhost:8000 || open http://localhost:8000

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -18,7 +18,6 @@ asyncpg
 streamlit-ace
 kaleido
 websockets
-nicegui
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,3 @@ kaleido
 websockets
 plotly
 pyvis
-nicegui

--- a/setup_env.py
+++ b/setup_env.py
@@ -78,7 +78,7 @@ def run_ui() -> None:
 
 
 def build_frontend(pip: list) -> None:
-    """Install UI deps and build the Transcendental Resonance frontend."""
+    """Install UI dependencies for the Transcendental Resonance frontend."""
     frontend_dir = Path('transcendental_resonance_frontend')
     ui_reqs = frontend_dir / 'requirements.txt'
     if ui_reqs.is_file():
@@ -88,14 +88,6 @@ def build_frontend(pip: list) -> None:
             logging.error('Failed to install UI dependencies: %s', exc)
             logging.error('Check your internet connection and try again.')
             raise
-    ui_script = frontend_dir / 'src' / 'main.py'
-    nicegui = [venv_bin('nicegui')] if not in_virtualenv() else ['nicegui']
-    try:
-        subprocess.check_call(nicegui + ['build', str(ui_script)])
-    except subprocess.CalledProcessError as exc:
-        logging.error('Failed to build the frontend: %s', exc)
-        logging.error('Ensure Node.js and NiceGUI are properly installed.')
-        raise
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- drop NiceGUI from requirements files
- remove NiceGUI build step from `setup_env.py`
- adjust install scripts to no longer run the NiceGUI frontend

## Testing
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68886b2213cc8320be330575451af47e