### PR TITLE
Add debug prints toggle for UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ Missing packages such as `tqdm` are installed automatically when you run `one_cl
   `STREAMLIT_SERVER_PORT` environment variable to use a different port.
 - **Browser does not open**: Navigate manually to
   [http://localhost:8888](http://localhost:8888) or the port you selected.
+- **Disable debug prints**: Set `UI_DEBUG_PRINTS=0` in your environment to silence
+  startup logging from `ui.py`.
 
 ### CI Health Check
 


### PR DESCRIPTION
## Summary
- add environment variable `UI_DEBUG_PRINTS` to control Streamlit debug logging
- print `UI up` and log when UI rendered and when pages load
- document how to disable debug prints in README

## Testing
- `pytest -q` *(fails: 65 failed, 312 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688895a8ca54832090db9f2297ae3782