### PR TITLE
Remove duplicate global-theme styles

### DIFF
--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -101,6 +101,8 @@ def apply_global_styles() -> None:
             'rel="stylesheet">'
         )
 
+    # remove any previously injected global theme style to avoid duplicates
+    ui.run_javascript("document.getElementById('global-theme')?.remove()")
     ui.add_head_html(
         f"""
         <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/transcendental_resonance_frontend/tests/test_styles.py
+++ b/transcendental_resonance_frontend/tests/test_styles.py
@@ -1,11 +1,25 @@
 import types
 from utils import styles
 
+
 def dummy_ui(captured):
     return types.SimpleNamespace(
         add_head_html=lambda html: captured.setdefault("html", html),
         run_javascript=lambda *_args, **_kwargs: None,
     )
+
+
+def dummy_ui_dom(captured):
+    def add_head_html(html: str) -> None:
+        captured.setdefault("htmls", []).append(html)
+
+    def run_javascript(script: str, *args, **kwargs) -> None:
+        if "global-theme" in script:
+            captured["htmls"] = [
+                h for h in captured.get("htmls", []) if "id=\"global-theme\"" not in h
+            ]
+
+    return types.SimpleNamespace(add_head_html=add_head_html, run_javascript=run_javascript)
 
 
 def test_set_theme_switches(monkeypatch):
@@ -49,3 +63,13 @@ def test_glow_card_css(monkeypatch):
     monkeypatch.setattr(styles, "ui", dummy)
     styles.apply_global_styles()
     assert ".glow-card" in captured["html"]
+
+
+def test_apply_global_styles_removes_old(monkeypatch):
+    captured = {}
+    dummy = dummy_ui_dom(captured)
+    monkeypatch.setattr(styles, "ui", dummy)
+    styles.apply_global_styles()
+    styles.apply_global_styles()
+    style_tags = [h for h in captured.get("htmls", []) if "id=\"global-theme\"" in h]
+    assert len(style_tags) == 1


### PR DESCRIPTION
## Summary
- prevent duplicate `global-theme` block by removing any existing element before inserting
- ensure repeated style injections keep only one copy
- test that calling `apply_global_styles()` twice doesn't leave multiple tags

## Testing
- `pytest transcendental_resonance_frontend/tests/test_styles.py -q`
- `pytest -q` *(fails: test suite has many unrelated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68894cdc90388320865193b5a53fb70c