### PR TITLE
Update Streamlit launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ pip install -r requirements.txt
 # python setup_env.py --launch-ui
 # or run manually with
 ./start.sh       # launches ui.py on port 8888
+python ui.py     # auto-runs the Streamlit server
+# or use the CLI directly
 streamlit run ui.py
-# running `python ui.py` directly will *not* start the Streamlit server
 
 # Try demo mode
 supernova-validate --demo
@@ -85,11 +86,12 @@ To launch the Streamlit UI:
 ```bash
 chmod +x start.sh
 ./start.sh  # launches ui.py
-# or run directly
-streamlit run ui.py
+python ui.py  # same as above
+streamlit run ui.py  # alternative
 ```
 
-This script launches `ui.py` automatically from any directory in the repo.
+Either `start.sh` or `python ui.py` will launch the dashboard from anywhere in the repo.
+Run `curl http://localhost:8888/?healthz=1` to verify the server is up.
 
 ## ☁️ Launch Online
 
@@ -339,8 +341,8 @@ from streamlit_helpers import header, alert, theme_selector, centered_container
 
 Import these helpers at the top of your Streamlit files to keep the UI code
 clean and consistent.
-Run these commands from the repository root. **Do not** execute `python ui.py`
-directly as that bypasses Streamlit's runtime.
+Run these commands from the repository root. `ui.py` is the official launcher
+and running `python ui.py` will start Streamlit automatically.
 
 Exporting plots as static images requires the `kaleido` package. Install it
 using `pip install -r requirements-streamlit.txt` if it isn't already available.


### PR DESCRIPTION
## Summary
- refactor `ui.py` to simplify main entry logic
- allow `python ui.py` to auto-run the Streamlit server
- clarify new launcher usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 52 failed, 288 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68889abe54788320b4914a6be7abf1e4