### PR TITLE
Enable multipage Streamlit UI

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -1,0 +1,8 @@
+"""Streamlit page modules."""
+
+__all__ = [
+    "validation",
+    "social",
+    "voting",
+    "agents",
+]

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,0 +1,5 @@
+"""Agent insights page."""
+from agent_ui import render_agent_insights_tab
+
+def main() -> None:
+    render_agent_insights_tab()

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -1,0 +1,5 @@
+"""Friends & Followers page."""
+from social_tabs import render_social_tab
+
+def main() -> None:
+    render_social_tab()

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -1,0 +1,5 @@
+"""Validation analysis page."""
+from ui import render_validation_ui
+
+def main() -> None:
+    render_validation_ui()

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -1,0 +1,5 @@
+"""Governance and voting page."""
+from voting_ui import render_voting_tab
+
+def main() -> None:
+    render_voting_tab()

--- a/utils/features.py
+++ b/utils/features.py
@@ -1,0 +1,2 @@
+"""Compatibility passthrough for frontend features."""
+from transcendental_resonance_frontend.src.utils.features import *  # noqa: F401,F403

--- a/utils/safe_markdown.py
+++ b/utils/safe_markdown.py
@@ -1,0 +1,2 @@
+"""Compatibility passthrough for safe_markdown."""
+from transcendental_resonance_frontend.src.utils.safe_markdown import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add Streamlit page modules under `transcendental_resonance_frontend/pages`
- expose page loader through `PAGES_DIR` and `import_module`
- provide passthroughs for frontend utilities in `utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68886e5a7e308320aaf0e5791a65690c