### PR TITLE
Add tests for transcendental frontend pages

### DIFF
--- a/tests/test_tr_frontend_pages.py
+++ b/tests/test_tr_frontend_pages.py
@@ -1,0 +1,33 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Import and UI tests for Transcendental Resonance pages."""
+
+import pytest
+import streamlit.testing.v1 as st_test
+
+
+def _run_page(module_name: str) -> None:
+    """Import and run a Streamlit page using AppTest."""
+    script = f"import {module_name} as m\nm.main()"
+    app = st_test.AppTest.from_string(script)
+    app.run()
+    assert not app.exception  # nosec B101
+
+
+def test_import_ideas_page():
+    _run_page("transcendental_resonance_frontend.pages.ideas")
+
+
+def test_import_video_page():
+    _run_page("transcendental_resonance_frontend.pages.video")
+
+
+@pytest.mark.asyncio
+async def test_video_client_offline(monkeypatch):
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    from external_services.video_client import VideoClient
+
+    client = VideoClient()
+    result = await client.generate_video_preview("test")
+    assert "placeholder" in result["video_url"]  # nosec B101


### PR DESCRIPTION
## Summary
- add test_tr_frontend_pages verifying ideas/video imports
- ensure pages render with AppTest
- check VideoClient offline mode similar to other client tests

## Testing
- `pre-commit run --files tests/test_tr_frontend_pages.py`
- `pytest tests/test_tr_frontend_pages.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68894c2578388320b02d750c60dd2f74