### PR TITLE
Add toggle for UI debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ Missing packages such as `tqdm` are installed automatically when you run `one_cl
   `STREAMLIT_PORT` environment variable to use a different port.
 - **Browser does not open**: Navigate manually to
   [http://localhost:8888](http://localhost:8888) or the port you selected.
+- **Disable debug prints**: Set `UI_DEBUG_PRINTS=0` in your environment to silence
+  startup logging from `ui.py`.
 
 ### CI Health Check
 

--- a/ui.py
+++ b/ui.py
@@ -47,15 +47,9 @@ HEALTH_CHECK_PARAM = "healthz"
 # Directory containing Streamlit page modules
 PAGES_DIR = Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages"
 
-# Toggle verbose output via env var
-DEBUG_MODE = os.getenv("DEBUG_UI", "").lower() in {"1", "true", "yes"}
-
-def dprint(msg: str) -> None:
-    """Print debug message if ``DEBUG_UI`` is enabled."""
-    if DEBUG_MODE:
-        print(msg, file=sys.stderr)
-
-dprint("\u23F3 Booting superNova_2177 UI...")
+# Toggle verbose output via env var used during startup
+if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+    print("\u23F3 Booting superNova_2177 UI...", file=sys.stderr)
 from streamlit_helpers import (
     alert,
     apply_theme,
@@ -879,35 +873,39 @@ def render_validation_ui() -> None:
 
 def main() -> None:
     import streamlit as st
-    dprint("main() invoked")
+
+    def log(msg: str) -> None:
+        if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+            print(msg, file=sys.stderr)
+
+    log("main() invoked")
     st.title("🤗//⚡//Launching main()")
-    import streamlit as st
     import os
     from importlib import import_module
 
     st.set_page_config(page_title="superNova_2177", layout="wide")
-    dprint("main() entered")
+    log("main() entered")
 
     if st.query_params.get(HEALTH_CHECK_PARAM) == "1" or os.environ.get("PATH_INFO", "").rstrip("/") == "/healthz":
-        dprint("health-check branch")
+        log("health-check branch")
         st.write("ok")
         return
 
-    dprint(f"loading pages from {PAGES_DIR}")
+    log(f"loading pages from {PAGES_DIR}")
     if not PAGES_DIR.is_dir():
-        dprint("pages directory missing")
+        log("pages directory missing")
         st.error("Pages directory not found")
         render_landing_page()
         return
     else:
-        dprint("pages directory found")
+        log("pages directory found")
 
     page_files = sorted(
         p.stem for p in PAGES_DIR.glob("*.py") if p.name != "__init__.py"
     )
 
     if not page_files:
-        dprint("pages directory empty")
+        log("pages directory empty")
         st.warning("No pages available — showing fallback UI.")
         render_landing_page()
         return
@@ -915,7 +913,7 @@ def main() -> None:
     render_main_ui()  # This shows sidebar etc.
 
     choice = st.sidebar.selectbox("Page", page_files)
-    dprint(f"loading page {choice}")
+    log(f"loading page {choice}")
     try:
         module = import_module(
             f"transcendental_resonance_frontend.pages.{choice}"
@@ -923,14 +921,14 @@ def main() -> None:
         page_main = getattr(module, "main", None)
         if callable(page_main):
             page_main()
-            dprint(f"page {choice} loaded")
+            log(f"page {choice} loaded")
         else:
             st.error(f"Page '{choice}' is missing a main() function.")
     except Exception as e:
         import traceback
         st.error(f"Error loading page '{choice}':")
         st.text("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-        dprint(f"exception loading {choice}: {e}")
+        log(f"exception loading {choice}: {e}")
 
 
 
@@ -949,9 +947,10 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action="store_true", help="Enable verbose logs")
     args = parser.parse_args()
     if args.debug:
-        DEBUG_MODE = True
+        os.environ["UI_DEBUG_PRINTS"] = "1"
 
-    dprint("__main__ entry")
+    if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+        print("__main__ entry", file=sys.stderr)
 
     try:
         main()
@@ -959,5 +958,6 @@ if __name__ == "__main__":
         import traceback
         st.write("App failed with exception:")
         st.text("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-        dprint(f"fatal error: {e}")
+        if os.getenv("UI_DEBUG_PRINTS", "1") != "0":
+            print(f"fatal error: {e}", file=sys.stderr)
         raise


### PR DESCRIPTION
## Summary
- gate startup message behind `UI_DEBUG_PRINTS`
- replace internal debug prints with a new `log()` helper in `ui.py`
- document how to disable verbose UI logging

## Testing
- `pip install -r requirements-minimal.txt`
- `pytest -q` *(fails: 52 failed, 288 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888999baa8083209144184c199429c9