### PR TITLE
Improve Streamlit startup logging

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -898,6 +898,7 @@ def main() -> None:
 
     log("⚡ main() invoked")
     st.set_page_config(page_title="superNova_2177", layout="wide")
+    log("App started")
 
     # Unified health check: Path priority for Cloud; query/env fallback for CI/local
     if (
@@ -951,3 +952,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+main()


### PR DESCRIPTION
## Summary
- log app startup after setting page config
- call `main()` when module is imported for Streamlit Cloud compatibility

## Testing
- `pytest -q` *(fails: 57 failed, 283 passed, 38 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888e222948c8320ba7ee65c230a8dc9