### PR TITLE
Add Streamlit page placeholders

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -1,0 +1,2 @@
+Streamlit pages for Transcendental Resonance.
+

--- a/transcendental_resonance_frontend/pages/ai_assist.py
+++ b/transcendental_resonance_frontend/pages/ai_assist.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Ai Assist")
+st.markdown("Streamlit version of `ai_assist` page.")

--- a/transcendental_resonance_frontend/pages/debug_panel.py
+++ b/transcendental_resonance_frontend/pages/debug_panel.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Debug Panel")
+st.markdown("Streamlit version of `debug_panel` page.")

--- a/transcendental_resonance_frontend/pages/events.py
+++ b/transcendental_resonance_frontend/pages/events.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Events")
+st.markdown("Streamlit version of `events` page.")

--- a/transcendental_resonance_frontend/pages/explore.py
+++ b/transcendental_resonance_frontend/pages/explore.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Explore")
+st.markdown("Streamlit version of `explore` page.")

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Feed")
+st.markdown("Streamlit version of `feed` page.")

--- a/transcendental_resonance_frontend/pages/forks.py
+++ b/transcendental_resonance_frontend/pages/forks.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Forks")
+st.markdown("Streamlit version of `forks` page.")

--- a/transcendental_resonance_frontend/pages/groups.py
+++ b/transcendental_resonance_frontend/pages/groups.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Groups")
+st.markdown("Streamlit version of `groups` page.")

--- a/transcendental_resonance_frontend/pages/login.py
+++ b/transcendental_resonance_frontend/pages/login.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Login")
+st.markdown("Streamlit version of `login` page.")

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Messages")
+st.markdown("Streamlit version of `messages` page.")

--- a/transcendental_resonance_frontend/pages/music.py
+++ b/transcendental_resonance_frontend/pages/music.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Music")
+st.markdown("Streamlit version of `music` page.")

--- a/transcendental_resonance_frontend/pages/network_analysis.py
+++ b/transcendental_resonance_frontend/pages/network_analysis.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Network Analysis")
+st.markdown("Streamlit version of `network_analysis` page.")

--- a/transcendental_resonance_frontend/pages/notifications.py
+++ b/transcendental_resonance_frontend/pages/notifications.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Notifications")
+st.markdown("Streamlit version of `notifications` page.")

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Profile")
+st.markdown("Streamlit version of `profile` page.")

--- a/transcendental_resonance_frontend/pages/proposals.py
+++ b/transcendental_resonance_frontend/pages/proposals.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Proposals")
+st.markdown("Streamlit version of `proposals` page.")

--- a/transcendental_resonance_frontend/pages/recommendations.py
+++ b/transcendental_resonance_frontend/pages/recommendations.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Recommendations")
+st.markdown("Streamlit version of `recommendations` page.")

--- a/transcendental_resonance_frontend/pages/register.py
+++ b/transcendental_resonance_frontend/pages/register.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Register")
+st.markdown("Streamlit version of the registration page.")

--- a/transcendental_resonance_frontend/pages/status.py
+++ b/transcendental_resonance_frontend/pages/status.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Status")
+st.markdown("Streamlit version of `status` page.")

--- a/transcendental_resonance_frontend/pages/system_insights.py
+++ b/transcendental_resonance_frontend/pages/system_insights.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("System Insights")
+st.markdown("Streamlit version of `system_insights` page.")

--- a/transcendental_resonance_frontend/pages/upload.py
+++ b/transcendental_resonance_frontend/pages/upload.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Upload")
+st.markdown("Streamlit version of `upload` page.")

--- a/transcendental_resonance_frontend/pages/validator_graph.py
+++ b/transcendental_resonance_frontend/pages/validator_graph.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Validator Graph")
+st.markdown("Streamlit version of `validator_graph` page.")

--- a/transcendental_resonance_frontend/pages/vibenodes.py
+++ b/transcendental_resonance_frontend/pages/vibenodes.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Vibenodes")
+st.markdown("Streamlit version of `vibenodes` page.")

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Video Chat")
+st.markdown("Streamlit version of `video_chat` page.")

--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -1,4 +1,4 @@
-"""Streamlit entry point to launch the NiceGUI-based Transcendental Resonance UI."""
+"""Streamlit entry point for the Transcendental Resonance UI."""
 
 from __future__ import annotations
 
@@ -6,9 +6,17 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
+import streamlit as st
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Importing the package starts the NiceGUI app via src.main
-import_module("transcendental_resonance_frontend")
+PAGES_DIR = Path(__file__).resolve().parent / "pages"
+page_names = sorted(p.stem for p in PAGES_DIR.glob("*.py"))
+
+st.sidebar.title("Navigation")
+choice = st.sidebar.selectbox("Page", page_names)
+
+if choice:
+    import_module(f"transcendental_resonance_frontend.pages.{choice}")

--- a/utils/features.py
+++ b/utils/features.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.features import *  # noqa: F401,F403

--- a/utils/safe_markdown.py
+++ b/utils/safe_markdown.py
@@ -1,0 +1,1 @@
+from transcendental_resonance_frontend.src.utils.safe_markdown import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- create pages directory with simple Streamlit versions of NiceGUI pages
- expose util modules for `features` and `safe_markdown`
- add a sidebar-based page selector in `transcendental_resonance_frontend/ui.py`

## Testing
- `pytest -q` *(fails: 56 failed, 285 passed, 37 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68886b079fa08320b93c48b408ad8e24