### PR TITLE
Add theme switching support

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -41,36 +41,58 @@ def header(title: str, *, layout: str = "centered") -> None:
     st.header(title)
 
 
+THEMES = {
+    "dark": {"bg": "#1e1e1e", "text": "#f0f0f0", "font": "'Inter', sans-serif"},
+    "minimalist_dark": {
+        "bg": "#1a1a1a",
+        "text": "#f0f0f0",
+        "font": "'Iosevka', monospace",
+        "font_link": '<link href="https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap" rel="stylesheet">',
+    },
+    "light": {"bg": "#ffffff", "text": "#000000", "font": "'Inter', sans-serif"},
+    "modern": {"bg": "#f5f5f5", "text": "#333333", "font": "'Inter', sans-serif"},
+}
+
+
 def apply_theme(theme: str) -> None:
-    """Apply light or dark theme styles based on ``theme``."""
-    if theme == "dark":
-        css = """
-            <style>
-            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
-            </style>
-        """
-    else:
-        css = """
-            <style>
-            body, .stApp { background-color: #ffffff; color: #000000; }
-            </style>
-        """
+    """Apply styles based on ``theme``."""
+    cfg = THEMES.get(theme, THEMES["light"])
+    font_link = cfg.get(
+        "font_link",
+        '<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">',
+    )
+    css = f"""
+        {font_link}
+        <style id="app-theme">
+        body, .stApp {{
+            background-color: {cfg['bg']};
+            color: {cfg['text']};
+            font-family: {cfg['font']};
+        }}
+        </style>
+    """
     st.markdown(css, unsafe_allow_html=True)
 
 
 def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
+    themes = [
+        ("Light", "light"),
+        ("Dark", "dark"),
+        ("Minimalist Dark", "minimalist_dark"),
+        ("Modern", "modern"),
+    ]
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
-    choice = st.radio(
-        label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
-        horizontal=True,
+    labels = [t[0] for t in themes]
+    current_label = next(
+        (l for l, v in themes if v == st.session_state["theme"]), labels[0]
     )
-    st.session_state["theme"] = choice.lower()
-    apply_theme(st.session_state["theme"])
-    return st.session_state["theme"]
+    choice = st.radio(label, labels, index=labels.index(current_label), horizontal=True)
+    selected = next(v for l, v in themes if l == choice)
+    st.session_state["theme"] = selected
+    apply_theme(selected)
+    return selected
 
 
 def centered_container(max_width: str = "900px") -> "st.delta_generator.DeltaGenerator":

--- a/tests/test_streamlit_helpers.py
+++ b/tests/test_streamlit_helpers.py
@@ -2,6 +2,10 @@ import importlib
 import sys
 import types
 
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 
 def test_alert_handles_missing_escape(monkeypatch):
     stub = types.ModuleType("streamlit")
@@ -21,3 +25,19 @@ def test_alert_handles_missing_escape(monkeypatch):
     helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
     helpers.alert("hello")
     assert calls
+
+
+def test_apply_theme_minimalist(monkeypatch):
+    stub = types.ModuleType("streamlit")
+
+    injected = []
+
+    def markdown(text, **kwargs):
+        injected.append(text)
+
+    stub.markdown = markdown
+
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+    helpers.apply_theme("minimalist_dark")
+    assert "app-theme" in injected[0]

--- a/transcendental_resonance_frontend/README.md
+++ b/transcendental_resonance_frontend/README.md
@@ -32,5 +32,5 @@ Replace the backend URL with the `BACKEND_URL` environment variable if your API 
 ## Notes
 
 This UI is mobile-first with a futuristic aesthetic. A theme selector cycles between
-dark, light, and a new **modern** palette powered by the Inter font.
+dark, a minimalist dark mode, light, and a **modern** palette powered by the Inter font.
 Future improvements include real-time notifications and internationalization.

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -1,5 +1,9 @@
 """Styling utilities for the Transcendental Resonance frontend."""
 
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 from typing import Dict, Optional
 
 from nicegui import ui
@@ -12,6 +16,13 @@ THEMES: Dict[str, Dict[str, str]] = {
         "background": "#121212",
         "text": "#ffffff",
         "gradient": "linear-gradient(135deg, #0d47a1 0%, #121212 100%)",
+    },
+    "minimalist_dark": {
+        "primary": "#2b2b2b",
+        "accent": "#5e9ed6",
+        "background": "#1a1a1a",
+        "text": "#f0f0f0",
+        "gradient": "linear-gradient(135deg, #2b2b2b 0%, #1a1a1a 100%)",
     },
     "light": {
         "primary": "#1976d2",
@@ -74,13 +85,15 @@ def apply_global_styles() -> None:
     theme["accent"] = ACTIVE_ACCENT
 
     font_family = "'Inter', sans-serif"
-    font_link = "<link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap\" rel=\"stylesheet\">"
+    font_link = '<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">'
     if ACTIVE_THEME_NAME == "cyberpunk":
         font_family = "'Orbitron', sans-serif"
-        font_link = (
-            "<link href=\"https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap\" rel=\"stylesheet\">"
-        )
+        font_link = '<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">'
+    elif ACTIVE_THEME_NAME == "minimalist_dark":
+        font_family = "'Iosevka', monospace"
+        font_link = '<link href="https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap" rel="stylesheet">'
 
+    ui.run_javascript("document.getElementById('global-theme')?.remove()")
     ui.add_head_html(
         f"""
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -90,7 +103,7 @@ def apply_global_styles() -> None:
             body {{ font-family: {font_family}; background: {theme['background']}; color: {theme['text']}; }}
             .q-btn:hover {{ border: 1px solid {theme['accent']}; }}
             .futuristic-gradient {{ background: {theme['gradient']}; }}
-            .glow-card {{ border: 1px solid {theme["accent"]}; box-shadow: 0 0 6px {theme["accent"]}; }}
+            .glow-card {{ border: 1px solid {theme['accent']}; box-shadow: 0 0 6px {theme['accent']}; }}
         </style>
         """
     )
@@ -128,6 +141,7 @@ def set_accent(color: str) -> None:
 
 
 _previous_theme = ACTIVE_THEME_NAME
+
 
 def toggle_high_contrast(enabled: bool) -> None:
     """Enable or disable high contrast mode."""


### PR DESCRIPTION
## Summary
- add disclaimers to styles and tests
- add `minimalist_dark` theme and dynamic style removal logic
- expand Streamlit theme helper to include new themes
- mention the new theme in frontend README
- unit test coverage for minimalist theme

## Testing
- `pytest -q >/tmp/pytest.log` *(fails: ImportError while collecting tests)*
- `pytest tests/test_streamlit_helpers.py -q`
- `mypy streamlit_helpers.py transcendental_resonance_frontend/src/utils/styles.py tests/test_streamlit_helpers.py`
- `flake8` *(fails: command not found)*
- `bandit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688949ce9ec48320b182627c75e5c306