### PR TITLE
Sync Streamlit theme styles

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -14,6 +14,12 @@ from typing import Literal
 
 import streamlit as st
 
+# isort: off
+from transcendental_resonance_frontend.src.utils import styles
+from transcendental_resonance_frontend.src.utils.styles import get_theme, get_theme_name
+
+# isort: on
+
 
 def alert(message: str, level: Literal["warning", "error", "info"] = "info") -> None:
     """Display a styled Markdown alert box."""
@@ -44,17 +50,37 @@ def header(title: str, *, layout: str = "centered") -> None:
 def apply_theme(theme: str) -> None:
     """Apply light or dark theme styles based on ``theme``."""
     if theme == "dark":
-        css = """
-            <style>
-            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
-            </style>
-        """
+        # Align Streamlit dark mode with the frontend's minimalist style
+        styles.set_theme("minimalist_dark")
     else:
-        css = """
-            <style>
-            body, .stApp { background-color: #ffffff; color: #000000; }
-            </style>
-        """
+        styles.set_theme(theme)
+
+    palette = get_theme()
+
+    font_family = "'Inter', sans-serif"
+    font_link = (
+        '<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"'
+        ' rel="stylesheet">'
+    )
+    if get_theme_name() == "cyberpunk":
+        font_family = "'Orbitron', sans-serif"
+        font_link = (
+            '<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap"'
+            ' rel="stylesheet">'
+        )
+
+    css = f"""
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        {font_link}
+        <style id="streamlit-theme">
+            body, .stApp {{
+                background-color: {palette['background']};
+                color: {palette['text']};
+                font-family: {font_family};
+            }}
+        </style>
+    """
     st.markdown(css, unsafe_allow_html=True)
 
 
@@ -62,15 +88,20 @@ def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
-    choice = st.radio(
-        label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
-        horizontal=True,
-    )
-    st.session_state["theme"] = choice.lower()
-    apply_theme(st.session_state["theme"])
-    return st.session_state["theme"]
+
+    options = ["Light", "Dark", "Minimalist Dark"]
+    if st.session_state["theme"] == "dark":
+        index = 1
+    elif st.session_state["theme"] == "minimalist_dark":
+        index = 2
+    else:
+        index = 0
+
+    choice = st.radio(label, options, index=index, horizontal=True)
+    key = choice.lower().replace(" ", "_")
+    st.session_state["theme"] = key
+    apply_theme(key)
+    return key
 
 
 def centered_container(max_width: str = "900px") -> "st.delta_generator.DeltaGenerator":


### PR DESCRIPTION
## Summary
- sync Streamlit theme handling with frontend styles
- add Minimalist Dark option to theme selector
- keep imports stable for pre-commit

## Testing
- `pre-commit run --files streamlit_helpers.py`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688948920d6c8320acdbe9580824e421