### PR TITLE
Enable minimalist dark theme

### DIFF
--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -27,6 +27,13 @@ THEMES: Dict[str, Dict[str, str]] = {
         "text": "#333333",
         "gradient": "linear-gradient(135deg, #6200EE 0%, #03DAC5 100%)",
     },
+    "minimalist_dark": {
+        "primary": "#242424",
+        "accent": "#8ab4f8",
+        "background": "#1a1a1a",
+        "text": "#F0F0F0",
+        "gradient": "linear-gradient(135deg, #1c1c1c 0%, #0f0f0f 100%)",
+    },
     "cyberpunk": {
         "primary": "#FF0080",
         "accent": "#00F0FF",
@@ -80,6 +87,13 @@ def apply_global_styles() -> None:
         font_link = (
             "<link href=\"https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap\" rel=\"stylesheet\">"
         )
+    elif ACTIVE_THEME_NAME == "minimalist_dark":
+        font_family = "'Iosevka', monospace"
+        font_link = (
+            "<link href=\"https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap\" rel=\"stylesheet\">"
+        )
+
+    ui.run_javascript("document.getElementById('global-theme')?.remove()")
 
     ui.add_head_html(
         f"""

--- a/transcendental_resonance_frontend/tests/test_styles.py
+++ b/transcendental_resonance_frontend/tests/test_styles.py
@@ -17,6 +17,14 @@ def test_set_theme_switches(monkeypatch):
     assert styles.get_theme_name() == "dark"
 
 
+def test_minimalist_dark_theme(monkeypatch):
+    dummy = dummy_ui({})
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.set_theme("minimalist_dark")
+    assert styles.get_theme_name() == "minimalist_dark"
+    assert styles.get_theme()["text"] == "#F0F0F0"
+
+
 def test_apply_global_styles_injects_css(monkeypatch):
     captured = {}
     dummy = dummy_ui(captured)


### PR DESCRIPTION
## Summary
- include a new `minimalist_dark` palette
- swap fonts when the new theme is active and remove old theme styles
- test the new theme selection

## Testing
- `pytest transcendental_resonance_frontend/tests/test_styles.py::test_minimalist_dark_theme -q`


------
https://chatgpt.com/codex/tasks/task_e_688949ce9ec48320b182627c75e5c306