### PR TITLE
Fix duplicate streamlit imports

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -33,7 +33,6 @@ Network = None  # imported lazily in run_analysis
 import os
 os.environ["STREAMLIT_WATCHER_TYPE"] = "poll"
 # ... your other imports here ...
-import streamlit as st
 
 # Bind to the default Streamlit port to satisfy platform health checks
 os.environ["STREAMLIT_SERVER_PORT"] = "8501"
@@ -868,10 +867,8 @@ def render_validation_ui() -> None:
         st.json(st.session_state["agent_output"])
 
 def main() -> None:
-    import streamlit as st
     print("[debug] main() invoked", file=sys.stderr)
     st.title("🤗//⚡//Launching main()")
-    import streamlit as st
     import os
     from importlib import import_module
 


### PR DESCRIPTION
## Summary
- remove repeated `import streamlit as st` lines in `ui.py`
- keep single import near start of file

## Testing
- `mypy`
- `pytest -q` *(fails: 65 failed, 312 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688895aa15448320a1fc33719e7ff802