### PR TITLE
Refactor card backgrounds to use theme colors

### DIFF
--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -92,7 +92,9 @@ async def events_page():
             events_list.clear()
             for e in events:
                 with events_list:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with ui.card().classes('w-full mb-2').style(
+                        f"border: 1px solid #333; background: {THEME['background']};"
+                    ):
                         ui.label(e['name']).classes('text-lg')
                         ui.label(e['description']).classes('text-sm')
                         ui.label(f"Start: {e['start_time']}").classes('text-sm')

--- a/transcendental_resonance_frontend/src/pages/explore_page.py
+++ b/transcendental_resonance_frontend/src/pages/explore_page.py
@@ -58,7 +58,9 @@ async def explore_page() -> None:
                     with (
                         ui.card()
                         .classes("w-full mb-2")
-                        .style("border: 1px solid #333; background: #1e1e1e;")
+                        .style(
+                            f"border: 1px solid #333; background: {THEME['background']};"
+                        )
                     ):
                         ui.label(p.get("name", "")).classes("text-lg")
                         ui.label(p.get("description", "")).classes("text-sm")

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -62,7 +62,9 @@ async def feed_page() -> None:
 
             for vn in vibenodes:
                 with feed_column:
-                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style(
+                        f"background: {theme['background']};"
+                    ):
                         ui.label('VibeNode').classes('text-sm font-bold')
                         ui.label(vn.get('description', '')).classes('text-sm')
                         ui.link('View', f"/vibenodes/{vn['id']}")
@@ -74,7 +76,9 @@ async def feed_page() -> None:
                                     ui.markdown(DISCLAIMER).classes('text-xs text-orange-5')
             for ev in events:
                 with feed_column:
-                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style(
+                        f"background: {theme['background']};"
+                    ):
                         ui.label('Event').classes('text-sm font-bold')
                         ui.label(ev.get('description', '')).classes('text-sm')
                         ui.link('View', f"/events/{ev['id']}")
@@ -86,7 +90,9 @@ async def feed_page() -> None:
                                     ui.markdown(DISCLAIMER).classes('text-xs text-orange-5')
             for n in notifs:
                 with feed_column:
-                    with swipeable_glow_card().classes('w-full mb-2').style('background: #1e1e1e;'):
+                    with swipeable_glow_card().classes('w-full mb-2').style(
+                        f"background: {theme['background']};"
+                    ):
                         ui.label('Notification').classes('text-sm font-bold')
                         ui.label(n.get('message', '')).classes('text-sm')
                         ui.link('View', f"/notifications/{n['id']}")

--- a/transcendental_resonance_frontend/src/pages/forks_page.py
+++ b/transcendental_resonance_frontend/src/pages/forks_page.py
@@ -49,7 +49,9 @@ async def forks_page() -> None:
             forks_list.clear()
             for f in forks:
                 with forks_list:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with ui.card().classes('w-full mb-2').style(
+                        f"border: 1px solid #333; background: {THEME['background']};"
+                    ):
                         ui.label(f"ID: {f.get('id')}").classes('text-sm')
                         ui.label(f"Consensus: {f.get('consensus')}").classes('text-sm')
 

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -66,7 +66,9 @@ async def groups_page():
             groups_list.clear()
             for g in groups:
                 with groups_list:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with ui.card().classes('w-full mb-2').style(
+                        f"border: 1px solid #333; background: {THEME['background']};"
+                    ):
                         ui.label(g['name']).classes('text-lg')
                         ui.label(g['description']).classes('text-sm')
                         async def join_fn(g_id=g['id']):
@@ -88,7 +90,7 @@ async def groups_page():
             for g in recs:
                 with suggestions:
                     with ui.card().classes('w-full mb-2').style(
-                        'border: 1px solid #333; background: #1e1e1e;'
+                        f"border: 1px solid #333; background: {THEME['background']};"
                     ):
                         ui.label(g.get('name', 'Unknown')).classes('text-lg')
                         desc = g.get('description')

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -108,7 +108,9 @@ async def messages_page():
                     with (
                         ui.card()
                         .classes("w-full mb-2")
-                        .style("border: 1px solid #333; background: #1e1e1e;")
+                        .style(
+                            f"border: 1px solid #333; background: {THEME['background']};"
+                        )
                     ):
                         with ui.row().classes("items-center justify-between"):
                             with ui.column().classes("grow"):

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -36,7 +36,9 @@ async def notifications_page():
                     with (
                         ui.card()
                         .classes("w-full mb-2")
-                        .style("border: 1px solid #333; background: #1e1e1e;")
+                        .style(
+                            f"border: 1px solid #333; background: {THEME['background']};"
+                        )
                     ):
                         ui.label(n["message"]).classes("text-sm")
                         if not n["is_read"]:

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -197,7 +197,7 @@ async def profile_page(username: str | None = None):
             for u in recs:
                 with suggestions:
                     with ui.card().classes('w-full mb-2').style(
-                        'border: 1px solid #333; background: #1e1e1e;'
+                        f"border: 1px solid #333; background: {THEME['background']};"
                     ):
                         ui.label(u.get('username', 'Unknown')).classes('text-lg')
                         bio = u.get('bio')

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -59,7 +59,9 @@ async def proposals_page():
             proposals_list.clear()
             for p in proposals:
                 with proposals_list:
-                    with ui.card().classes('w-full mb-2').style('border: 1px solid #333; background: #1e1e1e;'):
+                    with ui.card().classes('w-full mb-2').style(
+                        f"border: 1px solid #333; background: {THEME['background']};"
+                    ):
                         ui.label(p['title']).classes('text-lg')
                         ui.label(p['description']).classes('text-sm')
                         ui.label(f"Status: {p['status']}").classes('text-sm')

--- a/transcendental_resonance_frontend/src/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/src/pages/recommendations_page.py
@@ -38,7 +38,7 @@ async def recommendations_page():
             for rec in recs:
                 with rec_list:
                     with ui.card().classes('w-full mb-2').style(
-                        'border: 1px solid #333; background: #1e1e1e;'
+                        f"border: 1px solid #333; background: {THEME['background']};"
                     ):
                         name = rec.get('name') or rec.get('username', 'Unknown')
                         ui.label(name).classes('text-lg')

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -138,7 +138,9 @@ async def vibenodes_page():
                     with (
                         ui.card()
                         .classes("w-full mb-2")
-                        .style("border: 1px solid #333; background: #1e1e1e;")
+                        .style(
+                            f"border: 1px solid #333; background: {THEME['background']};"
+                        )
                     ):
                         ui.label(vn["name"]).classes("text-lg")
                         ui.label(vn["description"]).classes("text-sm")
@@ -203,7 +205,9 @@ async def vibenodes_page():
                     with (
                         ui.card()
                         .classes("w-full mb-2")
-                        .style("border: 1px solid #333; background: #1e1e1e;")
+                        .style(
+                            f"border: 1px solid #333; background: {THEME['background']};"
+                        )
                     ):
                         ui.label(vn["name"]).classes("text-lg")
                         ui.label(vn["description"]).classes("text-sm")
@@ -253,7 +257,7 @@ async def vibenodes_page():
                                 ui.column()
                                 .classes("w-full shadow rounded hidden")
                                 .style(
-                                    "background:#1e1e1e; position: absolute; z-index: 50;"
+                                    f"background: {THEME['background']}; position: absolute; z-index: 50;"
                                 )
                             )
 


### PR DESCRIPTION
## Summary
- remove hardcoded dark backgrounds
- use theme['background'] to style cards and containers in frontend pages

## Testing
- `pytest -q` *(fails: AttributeError: 'Element' object has no attribute 'props', ModuleNotFoundError: No module named 'streamlit_app', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68894893062083209fe781117f1deda0