### PR TITLE
Add ideas & video preview pages

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -5,4 +5,6 @@ __all__ = [
     "social",
     "voting",
     "agents",
+    "ideas",
+    "video",
 ]

--- a/transcendental_resonance_frontend/pages/ideas.py
+++ b/transcendental_resonance_frontend/pages/ideas.py
@@ -1,0 +1,57 @@
+"""STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+
+Display proposal ideas from the RFC directory.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+from pathlib import Path
+
+from ui_utils import summarize_text
+
+# Load the initial proposals document containing the idea list
+IDEAS_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "rfcs"
+    / "001-initial-proposals"
+    / "README.md"
+)
+
+
+def _load_ideas() -> list[str]:
+    """Return bullet list items extracted from the initial proposals file."""
+    try:
+        text = IDEAS_FILE.read_text()
+    except Exception:
+        return []
+
+    ideas: list[str] = []
+    recording = False
+    for line in text.splitlines():
+        if line.startswith("## Specification"):
+            recording = True
+            continue
+        if line.startswith("## ") and recording:
+            # stop when leaving the specification section
+            if not line.startswith("###"):
+                break
+        if recording and line.lstrip().startswith("-"):
+            idea = line.lstrip("- ").strip()
+            if idea:
+                ideas.append(idea)
+    return ideas
+
+
+def main() -> None:
+    """Render the ideas page."""
+    st.header("Project Ideas")
+    ideas = _load_ideas()
+    if not ideas:
+        st.info("No ideas found")
+        return
+
+    for idea in ideas:
+        st.markdown(f"- {summarize_text(idea)}")

--- a/transcendental_resonance_frontend/pages/video.py
+++ b/transcendental_resonance_frontend/pages/video.py
@@ -1,0 +1,32 @@
+"""STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+
+Preview page for upcoming video chat features.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+from realtime_comm.video_chat import VideoChatManager
+from ai_video_chat import create_session
+
+manager = VideoChatManager()
+
+
+def main() -> None:
+    """Render the video chat scaffolding page."""
+    st.header("Video Chat Preview")
+    st.write(
+        "This experimental page exposes placeholders for future video sessions."
+    )
+
+    user_ids = st.text_input("Participant IDs (comma separated)", "alice,bob")
+    if st.button("Create Demo Session"):
+        ids = [u.strip() for u in user_ids.split(",") if u.strip()]
+        session = create_session(ids)
+        manager.start_call(ids)
+        st.success(
+            f"Created session {session.session_id} with {len(session.participants)} participants"
+        )
+        st.info("Streaming not implemented yet – backend scaffolding only.")


### PR DESCRIPTION
## Summary
- list RFC ideas in new Ideas page
- scaffold video chat page for future streaming
- expose new pages in page registry

## Testing
- `pytest -q` *(fails: 71 failed, 270 passed, 37 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68894935a33c832097319de03dbbb87e