### PR TITLE
Fix UI bootstrap by exposing run()

### DIFF
--- a/transcendental_resonance_frontend/__main__.py
+++ b/transcendental_resonance_frontend/__main__.py
@@ -1,4 +1,16 @@
 """Entry point for ``python -m transcendental_resonance_frontend``."""
 
-# Importing ``main`` starts the NiceGUI application.
-from .src import main  # noqa: F401
+from nicegui import ui
+
+from .src import main
+
+
+def run() -> None:
+    """Launch the NiceGUI-based frontend."""
+    # Ensure at least one element is created before starting the app
+    ui.label("Launching Transcendental Resonance UI...")
+    main.run_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run()

--- a/transcendental_resonance_frontend/ui.py
+++ b/transcendental_resonance_frontend/ui.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib import import_module
 from pathlib import Path
 
 import streamlit as st
-
 
 HEALTH_CHECK_PARAM = "healthz"
 
@@ -22,9 +20,14 @@ for path in (ROOT, PKG_DIR, SRC_DIR):
         sys.path.insert(0, str(path))
 
 # Respond quickly to Cloud health probes before importing heavy modules
-if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO", "").rstrip("/") == "/healthz":
+if (
+    st.query_params.get(HEALTH_CHECK_PARAM) == "1"
+    or os.environ.get("PATH_INFO", "").rstrip("/") == "/healthz"
+):
     st.write("ok")
     st.stop()
 
-# Import the package's ``__main__`` module which launches the NiceGUI app
-import_module("transcendental_resonance_frontend.__main__")
+# Import and execute the NiceGUI launcher
+from transcendental_resonance_frontend.__main__ import run  # noqa: E402
+
+run()


### PR DESCRIPTION
## Summary
- create a `run()` helper in `transcendental_resonance_frontend.__main__`
- call `run()` from the Streamlit entry point instead of just importing the module

## Testing
- `pre-commit run --files transcendental_resonance_frontend/__main__.py transcendental_resonance_frontend/ui.py`
- `pytest tests/ui/test_ui_healthz.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68887a1c168483208aef08173d922b95