### PR TITLE
Fix UI launcher

### DIFF
--- a/transcendental_resonance_frontend/__main__.py
+++ b/transcendental_resonance_frontend/__main__.py
@@ -1,4 +1,14 @@
 """Entry point for ``python -m transcendental_resonance_frontend``."""
 
-# Importing ``main`` starts the NiceGUI application.
-from .src import main  # noqa: F401
+from nicegui import ui
+
+
+def run() -> None:
+    """Launch the NiceGUI interface."""
+    ui.label("Loading UI...")
+    from .src.main import run_app
+    run_app()
+
+
+if __name__ == "__main__":
+    run()

--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -183,4 +183,6 @@ def run_app() -> None:
             time.sleep(2)
 
 
-run_app()
+
+if __name__ == "__main__":
+    run_app()

--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib import import_module
 from pathlib import Path
 
 import streamlit as st
@@ -26,5 +25,7 @@ if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO",
     st.write("ok")
     st.stop()
 
-# Import the package's ``__main__`` module which launches the NiceGUI app
-import_module("transcendental_resonance_frontend.__main__")
+# Import and run the package's launcher
+from transcendental_resonance_frontend.__main__ import run
+
+run()


### PR DESCRIPTION
## Summary
- expose `run()` in `transcendental_resonance_frontend.__main__`
- call `run()` from Streamlit entrypoint
- guard `run_app()` in `src.main`

## Testing
- `pytest tests/ui/test_ui_healthz.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68887a1c168483208aef08173d922b95