### PR TITLE
Fix default Streamlit port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ The dashboard provides real-time integrity metrics and network graphs built with
 ```bash
 streamlit run ui.py
 ```
+By default the demo listens on port `8888`. Set `STREAMLIT_PORT` or pass
+`--server.port` to use a different port.
 
 Use the sidebar file uploader to select or update your dataset, then click **Run Analysis** to refresh the report.
 Missing packages such as `tqdm` are installed automatically when you run `one_click_install.py` so progress bars work without extra setup.
@@ -369,7 +371,7 @@ Missing packages such as `tqdm` are installed automatically when you run `one_cl
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run
   `pip install -r requirements-streamlit.txt` to ensure all packages are available.
 - **Port already in use**: Pass `--server.port` to Streamlit or set the
-  `STREAMLIT_SERVER_PORT` environment variable to use a different port.
+  `STREAMLIT_PORT` environment variable to use a different port.
 - **Browser does not open**: Navigate manually to
   [http://localhost:8888](http://localhost:8888) or the port you selected.
 

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,8 @@ if [[ ! -f "$UI_FILE" ]]; then
   exit 1
 fi
 
+# Listen on port 8888 by default. Set STREAMLIT_PORT or pass --server.port
+# to override this value.
 PORT="${STREAMLIT_PORT:-${PORT:-8888}}"
 
 echo "🚀 Launching Streamlit UI: $UI_FILE on port $PORT"

--- a/ui.py
+++ b/ui.py
@@ -14,13 +14,15 @@ import os
 import sys
 import traceback
 
-os.environ["STREAMLIT_SERVER_PORT"] = "8501"
+# Default port controlled by start.sh via STREAMLIT_PORT; old setting kept
+# for reference but disabled.
+# os.environ["STREAMLIT_SERVER_PORT"] = "8501"
 from datetime import datetime
 from pathlib import Path
 from importlib import import_module
 import time
 
-os.environ["STREAMLIT_SERVER_PORT"] = "8501"
+# os.environ["STREAMLIT_SERVER_PORT"] = "8501"
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -36,7 +38,7 @@ os.environ["STREAMLIT_WATCHER_TYPE"] = "poll"
 import streamlit as st
 
 # Bind to the default Streamlit port to satisfy platform health checks
-os.environ["STREAMLIT_SERVER_PORT"] = "8501"
+# os.environ["STREAMLIT_SERVER_PORT"] = "8501"
 
 # Name of the query parameter used for the CI health check. Adjust here if the
 # health check endpoint ever changes.


### PR DESCRIPTION
## Summary
- emphasize running `streamlit run ui.py` on port 8888
- note how to override the port in `start.sh` and docs
- remove hardcoded port settings in `ui.py`

## Testing
- `pytest -q` *(fails: KeyError: 'fetch_diary_entries', ...)*

------
https://chatgpt.com/codex/tasks/task_e_688895b0a9588320912537e0402edde2