### PR TITLE
Fix Streamlit port binding

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -26,6 +26,9 @@ Network = None  # imported lazily in run_analysis
 # Import Streamlit and register fallback health check
 import streamlit as st
 
+# Bind to the default Streamlit port to satisfy platform health checks
+os.environ["STREAMLIT_SERVER_PORT"] = "8501"
+
 # Name of the query parameter used for the CI health check. Adjust here if the
 # health check endpoint ever changes.
 HEALTH_CHECK_PARAM = "healthz"


### PR DESCRIPTION
## Summary
- set `STREAMLIT_SERVER_PORT` within `ui.py`

## Testing
- `pytest -q` *(fails: SyntaxError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_688878b50ba8832080d189db69f8b9d3