### PR TITLE
Support new streamlit themes

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -86,6 +86,85 @@ def apply_theme(theme: str) -> None:
                 }}
             </style>
         """
+    elif theme == "modern":
+        css = f"""
+            {font_link}
+            <style>
+                :root {{
+                    --bg-color: #f5f5f5;
+                    --text-color: #333333;
+                    --accent-color: #03DAC5;
+                }}
+
+                body, .stApp {{
+                    background-color: var(--bg-color);
+                    color: var(--text-color);
+                    font-family: 'Inter', 'Iosevka', monospace;
+                }}
+
+                .stButton>button {{
+                    background-color: var(--accent-color);
+                    color: var(--bg-color);
+                    border: none;
+                    border-radius: 4px;
+                    padding: 0.25rem 0.75rem;
+                }}
+
+                .stButton>button:hover {{
+                    filter: brightness(1.1);
+                }}
+
+                h1, h2, h3 {{
+                    color: var(--text-color);
+                }}
+
+                hr {{
+                    border-color: var(--accent-color);
+                    opacity: 0.3;
+                }}
+            </style>
+        """
+    elif theme == "minimalist_dark":
+        font_link = (
+            "<link href='https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap' rel='stylesheet'>"
+        )
+        css = f"""
+            {font_link}
+            <style>
+                :root {{
+                    --bg-color: #1a1a1a;
+                    --text-color: #e0e0e0;
+                    --accent-color: #6d8cff;
+                }}
+
+                body, .stApp {{
+                    background-color: var(--bg-color);
+                    color: var(--text-color);
+                    font-family: 'Iosevka', monospace;
+                }}
+
+                .stButton>button {{
+                    background-color: var(--accent-color);
+                    color: var(--bg-color);
+                    border: none;
+                    border-radius: 4px;
+                    padding: 0.25rem 0.75rem;
+                }}
+
+                .stButton>button:hover {{
+                    filter: brightness(1.1);
+                }}
+
+                h1, h2, h3 {{
+                    color: var(--text-color);
+                }}
+
+                hr {{
+                    border-color: var(--accent-color);
+                    opacity: 0.2;
+                }}
+            </style>
+        """
     else:
         css = f"""
             {font_link}
@@ -131,13 +210,22 @@ def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
+    options = ["Light", "Dark", "Modern", "Minimalist Dark"]
+    label_map = {
+        "light": "Light",
+        "dark": "Dark",
+        "modern": "Modern",
+        "minimalist_dark": "Minimalist Dark",
+    }
+    current_label = label_map.get(st.session_state["theme"], "Light")
     choice = st.radio(
         label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
+        options,
+        index=options.index(current_label),
         horizontal=True,
     )
-    st.session_state["theme"] = choice.lower()
+    reverse_map = {v: k for k, v in label_map.items()}
+    st.session_state["theme"] = reverse_map[choice]
     apply_theme(st.session_state["theme"])
     return st.session_state["theme"]
 

--- a/tests/test_streamlit_helpers.py
+++ b/tests/test_streamlit_helpers.py
@@ -21,3 +21,29 @@ def test_alert_handles_missing_escape(monkeypatch):
     helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
     helpers.alert("hello")
     assert calls
+
+
+def test_apply_theme_injects_unique_css(monkeypatch):
+    stub = types.ModuleType("streamlit")
+    captured = []
+
+    def markdown(text, **_kwargs):
+        captured.append(text)
+
+    stub.markdown = markdown
+    stub.text_util = types.ModuleType("streamlit.text_util")
+
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    monkeypatch.setitem(sys.modules, "streamlit.text_util", stub.text_util)
+
+    helpers = importlib.reload(importlib.import_module("streamlit_helpers"))
+
+    themes = ["light", "dark", "modern", "minimalist_dark"]
+    css_blocks = {}
+    for theme in themes:
+        captured.clear()
+        helpers.apply_theme(theme)
+        assert captured, f"No CSS injected for {theme}"
+        css_blocks[theme] = captured[0]
+
+    assert len(set(css_blocks.values())) == len(themes)


### PR DESCRIPTION
## Summary
- add Modern and Minimalist Dark themes to apply_theme()
- expose new options in `theme_selector`
- test that each theme injects CSS

## Testing
- `pytest tests/test_streamlit_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68894cdf719883208efe94a610c5f326