### PR TITLE
Add Codex streamlit theme

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -42,11 +42,28 @@ def header(title: str, *, layout: str = "centered") -> None:
 
 
 def apply_theme(theme: str) -> None:
-    """Apply light or dark theme styles based on ``theme``."""
+    """Apply light, dark, or codex theme styles based on ``theme``."""
     if theme == "dark":
         css = """
             <style>
             body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
+            </style>
+        """
+    elif theme in {"codex", "minimal_dark"}:
+        css = """
+            <style>
+            body, .stApp {
+                background-color: #141414;
+                color: #e8e8e8;
+                font-family: 'Iosevka', monospace;
+            }
+            button, .stButton>button {
+                background-color: #294e80;
+                color: #e8e8e8;
+            }
+            hr, .stDivider {
+                border-color: #333333;
+            }
             </style>
         """
     else:
@@ -62,10 +79,14 @@ def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
+
+    options = ["Light", "Dark", "Codex"]
+    current = st.session_state["theme"].capitalize()
+    index = options.index(current) if current in options else 0
     choice = st.radio(
         label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
+        options,
+        index=index,
         horizontal=True,
     )
     st.session_state["theme"] = choice.lower()

--- a/tests/test_streamlit_helpers.py
+++ b/tests/test_streamlit_helpers.py
@@ -21,3 +21,39 @@ def test_alert_handles_missing_escape(monkeypatch):
     helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
     helpers.alert("hello")
     assert calls
+
+
+def test_apply_codex_theme_injects_css(monkeypatch):
+    stub = types.ModuleType("streamlit")
+    captured = []
+
+    def markdown(text, **kwargs):
+        captured.append(text)
+
+    stub.markdown = markdown
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+    helpers.apply_theme("codex")
+    assert any("Iosevka" in css for css in captured)
+    assert any("294e80" in css for css in captured)
+
+
+def test_theme_selector_lists_codex(monkeypatch):
+    stub = types.ModuleType("streamlit")
+    captured_options = {}
+
+    def radio(label, options, **kwargs):
+        captured_options["options"] = options
+        return "Codex"
+
+    stub.radio = radio
+    stub.markdown = lambda *a, **k: None
+    stub.session_state = {}
+
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+    theme = helpers.theme_selector("Theme")
+    assert "Codex" in captured_options["options"]
+    assert theme == "codex"


### PR DESCRIPTION
## Summary
- support a new 'codex' (aka `minimal_dark`) theme for Streamlit UI
- include theme in `theme_selector`
- inject CSS for font, accent color and borders
- verify new theme behaviour with tests

## Testing
- `pytest tests/test_streamlit_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889487a5dcc8320a4fce64878800f4b