### PR TITLE
Add env toggle for UI debug prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ Missing packages such as `tqdm` are installed automatically when you run `one_cl
   `STREAMLIT_PORT` environment variable to use a different port.
 - **Browser does not open**: Navigate manually to
   [http://localhost:8888](http://localhost:8888) or the port you selected.
+- **Disable debug prints**: Set `UI_DEBUG_PRINTS=0` in your environment to silence
+  startup logging from `ui.py`.
 
 ### CI Health Check
 

--- a/ui.py
+++ b/ui.py
@@ -55,7 +55,8 @@ def dprint(msg: str) -> None:
     if DEBUG_MODE:
         print(msg, file=sys.stderr)
 
-dprint("\u23F3 Booting superNova_2177 UI...")
+if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+    print("\u23F3 Booting superNova_2177 UI...", file=sys.stderr)
 from streamlit_helpers import (
     alert,
     apply_theme,
@@ -879,35 +880,39 @@ def render_validation_ui() -> None:
 
 def main() -> None:
     import streamlit as st
-    dprint("main() invoked")
+    def log(msg: str) -> None:
+        if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+            print(msg, file=sys.stderr)
+
+    log("main() invoked")
     st.title("🤗//⚡//Launching main()")
     import streamlit as st
     import os
     from importlib import import_module
 
     st.set_page_config(page_title="superNova_2177", layout="wide")
-    dprint("main() entered")
+    log("main() entered")
 
     if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO", "").rstrip("/") == "/healthz":
-        dprint("health-check branch")
+        log("health-check branch")
         st.write("ok")
         return
 
-    dprint(f"loading pages from {PAGES_DIR}")
+    log(f"loading pages from {PAGES_DIR}")
     if not PAGES_DIR.is_dir():
-        dprint("pages directory missing")
+        log("pages directory missing")
         st.error("Pages directory not found")
         render_landing_page()
         return
     else:
-        dprint("pages directory found")
+        log("pages directory found")
 
     page_files = sorted(
         p.stem for p in PAGES_DIR.glob("*.py") if p.name != "__init__.py"
     )
 
     if not page_files:
-        dprint("pages directory empty")
+        log("pages directory empty")
         st.warning("No pages available — showing fallback UI.")
         render_landing_page()
         return
@@ -915,7 +920,7 @@ def main() -> None:
     render_main_ui()  # This shows sidebar etc.
 
     choice = st.sidebar.selectbox("Page", page_files)
-    dprint(f"loading page {choice}")
+    log(f"loading page {choice}")
     try:
         module = import_module(
             f"transcendental_resonance_frontend.pages.{choice}"
@@ -923,14 +928,14 @@ def main() -> None:
         page_main = getattr(module, "main", None)
         if callable(page_main):
             page_main()
-            dprint(f"page {choice} loaded")
+            log(f"page {choice} loaded")
         else:
             st.error(f"Page '{choice}' is missing a main() function.")
     except Exception as e:
         import traceback
         st.error(f"Error loading page '{choice}':")
         st.text("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-        dprint(f"exception loading {choice}: {e}")
+        log(f"exception loading {choice}: {e}")
 
 
 
@@ -951,7 +956,11 @@ if __name__ == "__main__":
     if args.debug:
         DEBUG_MODE = True
 
-    dprint("__main__ entry")
+    def log(msg: str) -> None:
+        if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+            print(msg, file=sys.stderr)
+
+    log("__main__ entry")
 
     try:
         main()
@@ -959,5 +968,5 @@ if __name__ == "__main__":
         import traceback
         st.write("App failed with exception:")
         st.text("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-        dprint(f"fatal error: {e}")
+        log(f"fatal error: {e}")
         raise


### PR DESCRIPTION
## Summary
- add a universal `UI_DEBUG_PRINTS` env check to silence debug prints
- log boot message only when enabled
- document how to disable debug output in README

## Testing
- `pytest -q` *(fails: AttributeError & ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6888998a74bc832090ace66565294f63