### PR TITLE
Fix UI launch entrypoints

### DIFF
--- a/transcendental_resonance_frontend/__main__.py
+++ b/transcendental_resonance_frontend/__main__.py
@@ -1,4 +1,16 @@
 """Entry point for ``python -m transcendental_resonance_frontend``."""
 
-# Importing ``main`` starts the NiceGUI application.
-from .src import main  # noqa: F401
+from nicegui import ui
+
+from .src import main as frontend_main
+
+
+def run() -> None:
+    """Launch the NiceGUI frontend."""
+    # Ensure at least one element is created before starting
+    ui.label("Launching frontend...")
+    frontend_main.run_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    run()

--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -183,4 +183,5 @@ def run_app() -> None:
             time.sleep(2)
 
 
-run_app()
+if __name__ == "__main__":  # pragma: no cover - manual run
+    run_app()

--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib import import_module
 from pathlib import Path
 
 import streamlit as st
@@ -26,5 +25,7 @@ if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO",
     st.write("ok")
     st.stop()
 
-# Import the package's ``__main__`` module which launches the NiceGUI app
-import_module("transcendental_resonance_frontend.__main__")
+# Import and launch the NiceGUI application
+from transcendental_resonance_frontend.__main__ import run
+
+run()


### PR DESCRIPTION
## Summary
- expose `run()` in `transcendental_resonance_frontend.__main__`
- call `run()` from the streamlit entrypoint
- allow `src.main` to be imported without starting the server

## Testing
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68887a1c168483208aef08173d922b95