### PR TITLE
Improve healthz logging

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -878,7 +878,8 @@ def main() -> None:
     st.set_page_config(page_title="superNova_2177", layout="wide")
 
     if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO", "").rstrip("/") == "/healthz":
-        print("[debug] healthz check", file=sys.stderr)
+        # Explicit console log for monitoring the health check endpoint
+        print("[DEBUG] healthz request served")
         st.write("ok")
         return
 


### PR DESCRIPTION
## Summary
- log when the `/?healthz=1` endpoint is used

## Testing
- `pytest tests/test_ui_launch.py::test_ui_healthz_query -q` *(fails: assert HTML response instead of `ok`)*

------
https://chatgpt.com/codex/tasks/task_e_6888959c1e608320a6e919773f9ff24b